### PR TITLE
feat: deliver Node-first MVP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,15 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --all-features
 
+      - name: Keep the shim dependency graph lightweight
+        shell: bash
+        run: |
+          cargo tree -p pinset-shim -e normal > shim-dependencies.txt
+          if grep -E 'reqwest|rustls|tar v|xz2|zip v|tempfile' shim-dependencies.txt; then
+            echo "pinset-shim unexpectedly includes download or archive dependencies" >&2
+            exit 1
+          fi
+
   build:
     name: Build ${{ matrix.artifact }}
     if: github.event_name != 'pull_request'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,15 @@ jobs:
       - name: Run Rust tests
         run: cargo test --workspace --all-features
 
+      - name: Keep the shim dependency graph lightweight
+        shell: bash
+        run: |
+          cargo tree -p pinset-shim -e normal > shim-dependencies.txt
+          if grep -E 'reqwest|rustls|tar v|xz2|zip v|tempfile' shim-dependencies.txt; then
+            echo "pinset-shim unexpectedly includes download or archive dependencies" >&2
+            exit 1
+          fi
+
   build:
     name: Build ${{ matrix.artifact }}
     needs: quality

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +846,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,7 +927,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "0.0.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "clap",
  "pinset-core",
@@ -915,23 +936,25 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "0.0.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "atomic-write-file",
  "hex",
  "reqwest",
  "serde",
  "sha2",
+ "tar",
  "tempfile",
  "thiserror",
  "toml",
  "url",
+ "xz2",
  "zip",
 ]
 
 [[package]]
 name = "pinset-shim"
-version = "0.0.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "pinset-core",
  "tempfile",
@@ -1492,6 +1515,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1991,6 +2025,25 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.85"
-version = "0.0.0"
+version = "0.1.0-alpha.1"
 authors = ["Future Element"]
 
 [workspace.dependencies]
@@ -19,8 +19,10 @@ hex = "0.4"
 reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "rustls", "system-proxy"] }
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.11"
+tar = "0.4"
 tempfile = "3"
 thiserror = "2"
 toml = "0.9"
 url = "2.5"
+xz2 = "0.1"
 zip = { version = "6.0.0", default-features = false, features = ["deflate"] }

--- a/README.md
+++ b/README.md
@@ -3,103 +3,79 @@
 [![CI](https://github.com/Future-Element/pinset/actions/workflows/ci.yml/badge.svg)](https://github.com/Future-Element/pinset/actions/workflows/ci.yml)
 [![Release](https://github.com/Future-Element/pinset/actions/workflows/release.yml/badge.svg)](https://github.com/Future-Element/pinset/actions/workflows/release.yml)
 
-Pinset 是一个面向多语言项目的本地优先运行时版本管理 CLI。它计划用一套一致的命令管理 Node.js、CPython 和 Flutter，并重点解决跨平台差异、旧管理器冲突、可复现安装和供应链校验。
+Pinset 是一个面向多语言项目的本地优先运行时版本管理 CLI。它希望用一套一致的命令替代 fnm/nvm、uv、FVM 等工具在“选择和安装运行时版本”上的重叠工作。
 
-> 当前状态：Phase 0 技术验证中。Spike A 已完成 Windows x64 功能原型，但端到端 shim 性能尚未达到候选目标；Spike B 已完成本地 HTTP + ZIP 的事务安装内核、本机安装源配置和无网络 Node 产物计划，真实上游校验与 Linux/macOS `tar.xz` 安装仍待接入。
+当前 `0.1.0-alpha.1` 是 Node-first MVP：
 
-## 核心定位
+- 支持 Node.js 精确版本 `x.y.z`；
+- 支持 Windows x64、Linux x64、macOS x64/arm64 的官方预编译产物；
+- 生成可提交的 `pinset.toml` 与 `pinset.lock`；
+- 从 Node 官方 HTTPS `SHASUMS256.txt` 取得哈希，镜像只改变传输位置；
+- 校验 SHA-256 后安全解压 ZIP/TAR.XZ，并以事务方式提交安装；
+- 提供 `use`、`install`、`current`、`which`、`exec`、`doctor` 和 shim；
+- 支持配置国内、企业内网或其他自定义镜像及有序回退。
 
-Pinset 不试图复制 mise/asdf 的全部能力。首版聚焦三个承诺：
+Python、Flutter、浮动版本选择器、PGP 验签、缓存管理和中央包管理器分发不属于这个 MVP，后续按路线图实现。项目不维护第三方 Homebrew Tap 或 Scoop Bucket。
 
-1. **可预测**：项目配置是纯数据；选择优先级、实际命令来源和回退行为都可解释。
-2. **可验证**：锁文件记录精确版本、目标平台、下载来源和校验信息；安装失败不会留下半成品。
-3. **可迁移**：识别 fnm、nvm、nvm-windows、uv、FVM、mise、asdf、vfox 等既有环境，遵循 “detect many, activate one”，不静默删除或改写用户环境。
+## 五分钟开始
 
-国内或受限网络可以显式切换安装源。安装源只替换下载位置，精确版本、官方产物身份和预期哈希仍来自锁文件/可信 provider；网络失败可以按用户配置回退，校验失败必须停止。
-
-## 首版范围
-
-- 运行时：Node.js、CPython、Flutter（Flutter 自带 Dart）
-- 平台：Windows、macOS、Linux
-- 使用方式：全局选择、项目选择、锁文件安装、临时执行、冲突诊断
-- 明确不做：npm/pnpm/pip/pub 依赖管理、任务运行器、环境变量/密钥管理、远程同步、GUI、任意脚本插件
-
-当前已实现且不会下载运行时的项目初始化命令：
+从 [GitHub Releases](https://github.com/Future-Element/pinset/releases) 下载当前系统的归档，校验 `SHA256SUMS` 后解压。将 `pinset` 放入 `PATH`，再进入一个项目：
 
 ```shell
 pinset init
-```
-
-它只在当前目录原子创建最小 `pinset.toml`，已有文件时拒绝覆盖。
-
-后续规划中的命令示例：
-
-```shell
-pinset use node@24
-pinset use python@3.13
-pinset use flutter@3.44.8
-pinset install
+pinset use node@24.0.0
 pinset current
 pinset which node
-pinset exec node@22 -- node -v
+pinset exec -- node --version
 pinset doctor
-pinset import --dry-run
 ```
 
-当前 spike 已实现且不会下载运行时的安装源命令：
+`pinset use` 会解析并锁定四个平台的官方 Node 产物，然后只为当前平台安装。要先生成配置和锁文件、暂不下载运行时：
 
 ```shell
-pinset source list [provider]
-pinset source add <provider> <alias> --base-url <https-url>
-pinset source use <provider> <alias>
-pinset source fallback <provider> [aliases...]
-pinset source remove <provider> <alias>
+pinset use node@24.0.0 --no-install
+pinset install --locked
 ```
 
-这些命令只读写 `$PINSET_HOME/sources.toml`。`official` 是不可覆盖、不可删除的内置源；自定义源默认必须使用 HTTPS。`source test` 仍是规划命令，当前不会由 Pinset 主动探测或测速第三方源。
+完整的 Windows、macOS、Linux、WSL、shim、镜像切换和故障排查说明见 [MVP 使用指南](docs/USAGE.md)。
 
-## 项目文档
+## 安装源
 
+安装源是本机配置，不写入项目锁文件。下面只是格式示例，请使用你信任且与 Node 官方目录结构兼容的镜像：
+
+```shell
+pinset source add node my-mirror --base-url https://mirror.example/node/
+pinset source use node my-mirror
+pinset source fallback node official
+pinset source list node
+```
+
+网络错误可按用户配置回退；哈希不匹配会立即停止，不会换源重试来掩盖异常。内置 `official` 源不可覆盖或删除。
+
+首次生成锁文件仍需访问 Node 官方 HTTPS 校验清单；已有并提交的锁文件可以在受限网络中只通过镜像执行 `install --locked`。详见使用指南。
+
+## 开发
+
+```shell
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-features
+cargo build --release --locked -p pinset-cli -p pinset-shim
+```
+
+测试使用临时目录、本地假 HTTP 服务和假运行时，不会安装真实 Node、Python 或 Flutter。
+
+## 文档
+
+- [MVP 使用指南](docs/USAGE.md)
 - [项目章程](docs/PROJECT_CHARTER.md)
 - [深度调研](docs/RESEARCH.md)
 - [产品规格](docs/PRODUCT_SPEC.md)
 - [技术架构](docs/ARCHITECTURE.md)
-- [路线图与验证计划](docs/ROADMAP.md)
+- [路线图](docs/ROADMAP.md)
 - [决策记录](docs/DECISIONS.md)
-- [Spike A：跨平台 shim](docs/spikes/SPIKE_A_SHIM.md)
-- [Spike B：事务安装内核](docs/spikes/SPIKE_B_INSTALL_TRANSACTION.md)
-- [WSL 构建与安全测试](docs/WSL_TESTING.md)
+- [WSL 构建与测试](docs/WSL_TESTING.md)
 
-## 当前开发
+## 许可
 
-```shell
-cargo test --workspace --all-features
-cargo clippy --workspace --all-targets --all-features -- -D warnings
-cargo run --release -p pinset-core --example resolve_bench -- 5000
-cargo build --release -p pinset-cli -p pinset-shim
-cargo run --release -p pinset-shim --example process_bench -- 1000
-```
-
-每次推送到 `main` 或手动运行 workflow 时，GitHub Actions 会先运行格式、Clippy 和测试，再并行生成三个可下载 artifact：
-
-- `pinset-linux-x86_64`
-- `pinset-windows-x86_64`
-- `pinset-macos-aarch64`
-
-Pull Request 只运行质量检查，避免私有仓库重复消耗三平台构建分钟。构建文件保留 14 天。版本标签会在质量检查后构建三个归档、生成 `SHA256SUMS` 并发布 GitHub Release。当前 artifact 和 Release 尚未进行代码签名或公证。
-
-当前 workspace 包含：
-
-- `pinset`：用于项目初始化、`which`、`current`、安装多调用 shim 和管理本机安装源的最小 CLI；
-- `pinset-core`：项目配置的原子创建与严格读取、祖先目录查找、命令解析、安全 shim 安装、原子化安装源配置，以及 feature 隔离的事务安装内核；
-- `pinset-shim`：根据调用文件名选择运行时，并完整传递参数与退出码。
-
-这仍是技术 spike，不代表 v0.1 CLI 契约已经冻结。
-
-## 名称与分发
-
-产品名和命令名确定为 `Pinset` / `pinset`。npm 上已经存在同名旧包，因此 Pinset 不依赖无作用域的 npm 包名；首选 GitHub Releases 分发，不维护第三方 Homebrew Tap 或 Scoop Bucket，中央包管理器渠道仅在满足其官方接收政策后评估。如未来需要 npm 启动器，应使用组织作用域。商标和域名尚未完成法律层面的可用性检索。
-
-## 许可证
-
-开源许可证尚未决定。进入公开代码阶段前，需要在 Apache-2.0 与 MIT（或双许可证）之间做出明确选择。
+开源许可证尚未决定。在许可证文件加入仓库前，不应把当前代码视作已授予通用开源许可。

--- a/crates/pinset-core/Cargo.toml
+++ b/crates/pinset-core/Cargo.toml
@@ -12,11 +12,15 @@ installer = [
     "dep:hex",
     "dep:reqwest",
     "dep:sha2",
+    "dep:tar",
     "dep:tempfile",
+    "dep:xz2",
     "dep:zip",
 ]
+lockfile = ["node-provider", "dep:atomic-write-file"]
+node-metadata = ["lockfile", "dep:reqwest"]
 node-provider = ["sources"]
-project-write = ["dep:tempfile"]
+project-write = ["dep:atomic-write-file", "dep:tempfile"]
 sources = [
     "dep:atomic-write-file",
     "dep:url",
@@ -28,10 +32,12 @@ hex = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 serde.workspace = true
 sha2 = { workspace = true, optional = true }
+tar = { workspace = true, optional = true }
 tempfile = { workspace = true, optional = true }
 thiserror.workspace = true
 toml.workspace = true
 url = { workspace = true, optional = true }
+xz2 = { workspace = true, optional = true }
 zip = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/pinset-core/src/config.rs
+++ b/crates/pinset-core/src/config.rs
@@ -7,7 +7,9 @@ use std::{
 #[cfg(feature = "project-write")]
 use std::io::Write;
 
-use serde::Deserialize;
+#[cfg(feature = "project-write")]
+use atomic_write_file::AtomicWriteFile;
+use serde::{Deserialize, Serialize};
 
 use crate::{Error, Result};
 
@@ -15,12 +17,18 @@ pub const PROJECT_CONFIG_FILENAME: &str = "pinset.toml";
 #[cfg(feature = "project-write")]
 const MINIMAL_PROJECT_CONFIG: &[u8] = b"schema = 1\n\n[tools]\n";
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectConfig {
     pub schema: u32,
     #[serde(default)]
     pub tools: BTreeMap<String, String>,
+}
+
+impl ProjectConfig {
+    pub fn set_tool(&mut self, tool: &str, version: &str) {
+        self.tools.insert(tool.to_owned(), version.to_owned());
+    }
 }
 
 pub fn find_project_config(start: &Path) -> Result<PathBuf> {
@@ -91,6 +99,30 @@ pub fn create_project_config(directory: &Path) -> Result<PathBuf> {
             source: error.error,
         }),
     }
+}
+
+#[cfg(feature = "project-write")]
+pub fn save_project_config(path: &Path, config: &ProjectConfig) -> Result<()> {
+    if config.schema != 1 {
+        return Err(Error::UnsupportedSchema {
+            actual: config.schema,
+        });
+    }
+    let serialized = toml::to_string_pretty(config)
+        .map_err(|source| Error::SerializeProjectConfig { source })?;
+    let mut file =
+        AtomicWriteFile::options()
+            .open(path)
+            .map_err(|source| Error::WriteProjectConfig {
+                path: path.to_path_buf(),
+                source,
+            })?;
+    file.write_all(serialized.as_bytes())
+        .and_then(|()| file.commit())
+        .map_err(|source| Error::WriteProjectConfig {
+            path: path.to_path_buf(),
+            source,
+        })
 }
 
 #[cfg(test)]
@@ -222,5 +254,25 @@ mod tests {
         );
         load_project_config(&project.join(PROJECT_CONFIG_FILENAME))
             .expect("winning config is complete");
+    }
+
+    #[cfg(feature = "project-write")]
+    #[test]
+    fn atomically_updates_project_tools() {
+        let root = tempdir().expect("temp directory");
+        let path = create_project_config(root.path()).expect("create config");
+        let mut config = load_project_config(&path).expect("load config");
+        config.set_tool("node", "24.0.0");
+
+        save_project_config(&path, &config).expect("save config");
+
+        assert_eq!(
+            load_project_config(&path)
+                .expect("reload config")
+                .tools
+                .get("node")
+                .map(String::as_str),
+            Some("24.0.0")
+        );
     }
 }

--- a/crates/pinset-core/src/error.rs
+++ b/crates/pinset-core/src/error.rs
@@ -22,9 +22,73 @@ pub enum Error {
     #[error("unsupported pinset.toml schema {actual}; this spike supports schema 1")]
     UnsupportedSchema { actual: u32 },
 
+    #[cfg(feature = "lockfile")]
+    #[error("failed to read lockfile {path}: {source}")]
+    ReadLockfile {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[cfg(feature = "lockfile")]
+    #[error("lockfile {path} is invalid TOML: {source}")]
+    ParseLockfile {
+        path: PathBuf,
+        #[source]
+        source: toml::de::Error,
+    },
+
+    #[cfg(feature = "lockfile")]
+    #[error("unsupported pinset.lock schema {actual}; this version supports schema 1")]
+    UnsupportedLockfileSchema { actual: u32 },
+
+    #[cfg(feature = "lockfile")]
+    #[error("invalid pinset.lock: {reason}")]
+    InvalidLockfile { reason: String },
+
+    #[cfg(feature = "lockfile")]
+    #[error("failed to serialize lockfile: {source}")]
+    SerializeLockfile {
+        #[source]
+        source: toml::ser::Error,
+    },
+
+    #[cfg(feature = "lockfile")]
+    #[error("failed to atomically write lockfile {path}: {source}")]
+    WriteLockfile {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[cfg(feature = "lockfile")]
+    #[error("pinset.lock does not contain tool \"{tool}\"")]
+    LockedToolMissing { tool: String },
+
+    #[cfg(feature = "lockfile")]
+    #[error("pinset.lock does not contain {tool} artifact for {target}")]
+    LockedArtifactMissing { tool: String, target: String },
+
+    #[cfg(feature = "lockfile")]
+    #[error(
+        "pinset.toml selects {tool}@{configured}, but pinset.lock contains {tool}@{locked}; run `pinset use {tool}@{configured}`"
+    )]
+    LockfileMismatch {
+        tool: String,
+        configured: String,
+        locked: String,
+    },
+
     #[cfg(feature = "project-write")]
     #[error("refusing to overwrite existing project config: {path}")]
     ProjectConfigAlreadyExists { path: PathBuf },
+
+    #[cfg(feature = "project-write")]
+    #[error("failed to serialize project config: {source}")]
+    SerializeProjectConfig {
+        #[source]
+        source: toml::ser::Error,
+    },
 
     #[cfg(feature = "project-write")]
     #[error("failed to atomically create project config {path}: {source}")]
@@ -50,8 +114,8 @@ pub enum Error {
         searched: String,
     },
 
-    #[error("PINSET_HOME is not set")]
-    PinsetHomeNotSet,
+    #[error("cannot determine Pinset data directory; set PINSET_HOME explicitly")]
+    PinsetHomeUnavailable,
 
     #[cfg(feature = "sources")]
     #[error("unsupported source provider \"{provider}\"; expected one of: node, python, flutter")]
@@ -159,6 +223,34 @@ pub enum Error {
     )]
     UnsupportedNodeTarget { target: String },
 
+    #[cfg(feature = "node-metadata")]
+    #[error("failed to request official Node.js metadata {url}: {source}")]
+    NodeMetadataRequest {
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+
+    #[cfg(feature = "node-metadata")]
+    #[error("failed while reading official Node.js metadata {url}: {source}")]
+    NodeMetadataRead {
+        url: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[cfg(feature = "node-metadata")]
+    #[error("official Node.js SHASUMS exceeds {limit} bytes")]
+    NodeMetadataTooLarge { limit: u64 },
+
+    #[cfg(feature = "node-metadata")]
+    #[error("invalid official Node.js SHASUMS: {reason}")]
+    InvalidNodeShasums { reason: String },
+
+    #[cfg(feature = "node-metadata")]
+    #[error("Node.js {version} SHASUMS does not contain {filename}")]
+    NodeChecksumMissing { version: String, filename: String },
+
     #[error("failed to create shim directory {path}: {source}")]
     CreateShimDirectory {
         path: PathBuf,
@@ -189,6 +281,10 @@ pub enum Error {
     #[cfg(feature = "installer")]
     #[error("invalid install path segment for {field}: \"{value}\"")]
     InvalidInstallSegment { field: &'static str, value: String },
+
+    #[cfg(feature = "installer")]
+    #[error("invalid archive strip-components value {value}; maximum is 8")]
+    InvalidStripComponents { value: usize },
 
     #[cfg(feature = "installer")]
     #[error("an install request must declare at least one required runtime path")]
@@ -282,6 +378,14 @@ pub enum Error {
         index: usize,
         #[source]
         source: zip::result::ZipError,
+    },
+
+    #[cfg(feature = "installer")]
+    #[error("failed to read TAR/XZ archive {path}: {source}")]
+    ReadTarArchive {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
     },
 
     #[cfg(feature = "installer")]

--- a/crates/pinset-core/src/installer.rs
+++ b/crates/pinset-core/src/installer.rs
@@ -7,9 +7,10 @@ use std::{
 };
 
 use reqwest::blocking::Client;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tempfile::Builder;
+use xz2::read::XzDecoder;
 use zip::ZipArchive;
 
 use crate::{Error, Result};
@@ -17,12 +18,14 @@ use crate::{Error, Result};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ArtifactFormat {
     Zip,
+    TarXz,
 }
 
 impl ArtifactFormat {
     fn receipt_name(self) -> &'static str {
         match self {
             Self::Zip => "zip",
+            Self::TarXz => "tar.xz",
         }
     }
 }
@@ -64,6 +67,7 @@ pub struct InstallRequest {
     pub version: String,
     pub target: String,
     pub artifact: ArtifactSpec,
+    pub strip_components: usize,
     pub required_paths: Vec<PathBuf>,
 }
 
@@ -119,7 +123,8 @@ impl Installer {
             .join(&request.version)
             .join(&request.target);
         if final_dir.exists() {
-            return Err(Error::InstallAlreadyExists { path: final_dir });
+            return existing_install_outcome(&final_dir, request)
+                .ok_or(Error::InstallAlreadyExists { path: final_dir });
         }
 
         let temporary_root = request.pinset_home.join("tmp");
@@ -167,7 +172,12 @@ impl Installer {
                     .unwrap_or_else(|| "no source was attempted".to_owned()),
             })?;
         match request.artifact.format {
-            ArtifactFormat::Zip => self.extract_zip(&download_path, &staging_dir)?,
+            ArtifactFormat::Zip => {
+                self.extract_zip(&download_path, &staging_dir, request.strip_components)?
+            }
+            ArtifactFormat::TarXz => {
+                self.extract_tar_xz(&download_path, &staging_dir, request.strip_components)?
+            }
         }
         validate_required_paths(&staging_dir, &request.required_paths)?;
         write_receipt(
@@ -280,7 +290,12 @@ impl Installer {
         Ok((total, actual_hex))
     }
 
-    fn extract_zip(&self, archive_path: &Path, destination: &Path) -> Result<()> {
+    fn extract_zip(
+        &self,
+        archive_path: &Path,
+        destination: &Path,
+        strip_components: usize,
+    ) -> Result<()> {
         let file = File::open(archive_path).map_err(|source| Error::ExtractArchiveEntry {
             entry: "<archive>".to_owned(),
             path: archive_path.to_path_buf(),
@@ -304,14 +319,23 @@ impl Installer {
                 .by_index(index)
                 .map_err(|source| Error::ReadZipEntry { index, source })?;
             let entry_name = entry.name().to_owned();
-            let relative = entry
+            let archived_path = entry
                 .enclosed_name()
                 .ok_or_else(|| Error::UnsafeArchiveEntry {
                     entry: entry_name.clone(),
                 })?;
-            if !is_safe_relative(&relative) || is_special_zip_entry(entry.unix_mode()) {
+            if !is_safe_relative(&archived_path) || is_special_zip_entry(entry.unix_mode()) {
                 return Err(Error::UnsafeArchiveEntry { entry: entry_name });
             }
+            let Some(relative) = strip_entry_path(
+                &archived_path,
+                strip_components,
+                entry.is_dir(),
+                &entry_name,
+            )?
+            else {
+                continue;
+            };
             let collision_key = archive_collision_key(&relative);
             if !seen.insert(collision_key) {
                 return Err(Error::DuplicateArchiveEntry { entry: entry_name });
@@ -383,14 +407,188 @@ impl Installer {
             output
                 .sync_all()
                 .map_err(|source| Error::ExtractArchiveEntry {
+                    entry: entry_name.clone(),
+                    path: output_path.clone(),
+                    source,
+                })?;
+            set_executable_permissions(&output_path, entry.unix_mode()).map_err(|source| {
+                Error::ExtractArchiveEntry {
                     entry: entry_name,
                     path: output_path,
                     source,
-                })?;
+                }
+            })?;
         }
 
         Ok(())
     }
+
+    fn extract_tar_xz(
+        &self,
+        archive_path: &Path,
+        destination: &Path,
+        strip_components: usize,
+    ) -> Result<()> {
+        let file = File::open(archive_path).map_err(|source| Error::ExtractArchiveEntry {
+            entry: "<archive>".to_owned(),
+            path: archive_path.to_path_buf(),
+            source,
+        })?;
+        let decoder = XzDecoder::new(file);
+        let mut archive = tar::Archive::new(decoder);
+        let entries = archive.entries().map_err(|source| Error::ReadTarArchive {
+            path: archive_path.to_path_buf(),
+            source,
+        })?;
+        let mut seen = HashSet::new();
+        let mut total_unpacked = 0_u64;
+        let mut entry_count = 0_usize;
+
+        for entry in entries {
+            entry_count += 1;
+            if entry_count > self.limits.max_archive_entries {
+                return Err(Error::TooManyArchiveEntries {
+                    actual: entry_count,
+                    limit: self.limits.max_archive_entries,
+                });
+            }
+            let mut entry = entry.map_err(|source| Error::ReadTarArchive {
+                path: archive_path.to_path_buf(),
+                source,
+            })?;
+            let archived_path = entry.path().map_err(|source| Error::ReadTarArchive {
+                path: archive_path.to_path_buf(),
+                source,
+            })?;
+            let entry_name = archived_path.to_string_lossy().into_owned();
+            let entry_type = entry.header().entry_type();
+            let is_directory = entry_type.is_dir();
+            if (!entry_type.is_file() && !is_directory) || !is_safe_relative(&archived_path) {
+                return Err(Error::UnsafeArchiveEntry { entry: entry_name });
+            }
+            let Some(relative) =
+                strip_entry_path(&archived_path, strip_components, is_directory, &entry_name)?
+            else {
+                continue;
+            };
+            if !seen.insert(archive_collision_key(&relative)) {
+                return Err(Error::DuplicateArchiveEntry { entry: entry_name });
+            }
+            let output_path = destination.join(&relative);
+            if is_directory {
+                fs::create_dir_all(&output_path).map_err(|source| Error::ExtractArchiveEntry {
+                    entry: entry_name,
+                    path: output_path,
+                    source,
+                })?;
+                continue;
+            }
+
+            let remaining = self
+                .limits
+                .max_unpacked_bytes
+                .checked_sub(total_unpacked)
+                .ok_or(Error::ArchiveTooLarge {
+                    limit: self.limits.max_unpacked_bytes,
+                })?;
+            let claimed_size = entry
+                .header()
+                .size()
+                .map_err(|source| Error::ReadTarArchive {
+                    path: archive_path.to_path_buf(),
+                    source,
+                })?;
+            if claimed_size > remaining {
+                return Err(Error::ArchiveTooLarge {
+                    limit: self.limits.max_unpacked_bytes,
+                });
+            }
+            if let Some(parent) = output_path.parent() {
+                fs::create_dir_all(parent).map_err(|source| Error::ExtractArchiveEntry {
+                    entry: entry_name.clone(),
+                    path: parent.to_path_buf(),
+                    source,
+                })?;
+            }
+            let mut output = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&output_path)
+                .map_err(|source| Error::ExtractArchiveEntry {
+                    entry: entry_name.clone(),
+                    path: output_path.clone(),
+                    source,
+                })?;
+            let mut limited_entry = (&mut entry).take(remaining.saturating_add(1));
+            let copied = io::copy(&mut limited_entry, &mut output).map_err(|source| {
+                Error::ExtractArchiveEntry {
+                    entry: entry_name.clone(),
+                    path: output_path.clone(),
+                    source,
+                }
+            })?;
+            if copied > remaining {
+                return Err(Error::ArchiveTooLarge {
+                    limit: self.limits.max_unpacked_bytes,
+                });
+            }
+            if copied != claimed_size {
+                return Err(Error::ExtractArchiveEntry {
+                    entry: entry_name,
+                    path: output_path,
+                    source: io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "TAR entry size did not match extracted bytes",
+                    ),
+                });
+            }
+            total_unpacked += copied;
+            output
+                .sync_all()
+                .map_err(|source| Error::ExtractArchiveEntry {
+                    entry: entry_name.clone(),
+                    path: output_path.clone(),
+                    source,
+                })?;
+            let mode = entry
+                .header()
+                .mode()
+                .map_err(|source| Error::ReadTarArchive {
+                    path: archive_path.to_path_buf(),
+                    source,
+                })?;
+            set_executable_permissions(&output_path, Some(mode)).map_err(|source| {
+                Error::ExtractArchiveEntry {
+                    entry: entry_name,
+                    path: output_path,
+                    source,
+                }
+            })?;
+        }
+        Ok(())
+    }
+}
+
+fn existing_install_outcome(final_dir: &Path, request: &InstallRequest) -> Option<InstallOutcome> {
+    let content = fs::read_to_string(final_dir.join(".pinset-install.toml")).ok()?;
+    let receipt: ExistingInstallReceipt = toml::from_str(&content).ok()?;
+    if !receipt.complete
+        || receipt.tool != request.tool
+        || receipt.version != request.version
+        || receipt.target != request.target
+        || receipt.artifact_sha256 != request.artifact.sha256.to_ascii_lowercase()
+    {
+        return None;
+    }
+    if validate_required_paths(final_dir, &request.required_paths).is_err() {
+        return None;
+    }
+    Some(InstallOutcome {
+        install_dir: final_dir.to_path_buf(),
+        bytes_downloaded: 0,
+        sha256: receipt.artifact_sha256,
+        source_id: receipt.selected_source,
+    })
 }
 
 pub fn sha256_hex(bytes: &[u8]) -> String {
@@ -410,6 +608,11 @@ fn validate_request(request: &InstallRequest) -> Result<()> {
     validate_segment("tool", &request.tool)?;
     validate_segment("version", &request.version)?;
     validate_segment("target", &request.target)?;
+    if request.strip_components > 8 {
+        return Err(Error::InvalidStripComponents {
+            value: request.strip_components,
+        });
+    }
     if request.required_paths.is_empty() {
         return Err(Error::RequiredPathsEmpty);
     }
@@ -440,6 +643,31 @@ fn validate_request(request: &InstallRequest) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn strip_entry_path(
+    path: &Path,
+    strip_components: usize,
+    is_directory: bool,
+    entry_name: &str,
+) -> Result<Option<PathBuf>> {
+    let components = path.components().collect::<Vec<_>>();
+    if components.len() < strip_components
+        || (components.len() == strip_components && !is_directory)
+    {
+        return Err(Error::UnsafeArchiveEntry {
+            entry: entry_name.to_owned(),
+        });
+    }
+    if components.len() == strip_components {
+        return Ok(None);
+    }
+    Ok(Some(
+        components
+            .into_iter()
+            .skip(strip_components)
+            .collect::<PathBuf>(),
+    ))
 }
 
 fn is_retryable_source_error(error: &Error) -> bool {
@@ -485,6 +713,21 @@ fn archive_collision_key(path: &Path) -> String {
     }
 }
 
+#[cfg(unix)]
+fn set_executable_permissions(path: &Path, mode: Option<u32>) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    if let Some(mode) = mode {
+        fs::set_permissions(path, fs::Permissions::from_mode(mode & 0o777))?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_executable_permissions(_path: &Path, _mode: Option<u32>) -> io::Result<()> {
+    Ok(())
+}
+
 fn redacted_url(value: &str) -> String {
     let Ok(mut url) = reqwest::Url::parse(value) else {
         return "<invalid-url>".to_owned();
@@ -520,6 +763,16 @@ struct InstallReceipt<'a> {
     artifact_sha256: &'a str,
     artifact_format: &'a str,
     bytes_downloaded: u64,
+}
+
+#[derive(Deserialize)]
+struct ExistingInstallReceipt {
+    complete: bool,
+    tool: String,
+    version: String,
+    target: String,
+    selected_source: String,
+    artifact_sha256: String,
 }
 
 fn write_receipt(
@@ -570,6 +823,7 @@ mod tests {
     };
 
     use tempfile::tempdir;
+    use xz2::write::XzEncoder;
     use zip::{ZipWriter, write::SimpleFileOptions};
 
     use super::*;
@@ -597,6 +851,48 @@ mod tests {
         assert!(!receipt.contains("must-not-be-recorded"));
         assert_eq!(outcome.bytes_downloaded, archive.len() as u64);
         assert_eq!(outcome.source_id, "local-mirror");
+        let repeated = test_installer()
+            .install(&request)
+            .expect("identical install is idempotent");
+        assert_eq!(repeated.install_dir, outcome.install_dir);
+        assert_eq!(repeated.bytes_downloaded, 0);
+        assert_transaction_root_is_empty(root.path());
+    }
+
+    #[test]
+    fn installs_tar_xz_with_stripped_root_and_executable_permissions() {
+        let archive = tar_xz_bytes(&[
+            ("node-v24.0.0-linux-x64/bin/node", b"fake node", 0o755),
+            ("node-v24.0.0-linux-x64/bin/npm", b"fake npm", 0o755),
+        ]);
+        let (url, server) = serve_once(archive.clone(), archive.len());
+        let root = tempdir().expect("temp root");
+        let mut request = request(root.path(), url, sha256_hex(&archive));
+        request.target = "linux-x86_64".to_owned();
+        request.artifact.format = ArtifactFormat::TarXz;
+        request.strip_components = 1;
+        request.required_paths = vec![PathBuf::from("bin/node"), PathBuf::from("bin/npm")];
+
+        let outcome = test_installer().install(&request).expect("install");
+        server.join().expect("server");
+
+        assert_eq!(
+            fs::read(outcome.install_dir.join("bin/node")).expect("runtime"),
+            b"fake node"
+        );
+        assert!(!outcome.install_dir.join("node-v24.0.0-linux-x64").exists());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_ne!(
+                fs::metadata(outcome.install_dir.join("bin/node"))
+                    .expect("metadata")
+                    .permissions()
+                    .mode()
+                    & 0o111,
+                0
+            );
+        }
         assert_transaction_root_is_empty(root.path());
     }
 
@@ -776,6 +1072,7 @@ mod tests {
                 sha256,
                 format: ArtifactFormat::Zip,
             },
+            strip_components: 0,
             required_paths: vec![PathBuf::from("bin/node.exe")],
         }
     }
@@ -805,6 +1102,23 @@ mod tests {
             writer.write_all(content).expect("zip content");
         }
         writer.finish().expect("zip finish").into_inner()
+    }
+
+    fn tar_xz_bytes(entries: &[(&str, &[u8], u32)]) -> Vec<u8> {
+        let encoder = XzEncoder::new(Vec::new(), 6);
+        let mut builder = tar::Builder::new(encoder);
+        for (path, content, mode) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_path(path).expect("tar path");
+            header.set_size(content.len() as u64);
+            header.set_mode(*mode);
+            header.set_cksum();
+            builder
+                .append(&header, Cursor::new(*content))
+                .expect("tar entry");
+        }
+        let encoder = builder.into_inner().expect("tar finish");
+        encoder.finish().expect("xz finish")
     }
 
     fn serve_once(body: Vec<u8>, declared_length: usize) -> (String, thread::JoinHandle<()>) {

--- a/crates/pinset-core/src/lib.rs
+++ b/crates/pinset-core/src/lib.rs
@@ -2,29 +2,46 @@ mod config;
 mod error;
 #[cfg(feature = "installer")]
 mod installer;
+#[cfg(feature = "lockfile")]
+mod lockfile;
+#[cfg(feature = "node-metadata")]
+mod node_metadata;
 #[cfg(feature = "node-provider")]
 mod node_provider;
+#[cfg(all(feature = "installer", feature = "lockfile"))]
+mod node_runtime;
 mod resolver;
 mod shim_install;
 #[cfg(feature = "sources")]
 mod source_config;
 mod target;
 
-#[cfg(feature = "project-write")]
-pub use config::create_project_config;
 pub use config::{
     PROJECT_CONFIG_FILENAME, ProjectConfig, find_project_config, load_project_config,
 };
+#[cfg(feature = "project-write")]
+pub use config::{create_project_config, save_project_config};
 pub use error::{Error, Result};
 #[cfg(feature = "installer")]
 pub use installer::{
     ArtifactFormat, ArtifactSource, ArtifactSourceKind, ArtifactSpec, InstallLimits,
     InstallOutcome, InstallRequest, Installer, sha256_hex,
 };
+#[cfg(feature = "lockfile")]
+pub use lockfile::{
+    LOCKFILE_FILENAME, LOCKFILE_SCHEMA, LockedArtifact, LockedArtifactFormat, LockedTool, Lockfile,
+    MVP_NODE_TARGETS, load_lockfile, load_optional_lockfile, lockfile_path, save_lockfile,
+    validate_lock_matches_project,
+};
+#[cfg(feature = "node-metadata")]
+pub use node_metadata::NodeMetadataClient;
 #[cfg(feature = "node-provider")]
 pub use node_provider::{NodeArchiveFormat, NodeArtifactPlan, plan_node_artifact};
+#[cfg(all(feature = "installer", feature = "lockfile"))]
+pub use node_runtime::{install_locked_node, node_command_directory};
 pub use resolver::{
-    CommandResolution, command_tool, pinset_home_from_env, resolve_command, resolve_from_env,
+    CommandResolution, command_tool, pinset_home, pinset_home_from_env, resolve_command,
+    resolve_from_env,
 };
 pub use shim_install::{ShimInstallMethod, ShimInstallResult, install_shims};
 #[cfg(feature = "sources")]

--- a/crates/pinset-core/src/lockfile.rs
+++ b/crates/pinset-core/src/lockfile.rs
@@ -1,0 +1,347 @@
+use std::{
+    collections::HashSet,
+    fs,
+    io::{ErrorKind, Write},
+    path::{Path, PathBuf},
+};
+
+use atomic_write_file::AtomicWriteFile;
+use serde::{Deserialize, Serialize};
+
+use crate::{Error, NodeArchiveFormat, Result, SourceConfig, plan_node_artifact};
+
+pub const LOCKFILE_FILENAME: &str = "pinset.lock";
+pub const LOCKFILE_SCHEMA: u32 = 1;
+pub const MVP_NODE_TARGETS: [&str; 4] = [
+    "windows-x86_64",
+    "macos-aarch64",
+    "macos-x86_64",
+    "linux-x86_64",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Lockfile {
+    pub schema: u32,
+    pub generated_by: String,
+    #[serde(rename = "tool")]
+    pub tools: Vec<LockedTool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LockedTool {
+    pub name: String,
+    pub requested: String,
+    pub version: String,
+    pub provider: String,
+    #[serde(rename = "artifact")]
+    pub artifacts: Vec<LockedArtifact>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LockedArtifact {
+    pub target: String,
+    pub canonical_url: String,
+    pub artifact_path: String,
+    pub sha256: String,
+    pub format: LockedArtifactFormat,
+    pub archive_root: String,
+    pub verification: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LockedArtifactFormat {
+    #[serde(rename = "zip")]
+    Zip,
+    #[serde(rename = "tar.xz")]
+    TarXz,
+}
+
+impl LockedArtifactFormat {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Zip => "zip",
+            Self::TarXz => "tar.xz",
+        }
+    }
+}
+
+impl Lockfile {
+    pub fn new_node(generated_by: String, version: String, artifacts: Vec<LockedArtifact>) -> Self {
+        Self {
+            schema: LOCKFILE_SCHEMA,
+            generated_by,
+            tools: vec![LockedTool {
+                name: "node".to_owned(),
+                requested: version.clone(),
+                version,
+                provider: "nodejs-official".to_owned(),
+                artifacts,
+            }],
+        }
+    }
+
+    pub fn tool(&self, name: &str) -> Option<&LockedTool> {
+        self.tools.iter().find(|tool| tool.name == name)
+    }
+}
+
+impl LockedTool {
+    pub fn artifact(&self, target: &str) -> Option<&LockedArtifact> {
+        self.artifacts
+            .iter()
+            .find(|artifact| artifact.target == target)
+    }
+}
+
+pub fn lockfile_path(project_config_path: &Path) -> PathBuf {
+    project_config_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(LOCKFILE_FILENAME)
+}
+
+pub fn load_lockfile(path: &Path) -> Result<Lockfile> {
+    let content = fs::read_to_string(path).map_err(|source| Error::ReadLockfile {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let lockfile: Lockfile = toml::from_str(&content).map_err(|source| Error::ParseLockfile {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    validate_lockfile(&lockfile)?;
+    Ok(lockfile)
+}
+
+pub fn save_lockfile(path: &Path, lockfile: &Lockfile) -> Result<()> {
+    validate_lockfile(lockfile)?;
+    let mut normalized = lockfile.clone();
+    normalized
+        .tools
+        .sort_by(|left, right| left.name.cmp(&right.name));
+    for tool in &mut normalized.tools {
+        tool.artifacts
+            .sort_by(|left, right| left.target.cmp(&right.target));
+    }
+    let serialized = toml::to_string_pretty(&normalized)
+        .map_err(|source| Error::SerializeLockfile { source })?;
+    let mut file =
+        AtomicWriteFile::options()
+            .open(path)
+            .map_err(|source| Error::WriteLockfile {
+                path: path.to_path_buf(),
+                source,
+            })?;
+    file.write_all(serialized.as_bytes())
+        .and_then(|()| file.commit())
+        .map_err(|source| Error::WriteLockfile {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+pub fn validate_lock_matches_project<'a>(
+    lockfile: &'a Lockfile,
+    project_node_version: &str,
+) -> Result<&'a LockedTool> {
+    let tool = lockfile.tool("node").ok_or(Error::LockedToolMissing {
+        tool: "node".to_owned(),
+    })?;
+    if tool.requested != project_node_version || tool.version != project_node_version {
+        return Err(Error::LockfileMismatch {
+            tool: "node".to_owned(),
+            configured: project_node_version.to_owned(),
+            locked: tool.version.clone(),
+        });
+    }
+    Ok(tool)
+}
+
+fn validate_lockfile(lockfile: &Lockfile) -> Result<()> {
+    if lockfile.schema != LOCKFILE_SCHEMA {
+        return Err(Error::UnsupportedLockfileSchema {
+            actual: lockfile.schema,
+        });
+    }
+    if lockfile.generated_by.trim().is_empty() {
+        return Err(Error::InvalidLockfile {
+            reason: "generated_by cannot be empty".to_owned(),
+        });
+    }
+    let mut tool_names = HashSet::with_capacity(lockfile.tools.len());
+    for tool in &lockfile.tools {
+        if !tool_names.insert(&tool.name) {
+            return Err(Error::InvalidLockfile {
+                reason: format!("duplicate tool {}", tool.name),
+            });
+        }
+        validate_locked_tool(tool)?;
+    }
+    Ok(())
+}
+
+fn validate_locked_tool(tool: &LockedTool) -> Result<()> {
+    if tool.name != "node" || tool.provider != "nodejs-official" {
+        return Err(Error::InvalidLockfile {
+            reason: format!(
+                "unsupported tool/provider pair {}/{}",
+                tool.name, tool.provider
+            ),
+        });
+    }
+    if tool.requested != tool.version {
+        return Err(Error::InvalidLockfile {
+            reason: "Node MVP requires requested and version to be the same exact version"
+                .to_owned(),
+        });
+    }
+    let mut targets = HashSet::with_capacity(tool.artifacts.len());
+    for artifact in &tool.artifacts {
+        if !targets.insert(artifact.target.as_str()) {
+            return Err(Error::InvalidLockfile {
+                reason: format!("duplicate artifact target {}", artifact.target),
+            });
+        }
+        validate_locked_artifact(&tool.version, artifact)?;
+    }
+    for target in MVP_NODE_TARGETS {
+        if !targets.contains(target) {
+            return Err(Error::InvalidLockfile {
+                reason: format!("missing Node MVP artifact for {target}"),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_locked_artifact(version: &str, artifact: &LockedArtifact) -> Result<()> {
+    let plan = plan_node_artifact(&SourceConfig::default(), version, &artifact.target)?;
+    let expected_format = match plan.format {
+        NodeArchiveFormat::Zip => LockedArtifactFormat::Zip,
+        NodeArchiveFormat::TarXz => LockedArtifactFormat::TarXz,
+    };
+    if artifact.canonical_url != plan.canonical_url
+        || artifact.artifact_path != plan.artifact_path
+        || artifact.archive_root != plan.archive_root
+        || artifact.format != expected_format
+    {
+        return Err(Error::InvalidLockfile {
+            reason: format!(
+                "artifact identity for {} does not match the built-in Node provider",
+                artifact.target
+            ),
+        });
+    }
+    if artifact.sha256.len() != 64 || !artifact.sha256.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err(Error::InvalidLockfile {
+            reason: format!("invalid SHA-256 for {}", artifact.target),
+        });
+    }
+    if artifact.verification != "nodejs-shasums-https" {
+        return Err(Error::InvalidLockfile {
+            reason: format!("unsupported verification for {}", artifact.target),
+        });
+    }
+    Ok(())
+}
+
+pub fn load_optional_lockfile(path: &Path) -> Result<Option<Lockfile>> {
+    match load_lockfile(path) {
+        Ok(lockfile) => Ok(Some(lockfile)),
+        Err(Error::ReadLockfile { source, .. }) if source.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn saves_deterministically_and_reloads_strictly() {
+        let root = tempdir().expect("temp directory");
+        let path = root.path().join(LOCKFILE_FILENAME);
+        let mut artifacts = MVP_NODE_TARGETS
+            .into_iter()
+            .rev()
+            .map(locked_artifact)
+            .collect::<Vec<_>>();
+        let lockfile = Lockfile::new_node(
+            "pinset 0.1.0".to_owned(),
+            "24.0.0".to_owned(),
+            artifacts.clone(),
+        );
+        save_lockfile(&path, &lockfile).expect("save lockfile");
+        let first = fs::read(&path).expect("first lockfile");
+
+        artifacts.rotate_left(1);
+        let reordered =
+            Lockfile::new_node("pinset 0.1.0".to_owned(), "24.0.0".to_owned(), artifacts);
+        save_lockfile(&path, &reordered).expect("save reordered lockfile");
+        let second = fs::read(&path).expect("second lockfile");
+
+        assert_eq!(first, second);
+        let loaded = load_lockfile(&path).expect("reload");
+        assert_eq!(
+            loaded.tools[0]
+                .artifacts
+                .iter()
+                .map(|artifact| artifact.target.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "linux-x86_64",
+                "macos-aarch64",
+                "macos-x86_64",
+                "windows-x86_64",
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_fields_and_mismatched_artifact_identity() {
+        let root = tempdir().expect("temp directory");
+        let path = root.path().join(LOCKFILE_FILENAME);
+        fs::write(
+            &path,
+            "schema = 1\ngenerated_by = \"pinset\"\nunknown = true\n",
+        )
+        .expect("invalid lock");
+        assert!(matches!(
+            load_lockfile(&path),
+            Err(Error::ParseLockfile { .. })
+        ));
+
+        let mut artifacts = MVP_NODE_TARGETS
+            .into_iter()
+            .map(locked_artifact)
+            .collect::<Vec<_>>();
+        artifacts[0].canonical_url = "https://mirror.example/node.zip".to_owned();
+        let lockfile = Lockfile::new_node("pinset".to_owned(), "24.0.0".to_owned(), artifacts);
+        assert!(matches!(
+            save_lockfile(&path, &lockfile),
+            Err(Error::InvalidLockfile { .. })
+        ));
+    }
+
+    fn locked_artifact(target: &str) -> LockedArtifact {
+        let plan = plan_node_artifact(&SourceConfig::default(), "24.0.0", target).expect("plan");
+        LockedArtifact {
+            target: target.to_owned(),
+            canonical_url: plan.canonical_url,
+            artifact_path: plan.artifact_path,
+            sha256: "ab".repeat(32),
+            format: match plan.format {
+                NodeArchiveFormat::Zip => LockedArtifactFormat::Zip,
+                NodeArchiveFormat::TarXz => LockedArtifactFormat::TarXz,
+            },
+            archive_root: plan.archive_root,
+            verification: "nodejs-shasums-https".to_owned(),
+        }
+    }
+}

--- a/crates/pinset-core/src/node_metadata.rs
+++ b/crates/pinset-core/src/node_metadata.rs
@@ -1,0 +1,237 @@
+use std::{collections::HashMap, io::Read, time::Duration};
+
+use reqwest::{Url, blocking::Client};
+
+use crate::{
+    Error, LockedArtifact, LockedArtifactFormat, Lockfile, MVP_NODE_TARGETS, NodeArchiveFormat,
+    Result, SourceConfig, plan_node_artifact,
+};
+
+const OFFICIAL_NODE_DIST_URL: &str = "https://nodejs.org/dist/";
+const MAX_SHASUMS_BYTES: u64 = 1024 * 1024;
+
+#[derive(Debug)]
+pub struct NodeMetadataClient {
+    client: Client,
+    metadata_base_url: Url,
+}
+
+impl NodeMetadataClient {
+    pub fn official() -> Result<Self> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|source| Error::HttpClient { source })?;
+        Ok(Self {
+            client,
+            metadata_base_url: Url::parse(OFFICIAL_NODE_DIST_URL)
+                .expect("built-in Node distribution URL is valid"),
+        })
+    }
+
+    pub fn resolve_exact_lock(&self, version: &str, generated_by: &str) -> Result<Lockfile> {
+        let plans = MVP_NODE_TARGETS
+            .into_iter()
+            .map(|target| plan_node_artifact(&SourceConfig::default(), version, target))
+            .collect::<Result<Vec<_>>>()?;
+        let manifest_url = self
+            .metadata_base_url
+            .join(&format!("v{version}/SHASUMS256.txt"))
+            .expect("validated exact version produces a safe relative URL");
+        let manifest = self.download_shasums(manifest_url)?;
+        let checksums = parse_shasums(&manifest)?;
+        let artifacts =
+            plans
+                .into_iter()
+                .map(|plan| {
+                    let filename = plan
+                        .artifact_path
+                        .rsplit('/')
+                        .next()
+                        .expect("artifact path contains a filename");
+                    let sha256 = checksums.get(filename).cloned().ok_or_else(|| {
+                        Error::NodeChecksumMissing {
+                            version: version.to_owned(),
+                            filename: filename.to_owned(),
+                        }
+                    })?;
+                    Ok(LockedArtifact {
+                        target: plan.target,
+                        canonical_url: plan.canonical_url,
+                        artifact_path: plan.artifact_path,
+                        sha256,
+                        format: match plan.format {
+                            NodeArchiveFormat::Zip => LockedArtifactFormat::Zip,
+                            NodeArchiveFormat::TarXz => LockedArtifactFormat::TarXz,
+                        },
+                        archive_root: plan.archive_root,
+                        verification: "nodejs-shasums-https".to_owned(),
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+        Ok(Lockfile::new_node(
+            generated_by.to_owned(),
+            version.to_owned(),
+            artifacts,
+        ))
+    }
+
+    fn download_shasums(&self, url: Url) -> Result<String> {
+        let display_url = url.to_string();
+        let mut response = self
+            .client
+            .get(url)
+            .send()
+            .and_then(reqwest::blocking::Response::error_for_status)
+            .map_err(|source| Error::NodeMetadataRequest {
+                url: display_url.clone(),
+                source,
+            })?;
+        if response
+            .content_length()
+            .is_some_and(|length| length > MAX_SHASUMS_BYTES)
+        {
+            return Err(Error::NodeMetadataTooLarge {
+                limit: MAX_SHASUMS_BYTES,
+            });
+        }
+        let mut bytes = Vec::new();
+        (&mut response)
+            .take(MAX_SHASUMS_BYTES + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|source| Error::NodeMetadataRead {
+                url: display_url,
+                source,
+            })?;
+        if bytes.len() as u64 > MAX_SHASUMS_BYTES {
+            return Err(Error::NodeMetadataTooLarge {
+                limit: MAX_SHASUMS_BYTES,
+            });
+        }
+        String::from_utf8(bytes).map_err(|_| Error::InvalidNodeShasums {
+            reason: "manifest is not UTF-8".to_owned(),
+        })
+    }
+}
+
+fn parse_shasums(manifest: &str) -> Result<HashMap<String, String>> {
+    let mut checksums = HashMap::new();
+    for (index, line) in manifest.lines().enumerate() {
+        let parts = line.split_whitespace().collect::<Vec<_>>();
+        if parts.len() != 2
+            || parts[0].len() != 64
+            || !parts[0].bytes().all(|byte| byte.is_ascii_hexdigit())
+            || parts[1].contains(['/', '\\'])
+        {
+            return Err(Error::InvalidNodeShasums {
+                reason: format!("invalid line {}", index + 1),
+            });
+        }
+        if checksums
+            .insert(parts[1].to_owned(), parts[0].to_ascii_lowercase())
+            .is_some()
+        {
+            return Err(Error::InvalidNodeShasums {
+                reason: format!("duplicate filename {}", parts[1]),
+            });
+        }
+    }
+    if checksums.is_empty() {
+        return Err(Error::InvalidNodeShasums {
+            reason: "manifest is empty".to_owned(),
+        });
+    }
+    Ok(checksums)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{Read as _, Write as _},
+        net::TcpListener,
+        thread,
+    };
+
+    use super::*;
+
+    #[test]
+    fn resolves_all_mvp_targets_from_official_style_shasums() {
+        let manifest = MVP_NODE_TARGETS
+            .into_iter()
+            .enumerate()
+            .map(|(index, target)| {
+                let plan =
+                    plan_node_artifact(&SourceConfig::default(), "24.0.0", target).expect("plan");
+                let filename = plan.artifact_path.rsplit('/').next().expect("filename");
+                format!("{}  {filename}", format!("{:x}", index + 1).repeat(64))
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let (base_url, server) = serve_once(manifest);
+        let client = NodeMetadataClient {
+            client: Client::builder()
+                .timeout(Duration::from_secs(5))
+                .build()
+                .expect("client"),
+            metadata_base_url: Url::parse(&base_url).expect("base URL"),
+        };
+
+        let lockfile = client
+            .resolve_exact_lock("24.0.0", "pinset test")
+            .expect("resolve lock");
+        server.join().expect("server");
+
+        let node = lockfile.tool("node").expect("node lock");
+        assert_eq!(node.artifacts.len(), MVP_NODE_TARGETS.len());
+        assert!(node.artifacts.iter().all(|artifact| {
+            artifact
+                .canonical_url
+                .starts_with("https://nodejs.org/dist/v24.0.0/")
+        }));
+    }
+
+    #[test]
+    fn rejects_invalid_or_incomplete_shasums() {
+        assert!(matches!(
+            parse_shasums("not-a-hash  node.zip"),
+            Err(Error::InvalidNodeShasums { .. })
+        ));
+        assert!(matches!(
+            parse_shasums(&format!("{}  ../node.zip", "a".repeat(64))),
+            Err(Error::InvalidNodeShasums { .. })
+        ));
+
+        let (base_url, server) = serve_once(format!("{}  unrelated.zip", "a".repeat(64)));
+        let client = NodeMetadataClient {
+            client: Client::builder()
+                .timeout(Duration::from_secs(5))
+                .build()
+                .expect("client"),
+            metadata_base_url: Url::parse(&base_url).expect("base URL"),
+        };
+        let error = client
+            .resolve_exact_lock("24.0.0", "pinset test")
+            .expect_err("missing target checksum");
+        server.join().expect("server");
+        assert!(matches!(error, Error::NodeChecksumMissing { .. }));
+    }
+
+    fn serve_once(body: String) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind server");
+        let address = listener.local_addr().expect("server address");
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut request = [0_u8; 4096];
+            let _ = stream.read(&mut request);
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .expect("response");
+        });
+        (format!("http://{address}/"), handle)
+    }
+}

--- a/crates/pinset-core/src/node_provider.rs
+++ b/crates/pinset-core/src/node_provider.rs
@@ -34,7 +34,7 @@ pub fn plan_node_artifact(
 ) -> Result<NodeArtifactPlan> {
     validate_exact_version(version)?;
     let platform = node_platform(target)?;
-    let format = if platform.ends_with("win-x64") || platform.ends_with("win-arm64") {
+    let format = if platform.starts_with("win-") {
         NodeArchiveFormat::Zip
     } else {
         NodeArchiveFormat::TarXz
@@ -119,6 +119,17 @@ mod tests {
         assert_eq!(plan.format, NodeArchiveFormat::TarXz);
         assert_eq!(plan.artifact_path, "v24.0.0/node-v24.0.0-linux-x64.tar.xz");
         assert_eq!(plan.node_executable, "node-v24.0.0-linux-x64/bin/node");
+    }
+
+    #[test]
+    fn plans_macos_as_tar_xz_not_windows_zip() {
+        for target in ["macos-x86_64", "macos-aarch64"] {
+            let plan =
+                plan_node_artifact(&SourceConfig::default(), "24.0.0", target).expect("plan");
+            assert_eq!(plan.format, NodeArchiveFormat::TarXz);
+            assert!(plan.artifact_path.ends_with(".tar.xz"));
+            assert!(plan.node_executable.ends_with("/bin/node"));
+        }
     }
 
     #[test]

--- a/crates/pinset-core/src/node_runtime.rs
+++ b/crates/pinset-core/src/node_runtime.rs
@@ -1,0 +1,97 @@
+use std::path::{Path, PathBuf};
+
+use crate::{
+    ArtifactFormat, ArtifactSource, ArtifactSourceKind, ArtifactSpec, Error, InstallOutcome,
+    InstallRequest, Installer, LockedArtifactFormat, LockedTool, Result, SourceConfig, SourceKind,
+};
+
+pub fn install_locked_node(
+    installer: &Installer,
+    pinset_home: &Path,
+    source_config: &SourceConfig,
+    locked_node: &LockedTool,
+    target: &str,
+) -> Result<InstallOutcome> {
+    let artifact = locked_node
+        .artifact(target)
+        .ok_or_else(|| Error::LockedArtifactMissing {
+            tool: "node".to_owned(),
+            target: target.to_owned(),
+        })?;
+    let sources = source_config
+        .resolve_artifact_sources("node", &artifact.artifact_path)?
+        .into_iter()
+        .map(|source| ArtifactSource {
+            id: source.alias,
+            url: source.url,
+            kind: match source.kind {
+                SourceKind::Official => ArtifactSourceKind::Official,
+                SourceKind::Custom => ArtifactSourceKind::Mirror,
+            },
+        })
+        .collect();
+    let request = InstallRequest {
+        pinset_home: pinset_home.to_path_buf(),
+        tool: "node".to_owned(),
+        version: locked_node.version.clone(),
+        target: target.to_owned(),
+        artifact: ArtifactSpec {
+            canonical_url: artifact.canonical_url.clone(),
+            sources,
+            sha256: artifact.sha256.clone(),
+            format: match artifact.format {
+                LockedArtifactFormat::Zip => ArtifactFormat::Zip,
+                LockedArtifactFormat::TarXz => ArtifactFormat::TarXz,
+            },
+        },
+        strip_components: 1,
+        required_paths: required_node_paths(target)?,
+    };
+    installer.install(&request)
+}
+
+pub fn node_command_directory(install_dir: &Path, target: &str) -> Result<PathBuf> {
+    if target.starts_with("windows-") {
+        Ok(install_dir.to_path_buf())
+    } else if target.starts_with("linux-") || target.starts_with("macos-") {
+        Ok(install_dir.join("bin"))
+    } else {
+        Err(Error::UnsupportedNodeTarget {
+            target: target.to_owned(),
+        })
+    }
+}
+
+fn required_node_paths(target: &str) -> Result<Vec<PathBuf>> {
+    if target.starts_with("windows-") {
+        Ok(vec![PathBuf::from("node.exe")])
+    } else if target.starts_with("linux-") || target.starts_with("macos-") {
+        Ok(vec![PathBuf::from("bin/node")])
+    } else {
+        Err(Error::UnsupportedNodeTarget {
+            target: target.to_owned(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_node_commands_to_native_archive_layout() {
+        let root = Path::new("/pinset/node");
+        assert_eq!(
+            node_command_directory(root, "windows-x86_64").expect("windows"),
+            root
+        );
+        assert_eq!(
+            node_command_directory(root, "linux-x86_64").expect("linux"),
+            root.join("bin")
+        );
+        assert_eq!(
+            node_command_directory(root, "macos-aarch64").expect("macOS"),
+            root.join("bin")
+        );
+    }
+}

--- a/crates/pinset-core/src/resolver.rs
+++ b/crates/pinset-core/src/resolver.rs
@@ -21,15 +21,45 @@ pub fn command_tool(command: &str) -> Option<&'static str> {
     }
 }
 
-pub fn pinset_home_from_env() -> Result<PathBuf> {
-    env::var_os("PINSET_HOME")
+pub fn pinset_home() -> Result<PathBuf> {
+    if let Some(path) = env::var_os("PINSET_HOME")
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
-        .ok_or(Error::PinsetHomeNotSet)
+    {
+        return Ok(path);
+    }
+
+    #[cfg(windows)]
+    {
+        env::var_os("LOCALAPPDATA")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+            .map(|path| path.join("Pinset"))
+            .ok_or(Error::PinsetHomeUnavailable)
+    }
+
+    #[cfg(not(windows))]
+    {
+        if let Some(path) = env::var_os("XDG_DATA_HOME")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+        {
+            return Ok(path.join("pinset"));
+        }
+        env::var_os("HOME")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+            .map(|path| path.join(".local").join("share").join("pinset"))
+            .ok_or(Error::PinsetHomeUnavailable)
+    }
+}
+
+pub fn pinset_home_from_env() -> Result<PathBuf> {
+    pinset_home()
 }
 
 pub fn resolve_from_env(command: &str, cwd: &Path) -> Result<CommandResolution> {
-    resolve_command(command, cwd, &pinset_home_from_env()?)
+    resolve_command(command, cwd, &pinset_home()?)
 }
 
 pub fn resolve_command(command: &str, cwd: &Path, pinset_home: &Path) -> Result<CommandResolution> {
@@ -47,12 +77,12 @@ pub fn resolve_command(command: &str, cwd: &Path, pinset_home: &Path) -> Result<
             config_path: config_path.clone(),
         })?;
 
-    let bin_dir = pinset_home
+    let install_dir = pinset_home
         .join("installs")
         .join(tool)
         .join(&version)
-        .join(current_target())
-        .join("bin");
+        .join(current_target());
+    let bin_dir = runtime_command_dir(&install_dir);
     let candidates = executable_candidates(&bin_dir, command);
     let executable = candidates
         .iter()
@@ -76,6 +106,14 @@ pub fn resolve_command(command: &str, cwd: &Path, pinset_home: &Path) -> Result<
         config_path,
         executable,
     })
+}
+
+fn runtime_command_dir(install_dir: &Path) -> PathBuf {
+    if cfg!(windows) {
+        install_dir.to_path_buf()
+    } else {
+        install_dir.join("bin")
+    }
 }
 
 fn executable_candidates(bin_dir: &Path, command: &str) -> Vec<PathBuf> {
@@ -115,12 +153,12 @@ mod tests {
         )
         .expect("project config");
 
-        let bin = home
+        let install_dir = home
             .join("installs")
             .join("node")
             .join("20.0.0")
-            .join(current_target())
-            .join("bin");
+            .join(current_target());
+        let bin = runtime_command_dir(&install_dir);
         fs::create_dir_all(&bin).expect("runtime bin");
         let executable = if cfg!(windows) {
             bin.join("node.exe")

--- a/crates/pinset-shim/tests/routing.rs
+++ b/crates/pinset-shim/tests/routing.rs
@@ -119,12 +119,16 @@ fn executes_through_an_installed_multicall_shim_name() {
 }
 
 fn create_fake_node(home: &Path, version: &str) -> PathBuf {
-    let bin = home
+    let install_dir = home
         .join("installs")
         .join("node")
         .join(version)
-        .join(current_target())
-        .join("bin");
+        .join(current_target());
+    let bin = if cfg!(windows) {
+        install_dir
+    } else {
+        install_dir.join("bin")
+    };
     fs::create_dir_all(&bin).expect("runtime bin");
 
     #[cfg(windows)]

--- a/crates/pinset/Cargo.toml
+++ b/crates/pinset/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap.workspace = true
-pinset-core = { path = "../pinset-core", features = ["node-provider", "project-write", "sources"] }
+pinset-core = { path = "../pinset-core", features = ["installer", "node-metadata", "project-write", "sources"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -1,18 +1,29 @@
 use std::{
     env,
+    ffi::OsString,
+    fs,
     path::{Path, PathBuf},
-    process::ExitCode,
+    process::{Command, ExitCode},
 };
+
+#[cfg(windows)]
+use std::ffi::OsStr;
 
 use clap::{Parser, Subcommand};
 use pinset_core::{
-    SUPPORTED_SOURCE_PROVIDERS, ShimInstallMethod, SourceView, create_project_config,
-    install_shims, load_source_config, pinset_home_from_env, resolve_command, save_source_config,
-    source_config_path,
+    Error, InstallLimits, Installer, NodeMetadataClient, SUPPORTED_SOURCE_PROVIDERS,
+    ShimInstallMethod, SourceView, create_project_config, current_target, find_project_config,
+    install_locked_node, install_shims, load_lockfile, load_project_config, load_source_config,
+    lockfile_path, node_command_directory, pinset_home, resolve_command, save_lockfile,
+    save_project_config, save_source_config, source_config_path, validate_lock_matches_project,
 };
 
 #[derive(Debug, Parser)]
-#[command(name = "pinset", version, about = "Pinset Phase 0 runtime shim spike")]
+#[command(
+    name = "pinset",
+    version,
+    about = "Predictable runtime version management for multilingual projects"
+)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -22,6 +33,22 @@ struct Cli {
 enum Commands {
     /// Create a minimal pinset.toml in the current directory.
     Init,
+    /// Select and lock an exact Node.js version for the current project.
+    Use {
+        /// Selection in the form node@x.y.z.
+        selection: String,
+        /// Update pinset.toml and pinset.lock without downloading the runtime.
+        #[arg(long)]
+        no_install: bool,
+    },
+    /// Install the current target from pinset.lock.
+    Install {
+        /// Require pinset.toml and pinset.lock to match. This is the MVP default.
+        #[arg(long)]
+        locked: bool,
+        #[arg(long)]
+        cwd: Option<PathBuf>,
+    },
     /// Print the exact runtime executable selected for a command.
     Which {
         command: String,
@@ -30,6 +57,18 @@ enum Commands {
     },
     /// Print the current project tool selections and their exact executable paths.
     Current {
+        #[arg(long)]
+        cwd: Option<PathBuf>,
+    },
+    /// Execute a command through the selected runtime without installing shims.
+    Exec {
+        #[arg(long)]
+        cwd: Option<PathBuf>,
+        #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
+        command: Vec<OsString>,
+    },
+    /// Report project, lockfile, installation and PATH state without modifying anything.
+    Doctor {
         #[arg(long)]
         cwd: Option<PathBuf>,
     },
@@ -87,7 +126,7 @@ enum SourceCommands {
 
 fn main() -> ExitCode {
     match run() {
-        Ok(()) => ExitCode::SUCCESS,
+        Ok(code) => code,
         Err(error) => {
             eprintln!("error: {error}");
             ExitCode::from(2)
@@ -95,7 +134,7 @@ fn main() -> ExitCode {
     }
 }
 
-fn run() -> Result<(), Box<dyn std::error::Error>> {
+fn run() -> Result<ExitCode, Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     match cli.command {
@@ -103,27 +142,51 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             let path = create_project_config(&env::current_dir()?)?;
             println!("created {}", path.display());
         }
+        Commands::Use {
+            selection,
+            no_install,
+        } => {
+            let version = parse_node_selection(&selection)?;
+            let cwd = env::current_dir()?;
+            let config_path = find_project_config(&cwd)?;
+            let mut project = load_project_config(&config_path)?;
+            let lockfile = NodeMetadataClient::official()?
+                .resolve_exact_lock(&version, &format!("pinset {}", env!("CARGO_PKG_VERSION")))?;
+            let lock_path = lockfile_path(&config_path);
+            save_lockfile(&lock_path, &lockfile)?;
+            project.set_tool("node", &version);
+            save_project_config(&config_path, &project)?;
+            println!(
+                "selected node@{version}; locked {} targets in {}",
+                lockfile
+                    .tool("node")
+                    .expect("generated lock contains node")
+                    .artifacts
+                    .len(),
+                lock_path.display()
+            );
+            if !no_install {
+                install_project(&cwd)?;
+            }
+        }
+        Commands::Install { locked: _, cwd } => {
+            install_project(&effective_cwd(cwd)?)?;
+        }
         Commands::Which { command, cwd } => {
             let cwd = effective_cwd(cwd)?;
-            let resolution = resolve_command(&command, &cwd, &pinset_home_from_env()?)?;
+            let resolution = resolve_command(&command, &cwd, &pinset_home()?)?;
             println!("{}", resolution.executable.display());
         }
         Commands::Current { cwd } => {
             let cwd = effective_cwd(cwd)?;
-            let home = pinset_home_from_env()?;
-            for command in ["node", "npm", "npx", "corepack"] {
-                match resolve_command(command, &cwd, &home) {
-                    Ok(resolution) => println!(
-                        "{} {} {} {}",
-                        resolution.tool,
-                        resolution.version,
-                        resolution.command,
-                        resolution.executable.display()
-                    ),
-                    Err(pinset_core::Error::RuntimeCommandNotFound { .. }) => {}
-                    Err(error) => return Err(error.into()),
-                }
-            }
+            print_current(&cwd)?;
+        }
+        Commands::Exec { cwd, command } => {
+            let cwd = effective_cwd(cwd)?;
+            return execute_selected(&cwd, &command);
+        }
+        Commands::Doctor { cwd } => {
+            run_doctor(&effective_cwd(cwd)?)?;
         }
         Commands::Shim {
             command:
@@ -149,11 +212,200 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         Commands::Source { command } => run_source_command(command)?,
     }
 
+    Ok(ExitCode::SUCCESS)
+}
+
+fn parse_node_selection(selection: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let Some((tool, version)) = selection.split_once('@') else {
+        return Err("selection must use node@x.y.z".into());
+    };
+    if tool != "node" || version.is_empty() || version.contains('@') {
+        return Err("the Node-first MVP only accepts node@x.y.z".into());
+    }
+    Ok(version.to_owned())
+}
+
+fn install_project(cwd: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let config_path = find_project_config(cwd)?;
+    let project = load_project_config(&config_path)?;
+    let configured = project
+        .tools
+        .get("node")
+        .ok_or_else(|| Error::ToolNotConfigured {
+            tool: "node".to_owned(),
+            config_path: config_path.clone(),
+        })?;
+    let lock_path = lockfile_path(&config_path);
+    let lockfile = load_lockfile(&lock_path)?;
+    let locked_node = validate_lock_matches_project(&lockfile, configured)?;
+    let home = pinset_home()?;
+    let sources = load_source_config(&source_config_path(&home))?;
+    let installer = Installer::new(InstallLimits::default())?;
+    let outcome = install_locked_node(&installer, &home, &sources, locked_node, &current_target())?;
+    if outcome.bytes_downloaded == 0 {
+        println!(
+            "already installed node@{} for {} at {}",
+            locked_node.version,
+            current_target(),
+            outcome.install_dir.display()
+        );
+    } else {
+        println!(
+            "installed node@{} for {} from {} at {}",
+            locked_node.version,
+            current_target(),
+            outcome.source_id,
+            outcome.install_dir.display()
+        );
+    }
     Ok(())
 }
 
+fn print_current(cwd: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let config_path = find_project_config(cwd)?;
+    let project = load_project_config(&config_path)?;
+    let version = project
+        .tools
+        .get("node")
+        .ok_or_else(|| Error::ToolNotConfigured {
+            tool: "node".to_owned(),
+            config_path: config_path.clone(),
+        })?;
+    match resolve_command("node", cwd, &pinset_home()?) {
+        Ok(resolution) => println!(
+            "node {} installed {} config={}",
+            version,
+            resolution.executable.display(),
+            config_path.display()
+        ),
+        Err(Error::RuntimeCommandNotFound { .. }) => {
+            let install_dir = pinset_home()?
+                .join("installs")
+                .join("node")
+                .join(version)
+                .join(current_target());
+            println!(
+                "node {} missing expected={} config={}",
+                version,
+                node_command_directory(&install_dir, &current_target())?.display(),
+                config_path.display()
+            );
+        }
+        Err(error) => return Err(error.into()),
+    }
+    Ok(())
+}
+
+fn execute_selected(
+    cwd: &Path,
+    command: &[OsString],
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let command_name = command
+        .first()
+        .and_then(|value| value.to_str())
+        .ok_or("command name must be valid UTF-8")?;
+    let resolution = resolve_command(command_name, cwd, &pinset_home()?)?;
+    let mut child = command_for_runtime(&resolution.executable);
+    child
+        .args(&command[1..])
+        .current_dir(cwd)
+        .env("PINSET_SELECTED_TOOL", &resolution.tool)
+        .env("PINSET_SELECTED_VERSION", &resolution.version)
+        .env("PINSET_CONFIG_PATH", &resolution.config_path);
+    let status = child.status()?;
+    Ok(ExitCode::from(
+        status
+            .code()
+            .and_then(|code| u8::try_from(code).ok())
+            .unwrap_or(1),
+    ))
+}
+
+fn command_for_runtime(executable: &Path) -> Command {
+    #[cfg(windows)]
+    {
+        let extension = executable
+            .extension()
+            .and_then(OsStr::to_str)
+            .unwrap_or_default();
+        if extension.eq_ignore_ascii_case("cmd") || extension.eq_ignore_ascii_case("bat") {
+            let mut command = Command::new("cmd.exe");
+            command.arg("/D").arg("/C").arg(executable);
+            return command;
+        }
+    }
+    Command::new(executable)
+}
+
+fn run_doctor(cwd: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let home = pinset_home()?;
+    println!("pinset_home {} ok", home.display());
+    let config_path = find_project_config(cwd)?;
+    println!("project_config {} ok", config_path.display());
+    let project = load_project_config(&config_path)?;
+    let version = project
+        .tools
+        .get("node")
+        .ok_or_else(|| Error::ToolNotConfigured {
+            tool: "node".to_owned(),
+            config_path: config_path.clone(),
+        })?;
+    let lock_path = lockfile_path(&config_path);
+    let lockfile = load_lockfile(&lock_path)?;
+    validate_lock_matches_project(&lockfile, version)?;
+    println!("lockfile {} matches node@{}", lock_path.display(), version);
+
+    match resolve_command("node", cwd, &home) {
+        Ok(resolution) => println!("runtime {} ok", resolution.executable.display()),
+        Err(Error::RuntimeCommandNotFound { .. }) => println!("runtime node@{version} missing"),
+        Err(error) => return Err(error.into()),
+    }
+
+    let shims = home.join("shims");
+    let shim_on_path = env::var_os("PATH")
+        .map(|value| env::split_paths(&value).any(|entry| paths_equal(&entry, &shims)))
+        .unwrap_or(false);
+    println!(
+        "shim_path {} {}",
+        shims.display(),
+        if shim_on_path {
+            "active"
+        } else {
+            "not-on-path"
+        }
+    );
+    for candidate in path_command_candidates("node") {
+        println!("path_node {}", candidate.display());
+    }
+    Ok(())
+}
+
+fn path_command_candidates(command: &str) -> Vec<PathBuf> {
+    let Some(path) = env::var_os("PATH") else {
+        return Vec::new();
+    };
+    let names: &[&str] = if cfg!(windows) {
+        &["node.exe", "node.cmd", "node.bat", "node"]
+    } else {
+        &[command]
+    };
+    env::split_paths(&path)
+        .flat_map(|directory| names.iter().map(move |name| directory.join(name)))
+        .filter(|candidate| fs::metadata(candidate).is_ok_and(|metadata| metadata.is_file()))
+        .collect()
+}
+
+fn paths_equal(left: &Path, right: &Path) -> bool {
+    if cfg!(windows) {
+        left.to_string_lossy()
+            .eq_ignore_ascii_case(&right.to_string_lossy())
+    } else {
+        left == right
+    }
+}
+
 fn run_source_command(command: SourceCommands) -> Result<(), Box<dyn std::error::Error>> {
-    let path = source_config_path(&pinset_home_from_env()?);
+    let path = source_config_path(&pinset_home()?);
     let mut config = load_source_config(&path)?;
     match command {
         SourceCommands::List { provider } => {

--- a/crates/pinset/tests/mvp_cli.rs
+++ b/crates/pinset/tests/mvp_cli.rs
@@ -1,0 +1,153 @@
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+use pinset_core::{
+    LockedArtifact, LockedArtifactFormat, Lockfile, MVP_NODE_TARGETS, NodeArchiveFormat,
+    ProjectConfig, SourceConfig, current_target, plan_node_artifact, save_lockfile,
+    save_project_config,
+};
+use tempfile::tempdir;
+
+#[test]
+fn current_which_exec_and_doctor_share_the_locked_fake_runtime() {
+    let root = tempdir().expect("temporary root");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    fs::create_dir(&project).expect("project");
+    write_project(&project, "24.0.0", "24.0.0");
+    let executable = create_fake_node(&home, "24.0.0");
+
+    let current = pinset(&project, &home, &["current"]);
+    assert_success_contains(&current, "node 24.0.0 installed");
+
+    let which = pinset(&project, &home, &["which", "node"]);
+    assert_success_contains(&which, &executable.display().to_string());
+
+    let exec = pinset(&project, &home, &["exec", "--", "node", "hello", "mvp"]);
+    assert_success_contains(&exec, "24.0.0:hello mvp");
+
+    let doctor = pinset(&project, &home, &["doctor"]);
+    assert_success_contains(&doctor, "lockfile");
+    assert_success_contains(&doctor, "matches node@24.0.0");
+    assert_success_contains(&doctor, "runtime");
+}
+
+#[test]
+fn locked_install_rejects_config_mismatch_before_network_or_installation() {
+    let root = tempdir().expect("temporary root");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    fs::create_dir(&project).expect("project");
+    write_project(&project, "23.0.0", "24.0.0");
+
+    let output = pinset(&project, &home, &["install", "--locked"]);
+
+    assert!(!output.status.success(), "mismatched lock must fail");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("pinset.toml selects node@23.0.0"),
+        "unexpected stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!home.exists());
+}
+
+fn write_project(project: &Path, configured_version: &str, locked_version: &str) {
+    let config_path = project.join("pinset.toml");
+    let config = ProjectConfig {
+        schema: 1,
+        tools: BTreeMap::from([("node".to_owned(), configured_version.to_owned())]),
+    };
+    save_project_config(&config_path, &config).expect("project config");
+
+    let artifacts = MVP_NODE_TARGETS
+        .into_iter()
+        .map(|target| locked_artifact(locked_version, target))
+        .collect();
+    let lockfile = Lockfile::new_node(
+        "pinset integration test".to_owned(),
+        locked_version.to_owned(),
+        artifacts,
+    );
+    save_lockfile(&project.join("pinset.lock"), &lockfile).expect("lockfile");
+}
+
+fn locked_artifact(version: &str, target: &str) -> LockedArtifact {
+    let plan = plan_node_artifact(&SourceConfig::default(), version, target).expect("plan");
+    LockedArtifact {
+        target: target.to_owned(),
+        canonical_url: plan.canonical_url,
+        artifact_path: plan.artifact_path,
+        sha256: "ab".repeat(32),
+        format: match plan.format {
+            NodeArchiveFormat::Zip => LockedArtifactFormat::Zip,
+            NodeArchiveFormat::TarXz => LockedArtifactFormat::TarXz,
+        },
+        archive_root: plan.archive_root,
+        verification: "nodejs-shasums-https".to_owned(),
+    }
+}
+
+fn create_fake_node(home: &Path, version: &str) -> PathBuf {
+    let install_dir = home
+        .join("installs")
+        .join("node")
+        .join(version)
+        .join(current_target());
+    let command_dir = if cfg!(windows) {
+        install_dir
+    } else {
+        install_dir.join("bin")
+    };
+    fs::create_dir_all(&command_dir).expect("command directory");
+
+    #[cfg(windows)]
+    {
+        let executable = command_dir.join("node.cmd");
+        fs::write(
+            &executable,
+            "@echo off\r\necho %PINSET_SELECTED_VERSION%:%*\r\n",
+        )
+        .expect("fake node");
+        executable
+    }
+
+    #[cfg(not(windows))]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let executable = command_dir.join("node");
+        fs::write(
+            &executable,
+            "#!/bin/sh\nprintf '%s:%s\\n' \"$PINSET_SELECTED_VERSION\" \"$*\"\n",
+        )
+        .expect("fake node");
+        let mut permissions = fs::metadata(&executable)
+            .expect("fake node metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&executable, permissions).expect("fake node permissions");
+        executable
+    }
+}
+
+fn pinset(project: &Path, home: &Path, arguments: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_pinset"))
+        .args(arguments)
+        .current_dir(project)
+        .env("PINSET_HOME", home)
+        .output()
+        .expect("run pinset")
+}
+
+fn assert_success_contains(output: &Output, expected: &str) {
+    assert!(
+        output.status.success() && String::from_utf8_lossy(&output.stdout).contains(expected),
+        "expected success containing {expected:?}\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -126,13 +126,13 @@ trait Provider {
 
 - 版本索引：Node.js 官方 `dist/index.json`；
 - 产物：官方归档；
-- 信任链：授权发布密钥 → 签名 SHASUMS → 归档哈希；
+- MVP 信任链：官方 HTTPS `SHASUMS256.txt` → 归档 SHA-256；稳定版目标为授权发布密钥 → 签名 SHASUMS → 归档哈希；
 - 布局映射：`node`、`npm`、`npx`、`corepack`。
 
-当前 provider 原型已经实现无网络的产物计划：
+当前 Node-first MVP 已实现：
 
 - 只接受不带前导 `v` 的精确稳定版本 `x.y.z`；
-- 支持 `windows/linux/macos` 的 `x86_64/aarch64` target 映射；
+- 锁定 `windows-x86_64`、`linux-x86_64`、`macos-x86_64` 和 `macos-aarch64` 四个目标；
 - Windows 生成官方 `.zip` 路径，Linux/macOS 生成官方 `.tar.xz` 路径；
 - canonical URL 始终来自内置 official 源；
 - 实际下载候选按本机 active → ordered fallback 构造；
@@ -140,7 +140,7 @@ trait Provider {
 - artifact path 必须是 ASCII 安全相对 URL 路径，拒绝前导 `/`、`..`、反斜杠、百分号编码、scheme、query 和 fragment；
 - 归档内部布局使用 `/` 分隔的 target 路径字符串，不使用宿主机 `PathBuf` 语义规划其他平台产物。
 
-该原型目前只生成计划，不访问网络。事务安装器仍仅支持 ZIP，因此 Linux/macOS 的 `tar.xz` 不能宣称已经可安装。
+元数据客户端只接受精确稳定版本，在联网前验证输入，从 Node 官方 HTTPS 发布目录解析 `SHASUMS256.txt`，并要求四个平台产物的哈希全部存在。事务安装器支持安全 ZIP 与 TAR.XZ 解压、归档根目录剥离、路径穿越和特殊条目拒绝、展开上限、SHA-256 强制校验及原子提交。PGP 签名验证尚未实现，因此文档不会把 HTTPS 清单描述为已签名验证。
 
 ### Python provider
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -31,6 +31,9 @@
 | D-025 | Provisional | Node provider 首先只解析精确稳定版本 `x.y.z` | 浮动选择器必须等待可信版本索引与 lock 流程；预发布版本语义后续单独设计 |
 | D-026 | Accepted | canonical URL 与有序下载候选分别构造 | active/fallback 只能改变传输位置，不能改变官方产物路径和身份 |
 | D-027 | Accepted | 分发首选 GitHub Releases，不维护第三方 Homebrew Tap 或 Scoop Bucket | 避免长期维护额外仓库；中央包管理器渠道只在满足官方接收政策后评估 |
+| D-028 | Accepted | 先发布 Node-only `0.1.0-alpha.1` MVP，再扩展 Python 与 Flutter | 先证明锁定、镜像、校验、事务安装和项目执行的完整闭环，避免三个 provider 同时扩张 |
+| D-029 | Accepted | Node MVP 只接受精确稳定版本并锁定四个平台产物 | 避免浮动版本在不同时间解析出不同结果，同时允许同一锁文件跨团队平台复用 |
+| D-030 | Provisional | Node MVP 以官方 HTTPS `SHASUMS256.txt` 的 SHA-256 为信任值 | 已阻止镜像改变哈希；PGP 签名验证仍是进入稳定版前的供应链增强项 |
 
 ## 尚待决策
 

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -1,7 +1,13 @@
-# Pinset v0.1 产品规格
+# Pinset 产品规格
 
-状态：方案候选，关键技术验证后冻结  
+状态：Node-first MVP 已实现；多语言 v0.1 仍在验证
 更新日期：2026-07-28
+
+## 0. MVP 冻结范围
+
+`0.1.0-alpha.1` 先交付一个可独立使用的 Node.js 闭环：只接受精确版本，生成四平台锁文件，使用官方 HTTPS `SHASUMS256.txt` 建立 SHA-256 信任值，支持官方源/自定义镜像传输、安全 ZIP/TAR.XZ 解压、事务安装、项目解析、临时执行、shim 和只读诊断。
+
+Python、Flutter、浮动选择器、PGP 验签和自动 PATH 修改不在这个 MVP 内。下文未特别标注的多语言能力仍是后续 v0.1 目标，不应当作当前实现声明。
 
 ## 1. 支持矩阵
 
@@ -60,7 +66,7 @@ target = "windows-x86_64"
 canonical_url = "https://nodejs.org/dist/..."
 artifact_path = "v24.x.y/node-v24.x.y-win-x64.zip"
 sha256 = "..."
-verification = "signed-shasums"
+verification = "nodejs-shasums-https"
 ```
 
 最终 schema 必须满足：
@@ -152,7 +158,7 @@ base_url = "https://npmmirror.com/mirrors/node/"
 
 ### `pinset source`
 
-当前 spike 已实现：
+当前 MVP 已实现：
 
 ```shell
 pinset source list [provider]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,9 +2,22 @@
 
 路线图以风险消除为顺序，不以功能数量为顺序。任何阶段通过前，不承诺具体发布日期。
 
+## Node-first MVP：`0.1.0-alpha.1`
+
+当前状态：实现完成，等待 GitHub 三平台 CI 验证。
+
+已交付精确 Node 版本锁定、四目标产物清单、官方 HTTPS 哈希获取、镜像传输、安全 ZIP/TAR.XZ 解压、事务安装、重复安装复用、`current/which/exec/doctor`、多调用 shim 和使用文档。自动化测试不安装真实运行时。
+
+MVP 发布门槛：
+
+- Ubuntu 上格式、Clippy 和全 workspace 测试通过；
+- Windows x64、Linux x64、macOS arm64 Release 构建通过；
+- shim 依赖图不包含 HTTP、TLS、归档和临时文件依赖；
+- 在隔离的 WSL 环境完成一次真实 Node 安装观察性测试。
+
 ## Phase 0：立项与关键技术验证
 
-当前状态：进行中。Spike A 已完成 Windows x64 功能原型，但性能门槛暂未通过；macOS/Linux 尚未运行。详见 [Spike A 记录](spikes/SPIKE_A_SHIM.md)。
+当前状态：Node 路径已进入 MVP 验证；Python、Flutter 与 shim 性能认证仍在进行。详见 [Spike A 记录](spikes/SPIKE_A_SHIM.md)。
 
 ### Spike A：跨平台 shim
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,246 @@
+# Pinset Node-first MVP 使用指南
+
+适用版本：`0.1.0-alpha.1`
+
+## 1. 当前能做什么
+
+MVP 只管理 Node.js 精确版本，版本必须写成完整的 `x.y.z`，例如 `24.0.0`。它支持：
+
+| 系统 | 目标标识 | Node 归档 |
+| --- | --- | --- |
+| Windows x64 | `windows-x86_64` | ZIP |
+| Linux x64 (glibc) | `linux-x86_64` | TAR.XZ |
+| macOS Intel | `macos-x86_64` | TAR.XZ |
+| macOS Apple Silicon | `macos-aarch64` | TAR.XZ |
+
+WSL 是独立的 Linux 环境，不与 Windows 原生安装目录或 PATH 混用。
+
+## 2. 安装 Pinset
+
+在 GitHub Releases 下载当前平台的归档和 `SHA256SUMS`：
+
+- Windows x64：`pinset-windows-x86_64.zip`
+- Linux x64：`pinset-linux-x86_64.tar.gz`
+- macOS Apple Silicon：`pinset-macos-aarch64.tar.gz`
+
+归档包含两个程序：
+
+- `pinset`：配置、锁定、下载、安装和诊断；
+- `pinset-shim`：多调用入口，由 `node`、`npm`、`npx`、`corepack` 等文件名调用。
+
+Linux/macOS 校验示例：
+
+```bash
+sha256sum -c SHA256SUMS --ignore-missing
+```
+
+Windows PowerShell 校验示例：
+
+```powershell
+Get-FileHash .\pinset-windows-x86_64.zip -Algorithm SHA256
+Get-Content .\SHA256SUMS
+```
+
+比较归档的哈希后，把 `pinset` 放到已在 PATH 中的个人目录。Pinset 不要求管理员权限，也不会自动改写 shell profile。
+
+默认数据目录：
+
+| 系统 | 默认目录 |
+| --- | --- |
+| Windows | `%LOCALAPPDATA%\Pinset` |
+| Linux/macOS | `$XDG_DATA_HOME/pinset`，未设置时为 `$HOME/.local/share/pinset` |
+
+可以用 `PINSET_HOME` 覆盖它。Windows 与 WSL 应各自使用本地文件系统中的独立目录。
+
+## 3. 项目内选择并安装 Node
+
+在项目根目录执行：
+
+```shell
+pinset init
+pinset use node@24.0.0
+```
+
+结果：
+
+1. `pinset init` 原子创建最小 `pinset.toml`，已有文件时拒绝覆盖；
+2. `pinset use` 从 Node 官方 HTTPS 发布目录读取 `SHASUMS256.txt`；
+3. 为四个 MVP 平台生成确定性的 `pinset.lock`；
+4. 将精确版本写入 `pinset.toml`；
+5. 下载当前平台的归档、核对锁定哈希、安全解压并提交安装。
+
+建议把这两个文件提交到版本库：
+
+```text
+pinset.toml
+pinset.lock
+```
+
+只锁定、不安装：
+
+```shell
+pinset use node@24.0.0 --no-install
+```
+
+根据已有锁文件安装：
+
+```shell
+pinset install --locked
+```
+
+MVP 中 `install` 始终执行锁定安装；`--locked` 用于明确表达 CI 意图。只要 `pinset.toml` 与 `pinset.lock` 不一致，安装会在联网和写入安装目录前失败。
+
+## 4. 使用运行时
+
+不安装 shim 也可以完整使用：
+
+```shell
+pinset current
+pinset which node
+pinset exec -- node --version
+pinset exec -- npm --version
+pinset exec -- node ./scripts/build.mjs
+```
+
+命令从当前目录向上查找最近的 `pinset.toml`。`exec` 会把子进程退出码传回调用者，适合脚本与 CI。
+
+在其他目录检查项目：
+
+```shell
+pinset current --cwd /path/to/project
+pinset doctor --cwd /path/to/project
+```
+
+## 5. 安装 shim
+
+shim 让现有的 `node`、`npm`、`npx`、`corepack` 命令自动使用最近项目配置。它只创建在用户指定目录中，不自动修改 PATH，也不覆盖已有同名文件。
+
+### Windows PowerShell
+
+假设两个 exe 位于当前目录：
+
+```powershell
+$shimDir = Join-Path $env:LOCALAPPDATA "Pinset\shims"
+pinset shim install --binary .\pinset-shim.exe --dir $shimDir
+```
+
+然后把 `%LOCALAPPDATA%\Pinset\shims` 加到用户 PATH，并新开终端。临时验证可以执行：
+
+```powershell
+$env:PATH = "$shimDir;$env:PATH"
+node --version
+pinset doctor
+```
+
+### Linux/macOS
+
+```bash
+PINSET_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/pinset"
+pinset shim install --binary ./pinset-shim --dir "$PINSET_DATA_HOME/shims"
+export PATH="$PINSET_DATA_HOME/shims:$PATH"
+node --version
+pinset doctor
+```
+
+确认无冲突后，再把 `export PATH=...` 写入你使用的 shell profile。`doctor` 会显示 shim 目录是否在 PATH 中，并列出 PATH 上可见的 Node 候选。
+
+## 6. 切换国内或企业镜像
+
+自定义源必须保持 Node 官方发布目录的相对路径布局，例如 Pinset 会把：
+
+```text
+v24.0.0/node-v24.0.0-linux-x64.tar.xz
+```
+
+追加到你配置的 `base-url`。配置示例：
+
+```shell
+pinset source add node cn-mirror --base-url https://mirror.example/node/
+pinset source use node cn-mirror
+pinset source fallback node official
+pinset source list node
+```
+
+截至 2026-07-28，npmmirror 的 Node 目录仍兼容该相对路径结构；如果你接受这个第三方传输来源，可以配置：
+
+```shell
+pinset source add node npmmirror --base-url https://npmmirror.com/mirrors/node/
+pinset source use node npmmirror
+pinset source fallback node official
+```
+
+Pinset 不内置或默认启用社区镜像。第三方服务的可用性和运营方可能变化，团队应自行评估并可改用企业代理。
+
+恢复官方源：
+
+```shell
+pinset source use node official
+pinset source fallback node
+```
+
+删除不再使用的自定义源：
+
+```shell
+pinset source remove node cn-mirror
+```
+
+活动源或回退列表正在引用的源不能删除。默认只接受 HTTPS；受信任局域网确实只有 HTTP 时必须显式添加 `--allow-insecure`。
+
+安全边界：
+
+- 精确版本、规范产物路径和 SHA-256 都来自项目锁文件；
+- 锁文件中的 SHA-256 由 Node 官方 HTTPS `SHASUMS256.txt` 解析得到；
+- 镜像只提供相同字节的下载传输，不能改变预期哈希；
+- 连接、超时等网络错误可以回退；
+- 哈希错误是硬失败，不会自动换源；
+- MVP 尚未校验 `SHASUMS256.txt` 的 PGP 签名，这是后续供应链增强项。
+
+首次执行 `pinset use` 仍需要从 `nodejs.org` 的 HTTPS 发布目录取得体积很小的 `SHASUMS256.txt`；镜像配置目前只替换运行时归档的下载位置。如果官方站在某个网络中完全不可达，可以在可访问网络中生成并提交 `pinset.lock`，然后在受限网络中配置镜像并执行 `pinset install --locked`。这个安装过程直接使用锁文件中的哈希，不再请求官方清单。
+
+## 7. CI 使用
+
+把 `pinset.toml` 和 `pinset.lock` 提交后，CI 可执行：
+
+```shell
+pinset install --locked
+pinset exec -- node --version
+pinset exec -- npm ci
+pinset exec -- npm test
+```
+
+首次需要网络，重复安装同一版本和目标时会验证安装收据和关键路径，并直接复用。
+
+## 8. 诊断
+
+```shell
+pinset doctor
+```
+
+它只读检查：
+
+- Pinset 数据目录；
+- 最近项目配置；
+- 锁文件是否与项目版本一致；
+- 当前目标的 Node 是否已安装；
+- shim 目录是否在 PATH；
+- PATH 上其他 Node 候选。
+
+常见问题：
+
+- `pinset.toml was not found`：在项目目录运行，或先执行 `pinset init`。
+- `lockfile does not match`：重新执行 `pinset use node@完整版本 --no-install` 并审查锁文件。
+- `runtime ... missing`：执行 `pinset install --locked`。
+- shim 安装提示目标已存在：Pinset 为避免覆盖其他管理器或用户文件而停止；先用 `pinset doctor` 和系统命令确认冲突来源。
+- 镜像 404：镜像 URL 不是 Node 发布目录根路径，或尚未同步该版本。
+- 哈希不匹配：停止使用该镜像并调查，不要通过关闭校验绕过。Pinset 没有关闭校验的选项。
+
+## 9. MVP 明确不包含
+
+- Python、Flutter 安装；
+- `node@24`、`lts`、`latest` 等浮动选择器；
+- Node 发布清单 PGP 验签；
+- 自动编辑 PATH 或 shell profile；
+- 自动导入 nvm/fnm/uv/FVM 配置；
+- 缓存清理、离线包导入、卸载；
+- Homebrew Tap、Scoop Bucket 或其他第三方包仓库维护；
+- 任意脚本插件、安装后脚本、远程代码执行配置。

--- a/docs/WSL_TESTING.md
+++ b/docs/WSL_TESTING.md
@@ -1,121 +1,82 @@
-# 在 WSL 中构建和安全测试 Pinset
+# 在 WSL 中构建和测试 Pinset
 
-本文只构建 Pinset 自身并测试配置、路由和 Node 产物计划，不下载或安装真实 Node、Python、Flutter，也不修改 Windows PATH、Shell 或现有版本管理器。
+WSL 按独立 Linux 环境处理。Windows 编译出的 PE 可执行文件不能作为 Linux 原生 Pinset 使用；请直接下载 GitHub Release 的 Linux x64 归档，或在 WSL 中构建 ELF。
 
-当前已确认的本机 WSL 环境是 Ubuntu、WSL2、x86_64。WSL 中尚未安装 Rust 和 GCC，以下安装步骤需要由用户自行执行。
+## 直接测试 GitHub Release
 
-## 1. 准备 WSL 构建环境
+下载并解压 `pinset-linux-x86_64.tar.gz`：
 
-在 Ubuntu WSL 中执行：
+```bash
+tar -xzf pinset-linux-x86_64.tar.gz
+chmod +x pinset pinset-shim
+./pinset --version
+file pinset pinset-shim
+```
+
+先做不安装真实 Node 的安全检查：
+
+```bash
+TEST_HOME="$(mktemp -d)"
+export PINSET_HOME="$TEST_HOME"
+
+./pinset source list node
+./pinset init
+./pinset doctor
+```
+
+`doctor` 在尚未选择版本时报告项目未配置 Node 是预期行为。测试后可退出当前 shell；临时目录不会影响 Windows 或默认 WSL 数据目录。
+
+真实 Node 安装测试请在你准备好的 WSL 测试目录内自行执行：
+
+```bash
+mkdir -p "$HOME/pinset-mvp-test"
+cd "$HOME/pinset-mvp-test"
+/path/to/pinset init
+/path/to/pinset use node@24.0.0
+/path/to/pinset exec -- node --version
+```
+
+## 在 WSL 中从源码构建
+
+Ubuntu 安装构建依赖：
 
 ```bash
 sudo apt update
-sudo apt install -y build-essential curl ca-certificates git rsync
-
+sudo apt install -y build-essential curl ca-certificates git pkg-config liblzma-dev
 curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
 source "$HOME/.cargo/env"
-
-rustc --version
-cargo --version
-gcc --version
-```
-
-项目声明的最低 Rust 版本是 1.85。使用当前 stable Rust 即可；若 `rustc --version` 低于 1.85，执行：
-
-```bash
 rustup update stable
-rustup default stable
 ```
 
-## 2. 把源码同步到 WSL 文件系统
-
-可以直接在 `/mnt/c` 构建，但 Cargo 会产生大量小文件，速度和 Linux 权限语义都不理想。建议从 Windows 工作区同步到 WSL 的 ext4 文件系统：
+Pinset 的最低 Rust 版本是 1.85。建议把源码放到 WSL 的 ext4 文件系统，而不是直接在 `/mnt/c` 编译：
 
 ```bash
-mkdir -p "$HOME/src/Pinset"
-rsync -a \
-  --exclude '.git/' \
-  --exclude 'target/' \
-  /mnt/c/Users/zhoub/Code/Future-Element/Pinset/ \
-  "$HOME/src/Pinset/"
-
+git clone git@github.com:Future-Element/pinset.git "$HOME/src/Pinset"
 cd "$HOME/src/Pinset"
-```
-
-这条命令不会删除 WSL 目标目录中的额外文件。后续代码变化时可以再次执行相同的 `rsync`。
-
-## 3. 构建 Linux x86_64 二进制
-
-在 WSL 源码目录执行：
-
-```bash
 cargo build --release --locked -p pinset-cli -p pinset-shim
 ```
 
-生成文件：
+产物：
 
 ```text
 target/release/pinset
 target/release/pinset-shim
 ```
 
-确认它们是 Linux ELF，而不是 Windows PE：
+验证它们是 Linux ELF：
 
 ```bash
 file target/release/pinset target/release/pinset-shim
 ldd target/release/pinset
-./target/release/pinset --version
+target/release/pinset --version
 ```
 
-WSL x86_64 原生构建对应 Rust target `x86_64-unknown-linux-gnu`。不建议在 Windows MSVC 工具链中直接加 `--target x86_64-unknown-linux-gnu`：仅安装 Rust target 不会自动提供 Linux glibc linker。
-
-## 4. 不安装运行时的安全测试
-
-下面的测试不启用 `installer` feature：
+运行项目测试不会安装真实运行时：
 
 ```bash
-cargo test -p pinset-core --features node-provider,sources
-cargo test -p pinset-cli
-cargo test -p pinset-shim
-cargo clippy -p pinset-core --all-targets \
-  --features node-provider,sources -- -D warnings
-cargo clippy -p pinset-cli -p pinset-shim \
-  --all-targets -- -D warnings
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-features
 ```
 
-手动测试 source CLI 时，为 Pinset 指定一次性目录：
-
-```bash
-PINSET_TEST_HOME="$(mktemp -d)"
-export PINSET_HOME="$PINSET_TEST_HOME"
-
-./target/release/pinset source list node
-./target/release/pinset source add node example \
-  --base-url https://mirror.example/node/
-./target/release/pinset source use node example
-./target/release/pinset source fallback node official
-./target/release/pinset source list node
-
-test ! -e "$PINSET_TEST_HOME/installs"
-test ! -e "$PINSET_TEST_HOME/shims"
-printf 'temporary PINSET_HOME=%s\n' "$PINSET_TEST_HOME"
-```
-
-`mirror.example` 是保留的示例域名；上述命令只保存 URL，不会连接它。确认结果后可以手动删除打印出的临时目录。
-
-## 5. 当前 Linux 能测试和不能测试的边界
-
-可以测试：
-
-- Linux 原生编译和启动；
-- `source list/add/use/fallback/remove`；
-- Node Windows/Linux/macOS 产物路径与源候选的单元测试；
-- fake runtime 的 shim 路由、递归保护和退出码传递。
-
-暂时不能测试：
-
-- 真实 Node 下载与安装 CLI；
-- Linux `tar.xz` 解压和权限恢复；
-- Node 签名 `SHASUMS256.txt` 验证；
-- Shell profile/PATH 自动接管；
-- Python 和 Flutter 真实安装。
+这些测试只使用临时目录、本地假 HTTP 服务、构造归档和假运行时。完整命令见 [MVP 使用指南](USAGE.md)。


### PR DESCRIPTION
## Summary
- deliver the Node-first `0.1.0-alpha.1` MVP command loop
- add deterministic cross-platform locks, official Node checksum metadata, mirror transport, and safe ZIP/TAR.XZ transactional installs
- add fake-runtime/security coverage, lightweight-shim CI guard, and complete Chinese usage/WSL documentation

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked` (55 tests)
- `cargo build --release --locked -p pinset-cli -p pinset-shim`
- `cargo tree -p pinset-shim -e normal`

No real Node, Python, or Flutter runtime was installed during local verification. Real Node installation remains an isolated WSL observation step. PGP verification of Node's checksum manifest is explicitly deferred beyond this alpha MVP.