### PR TITLE
feat: open-source release pipeline and curl installer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.sh text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+    types:
+      - ready_for_review
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
     types:
+      - opened
+      - reopened
+      - synchronize
       - ready_for_review
   workflow_dispatch:
 
@@ -18,6 +21,7 @@ concurrency:
 
 jobs:
   quality:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Quality
     runs-on: ubuntu-24.04
     timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --all-features
 
+      - name: Test curl installer without network or runtime installation
+        run: sh scripts/tests/install_sh_test.sh
+
       - name: Keep the shim dependency graph lightweight
         shell: bash
         run: |
@@ -52,7 +55,7 @@ jobs:
 
   build:
     name: Build ${{ matrix.artifact }}
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'workflow_dispatch'
     needs: quality
     strategy:
       fail-fast: false
@@ -82,6 +85,11 @@ jobs:
 
       - name: Build release binaries
         run: cargo build --release --locked -p pinset-cli -p pinset-shim
+
+      - name: Test Unix curl installer
+        if: runner.os != 'Windows'
+        shell: bash
+        run: sh scripts/tests/install_sh_test.sh
 
       - name: Package Unix binaries
         if: runner.os != 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Run Rust tests
         run: cargo test --workspace --all-features
 
+      - name: Test curl installer without network or runtime installation
+        run: sh scripts/tests/install_sh_test.sh
+
       - name: Keep the shim dependency graph lightweight
         shell: bash
         run: |
@@ -88,6 +91,11 @@ jobs:
 
       - name: Build release binaries
         run: cargo build --release --locked -p pinset-cli -p pinset-shim
+
+      - name: Test Unix curl installer
+        if: runner.os != 'Windows'
+        shell: bash
+        run: sh scripts/tests/install_sh_test.sh
 
       - name: Package Unix binaries
         if: runner.os != 'Windows'
@@ -139,9 +147,12 @@ jobs:
       - name: Generate checksums
         shell: bash
         run: |
+          cp install.sh dist/install.sh
+          chmod 755 dist/install.sh
           (
             cd dist
             sha256sum \
+              install.sh \
               pinset-linux-x86_64.tar.gz \
               pinset-macos-aarch64.tar.gz \
               pinset-windows-x86_64.zip \
@@ -154,6 +165,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           assets=(
+            dist/install.sh
             dist/pinset-linux-x86_64.tar.gz
             dist/pinset-macos-aarch64.tar.gz
             dist/pinset-windows-x86_64.zip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to Pinset
+
+感谢你帮助改进 Pinset。项目当前处于 Node-first alpha 阶段，优先保证跨平台行为、安全边界和可复现安装，而不是快速扩大 provider 数量。
+
+## 开发环境
+
+- Rust 1.85 或更高版本；
+- Windows x64、Linux x64 或 macOS arm64；
+- Linux 构建 TAR.XZ 支持时需要常规 C toolchain、CMake 与 liblzma 开发包。
+
+```shell
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+cargo test --workspace --all-features --locked
+```
+
+Unix curl 安装器使用完全离线的假 Release 测试：
+
+```sh
+sh scripts/tests/install_sh_test.sh
+```
+
+这些测试不会安装真实 Node、Python 或 Flutter。真实运行时烟雾测试应在明确隔离的临时环境中进行，并在 PR 中说明平台与结果。
+
+## Pull Request
+
+- 从最新 `main` 创建短生命周期分支；
+- 不混入无关格式化或本地环境文件；
+- 对安全边界和跨平台差异补回归测试；
+- 明确写出已验证与未验证的平台；
+- 不提交下载缓存、运行时归档、密钥或凭据。
+
+涉及配置执行、远程脚本、遥测、权限提升、来源信任或自动修改 shell profile 的变更，需要单独的安全评审。

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Future Element
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ cargo build --release --locked -p pinset-cli -p pinset-shim
 
 测试使用临时目录、本地假 HTTP 服务和假运行时，不会安装真实 Node、Python 或 Flutter。
 
+开发分支应优先在本机或 WSL 使用增量编译和测试。Pull Request 只有从草稿转为 Ready 时自动运行一次 Quality；后续按需手动触发，避免每次 push 消耗 GitHub Actions。推送到 `main` 和版本标签仍执行发布所需的完整检查与构建。
+
 ## 文档
 
 - [MVP 使用指南](docs/USAGE.md)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,19 @@ Python、Flutter、浮动版本选择器、PGP 验签、缓存管理和中央包
 
 ## 五分钟开始
 
-从 [GitHub Releases](https://github.com/Future-Element/pinset/releases) 下载当前系统的归档，校验 `SHA256SUMS` 后解压。将 `pinset` 放入 `PATH`，再进入一个项目：
+当前预发布版在 Linux x64 和 macOS Apple Silicon 上可以执行：
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/Future-Element/pinset/releases/download/v0.1.0-alpha.1/install.sh |
+  sh -s -- --version 0.1.0-alpha.1
+```
+
+安装器识别平台，从同一个 GitHub Release 下载归档和 `SHA256SUMS`，强制核对 SHA-256，然后把 `pinset` 与 `pinset-shim` 原子安装到 `$HOME/.local/bin`。它不使用 `sudo`、不改 shell profile，也不安装 Node。
+
+稳定版本发布后可以把固定版本 URL 换成 `https://github.com/Future-Element/pinset/releases/latest/download/install.sh`。也可以从 [GitHub Releases](https://github.com/Future-Element/pinset/releases) 手动下载当前系统的归档。
+
+安装后将 `pinset` 放入 `PATH`，再进入一个项目：
 
 ```shell
 pinset init
@@ -65,7 +77,7 @@ cargo build --release --locked -p pinset-cli -p pinset-shim
 
 测试使用临时目录、本地假 HTTP 服务和假运行时，不会安装真实 Node、Python 或 Flutter。
 
-开发分支应优先在本机或 WSL 使用增量编译和测试。Pull Request 只有从草稿转为 Ready 时自动运行一次 Quality；后续按需手动触发，避免每次 push 消耗 GitHub Actions。推送到 `main` 和版本标签仍执行发布所需的完整检查与构建。
+开发分支应优先在本机或 WSL 使用增量编译和测试。Pull Request 只有从草稿转为 Ready 时自动运行一次 Quality；后续按需手动触发，避免每次 push 消耗 GitHub Actions。推送到 `main` 运行质量门禁，版本标签执行完整三平台构建并自动发布 GitHub Release。
 
 ## 文档
 
@@ -77,6 +89,9 @@ cargo build --release --locked -p pinset-cli -p pinset-shim
 - [路线图](docs/ROADMAP.md)
 - [决策记录](docs/DECISIONS.md)
 - [WSL 构建与测试](docs/WSL_TESTING.md)
+- [发布流程](docs/RELEASING.md)
+- [贡献指南](CONTRIBUTING.md)
+- [安全策略](SECURITY.md)
 
 ## 许可
 

--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ cargo build --release --locked -p pinset-cli -p pinset-shim
 
 ## 许可
 
-开源许可证尚未决定。在许可证文件加入仓库前，不应把当前代码视作已授予通用开源许可。
+Pinset 使用 [MIT License](LICENSE) 开源。

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ cargo build --release --locked -p pinset-cli -p pinset-shim
 
 测试使用临时目录、本地假 HTTP 服务和假运行时，不会安装真实 Node、Python 或 Flutter。
 
-开发分支应优先在本机或 WSL 使用增量编译和测试。Pull Request 只有从草稿转为 Ready 时自动运行一次 Quality；后续按需手动触发，避免每次 push 消耗 GitHub Actions。推送到 `main` 运行质量门禁，版本标签执行完整三平台构建并自动发布 GitHub Release。
+开发分支应优先在本机或 WSL 使用增量编译和测试。非草稿 Pull Request 在新建、重新打开和后续推送时自动运行 Quality，草稿 PR 跳过检查。推送到 `main` 运行质量门禁，版本标签执行完整三平台构建并自动发布 GitHub Release。
 
 ## 文档
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported versions
+
+Pinset 仍处于 alpha 阶段，目前只对最新 GitHub Release 提供安全修复。预发布版本可能包含不兼容变更。
+
+## Reporting a vulnerability
+
+请不要在公开 Issue 中披露尚未修复的漏洞。优先使用 GitHub 仓库的 Private vulnerability reporting；如果该入口暂不可见，请联系仓库维护者并仅说明需要建立私密沟通渠道，不要在首次公开消息中附带漏洞细节、利用代码、令牌或用户数据。
+
+报告建议包含：
+
+- 受影响版本和平台；
+- 最小复现条件；
+- 可能影响的文件、命令或信任边界；
+- 是否存在已知利用；
+- 建议的缓解方式（如有）。
+
+维护者确认安全沟通渠道后，再交换完整细节。修复发布前会尽量协调披露时间。

--- a/crates/pinset-core/src/error.rs
+++ b/crates/pinset-core/src/error.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{env::JoinPathsError, path::PathBuf};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -112,6 +112,15 @@ pub enum Error {
         version: String,
         command: String,
         searched: String,
+    },
+
+    #[error("runtime executable has no parent directory: {path}")]
+    RuntimeCommandDirectoryMissing { path: PathBuf },
+
+    #[error("failed to construct PATH for the selected runtime: {source}")]
+    RuntimePathJoin {
+        #[source]
+        source: JoinPathsError,
     },
 
     #[error("cannot determine Pinset data directory; set PINSET_HOME explicitly")]

--- a/crates/pinset-core/src/error.rs
+++ b/crates/pinset-core/src/error.rs
@@ -389,23 +389,23 @@ pub enum Error {
     },
 
     #[cfg(feature = "installer")]
-    #[error("unsafe ZIP entry rejected: {entry}")]
+    #[error("unsafe archive entry rejected: {entry}")]
     UnsafeArchiveEntry { entry: String },
 
     #[cfg(feature = "installer")]
-    #[error("duplicate or case-colliding ZIP entry rejected: {entry}")]
+    #[error("duplicate or case-colliding archive entry rejected: {entry}")]
     DuplicateArchiveEntry { entry: String },
 
     #[cfg(feature = "installer")]
-    #[error("ZIP contains {actual} entries, exceeding limit {limit}")]
+    #[error("archive contains {actual} entries, exceeding limit {limit}")]
     TooManyArchiveEntries { actual: usize, limit: usize },
 
     #[cfg(feature = "installer")]
-    #[error("ZIP expanded size exceeds limit {limit} bytes")]
+    #[error("archive expanded size exceeds limit {limit} bytes")]
     ArchiveTooLarge { limit: u64 },
 
     #[cfg(feature = "installer")]
-    #[error("failed to extract ZIP entry {entry} to {path}: {source}")]
+    #[error("failed to extract archive entry {entry} to {path}: {source}")]
     ExtractArchiveEntry {
         entry: String,
         path: PathBuf,

--- a/crates/pinset-core/src/installer.rs
+++ b/crates/pinset-core/src/installer.rs
@@ -441,6 +441,7 @@ impl Installer {
             source,
         })?;
         let mut seen = HashSet::new();
+        let mut pending_symlinks = Vec::new();
         let mut total_unpacked = 0_u64;
         let mut entry_count = 0_usize;
 
@@ -463,7 +464,10 @@ impl Installer {
             let entry_name = archived_path.to_string_lossy().into_owned();
             let entry_type = entry.header().entry_type();
             let is_directory = entry_type.is_dir();
-            if (!entry_type.is_file() && !is_directory) || !is_safe_relative(&archived_path) {
+            let is_symlink = entry_type.is_symlink();
+            if (!entry_type.is_file() && !is_directory && !is_symlink)
+                || !is_safe_relative(&archived_path)
+            {
                 return Err(Error::UnsafeArchiveEntry { entry: entry_name });
             }
             let Some(relative) =
@@ -481,6 +485,26 @@ impl Installer {
                     path: output_path,
                     source,
                 })?;
+                continue;
+            }
+            if is_symlink {
+                let link_target = entry
+                    .link_name()
+                    .map_err(|source| Error::ReadTarArchive {
+                        path: archive_path.to_path_buf(),
+                        source,
+                    })?
+                    .ok_or_else(|| Error::UnsafeArchiveEntry {
+                        entry: entry_name.clone(),
+                    })?
+                    .into_owned();
+                let resolved_target =
+                    resolve_archive_symlink(&relative, &link_target).ok_or_else(|| {
+                        Error::UnsafeArchiveEntry {
+                            entry: entry_name.clone(),
+                        }
+                    })?;
+                pending_symlinks.push((entry_name, output_path, link_target, resolved_target));
                 continue;
             }
 
@@ -558,6 +582,25 @@ impl Installer {
                     source,
                 })?;
             set_executable_permissions(&output_path, Some(mode)).map_err(|source| {
+                Error::ExtractArchiveEntry {
+                    entry: entry_name,
+                    path: output_path,
+                    source,
+                }
+            })?;
+        }
+        for (entry_name, output_path, link_target, resolved_target) in pending_symlinks {
+            if !destination.join(resolved_target).is_file() {
+                return Err(Error::UnsafeArchiveEntry { entry: entry_name });
+            }
+            if let Some(parent) = output_path.parent() {
+                fs::create_dir_all(parent).map_err(|source| Error::ExtractArchiveEntry {
+                    entry: entry_name.clone(),
+                    path: parent.to_path_buf(),
+                    source,
+                })?;
+            }
+            create_archive_symlink(&link_target, &output_path).map_err(|source| {
                 Error::ExtractArchiveEntry {
                     entry: entry_name,
                     path: output_path,
@@ -667,6 +710,50 @@ fn strip_entry_path(
             .into_iter()
             .skip(strip_components)
             .collect::<PathBuf>(),
+    ))
+}
+
+fn resolve_archive_symlink(link_path: &Path, target: &Path) -> Option<PathBuf> {
+    if target.as_os_str().is_empty()
+        || target.is_absolute()
+        || target.to_string_lossy().contains('\\')
+    {
+        return None;
+    }
+    let mut resolved = link_path
+        .parent()
+        .unwrap_or_else(|| Path::new(""))
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(value) => Some(value.to_owned()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    for component in target.components() {
+        match component {
+            Component::Normal(value) => resolved.push(value.to_owned()),
+            Component::ParentDir => {
+                resolved.pop()?;
+            }
+            Component::CurDir | Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    if resolved.is_empty() {
+        return None;
+    }
+    Some(resolved.into_iter().collect())
+}
+
+#[cfg(unix)]
+fn create_archive_symlink(target: &Path, link: &Path) -> io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(not(unix))]
+fn create_archive_symlink(_target: &Path, _link: &Path) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "archive symbolic links are only supported on Unix targets",
     ))
 }
 
@@ -896,6 +983,49 @@ mod tests {
         assert_transaction_root_is_empty(root.path());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn installs_tar_xz_with_safe_node_style_symlinks() {
+        let archive = tar_xz_with_symlink("../lib/node_modules/corepack/dist/corepack.js");
+        let (url, server) = serve_once(archive.clone(), archive.len());
+        let root = tempdir().expect("temp root");
+        let mut request = request(root.path(), url, sha256_hex(&archive));
+        request.target = "linux-x86_64".to_owned();
+        request.artifact.format = ArtifactFormat::TarXz;
+        request.strip_components = 1;
+        request.required_paths = vec![PathBuf::from("bin/node"), PathBuf::from("bin/corepack")];
+
+        let outcome = test_installer().install(&request).expect("install");
+        server.join().expect("server");
+
+        assert_eq!(
+            fs::read_link(outcome.install_dir.join("bin/corepack")).expect("link"),
+            PathBuf::from("../lib/node_modules/corepack/dist/corepack.js")
+        );
+        assert!(outcome.install_dir.join("bin/corepack").is_file());
+        assert_transaction_root_is_empty(root.path());
+    }
+
+    #[test]
+    fn rejects_tar_xz_symlinks_that_escape_the_install_root() {
+        let archive = tar_xz_with_symlink("../../outside");
+        let (url, server) = serve_once(archive.clone(), archive.len());
+        let root = tempdir().expect("temp root");
+        let mut request = request(root.path(), url, sha256_hex(&archive));
+        request.target = "linux-x86_64".to_owned();
+        request.artifact.format = ArtifactFormat::TarXz;
+        request.strip_components = 1;
+
+        let error = test_installer()
+            .install(&request)
+            .expect_err("escaping symlink");
+        server.join().expect("server");
+
+        assert!(matches!(error, Error::UnsafeArchiveEntry { .. }));
+        assert!(!final_dir(root.path()).exists());
+        assert_transaction_root_is_empty(root.path());
+    }
+
     #[test]
     fn falls_back_to_next_source_only_after_network_failure() {
         let archive = zip_bytes(&[("bin/node.exe", b"fake node")]);
@@ -1117,6 +1247,47 @@ mod tests {
                 .append(&header, Cursor::new(*content))
                 .expect("tar entry");
         }
+        let encoder = builder.into_inner().expect("tar finish");
+        encoder.finish().expect("xz finish")
+    }
+
+    fn tar_xz_with_symlink(link_target: &str) -> Vec<u8> {
+        let encoder = XzEncoder::new(Vec::new(), 6);
+        let mut builder = tar::Builder::new(encoder);
+        for (path, content, mode) in [
+            (
+                "node-v24.0.0-linux-x64/bin/node",
+                b"fake node".as_slice(),
+                0o755,
+            ),
+            (
+                "node-v24.0.0-linux-x64/lib/node_modules/corepack/dist/corepack.js",
+                b"fake corepack".as_slice(),
+                0o755,
+            ),
+        ] {
+            let mut header = tar::Header::new_gnu();
+            header.set_path(path).expect("tar path");
+            header.set_size(content.len() as u64);
+            header.set_mode(mode);
+            header.set_cksum();
+            builder
+                .append(&header, Cursor::new(content))
+                .expect("tar entry");
+        }
+        let mut link_header = tar::Header::new_gnu();
+        link_header
+            .set_path("node-v24.0.0-linux-x64/bin/corepack")
+            .expect("link path");
+        link_header.set_entry_type(tar::EntryType::Symlink);
+        link_header.set_link_name(link_target).expect("link target");
+        link_header.set_size(0);
+        link_header.set_mode(0o777);
+        link_header.set_cksum();
+        builder
+            .append(&link_header, io::empty())
+            .expect("tar symlink");
+
         let encoder = builder.into_inner().expect("tar finish");
         encoder.finish().expect("xz finish")
     }

--- a/crates/pinset-core/src/lib.rs
+++ b/crates/pinset-core/src/lib.rs
@@ -40,8 +40,8 @@ pub use node_provider::{NodeArchiveFormat, NodeArtifactPlan, plan_node_artifact}
 #[cfg(all(feature = "installer", feature = "lockfile"))]
 pub use node_runtime::{install_locked_node, node_command_directory};
 pub use resolver::{
-    CommandResolution, command_tool, pinset_home, pinset_home_from_env, resolve_command,
-    resolve_from_env,
+    CommandResolution, command_tool, path_with_selected_runtime, pinset_home, pinset_home_from_env,
+    resolve_command, resolve_from_env,
 };
 pub use shim_install::{ShimInstallMethod, ShimInstallResult, install_shims};
 #[cfg(feature = "sources")]

--- a/crates/pinset-core/src/node_metadata.rs
+++ b/crates/pinset-core/src/node_metadata.rs
@@ -122,7 +122,7 @@ fn parse_shasums(manifest: &str) -> Result<HashMap<String, String>> {
         if parts.len() != 2
             || parts[0].len() != 64
             || !parts[0].bytes().all(|byte| byte.is_ascii_hexdigit())
-            || parts[1].contains(['/', '\\'])
+            || !is_safe_manifest_path(parts[1])
         {
             return Err(Error::InvalidNodeShasums {
                 reason: format!("invalid line {}", index + 1),
@@ -143,6 +143,15 @@ fn parse_shasums(manifest: &str) -> Result<HashMap<String, String>> {
         });
     }
     Ok(checksums)
+}
+
+fn is_safe_manifest_path(path: &str) -> bool {
+    !path.is_empty()
+        && !path.starts_with('/')
+        && !path.contains('\\')
+        && path
+            .split('/')
+            .all(|segment| !segment.is_empty() && segment != "." && segment != "..")
 }
 
 #[cfg(test)]
@@ -215,6 +224,32 @@ mod tests {
             .expect_err("missing target checksum");
         server.join().expect("server");
         assert!(matches!(error, Error::NodeChecksumMissing { .. }));
+    }
+
+    #[test]
+    fn accepts_safe_nested_paths_used_by_official_windows_entries() {
+        let hash = "a".repeat(64);
+        let checksums = parse_shasums(&format!(
+            "{hash}  node-v24.0.0-win-x64.zip\n{hash}  win-x64/node.exe"
+        ))
+        .expect("official manifest paths");
+
+        assert_eq!(
+            checksums.get("win-x64/node.exe").map(String::as_str),
+            Some(hash.as_str())
+        );
+        for unsafe_path in [
+            "../node.exe",
+            "win-x64/../node.exe",
+            "/win-x64/node.exe",
+            "win-x64\\node.exe",
+            "win-x64//node.exe",
+        ] {
+            assert!(matches!(
+                parse_shasums(&format!("{hash}  {unsafe_path}")),
+                Err(Error::InvalidNodeShasums { .. })
+            ));
+        }
     }
 
     fn serve_once(body: String) -> (String, thread::JoinHandle<()>) {

--- a/crates/pinset-core/src/resolver.rs
+++ b/crates/pinset-core/src/resolver.rs
@@ -1,5 +1,6 @@
 use std::{
     env,
+    ffi::OsString,
     path::{Path, PathBuf},
 };
 
@@ -106,6 +107,22 @@ pub fn resolve_command(command: &str, cwd: &Path, pinset_home: &Path) -> Result<
         config_path,
         executable,
     })
+}
+
+pub fn path_with_selected_runtime(executable: &Path) -> Result<OsString> {
+    let command_dir = executable
+        .parent()
+        .ok_or_else(|| Error::RuntimeCommandDirectoryMissing {
+            path: executable.to_path_buf(),
+        })?;
+    let inherited = env::var_os("PATH");
+    let entries = std::iter::once(command_dir.to_path_buf()).chain(
+        inherited
+            .as_ref()
+            .into_iter()
+            .flat_map(|value| env::split_paths(value)),
+    );
+    env::join_paths(entries).map_err(|source| Error::RuntimePathJoin { source })
 }
 
 fn runtime_command_dir(install_dir: &Path) -> PathBuf {

--- a/crates/pinset-shim/src/main.rs
+++ b/crates/pinset-shim/src/main.rs
@@ -8,7 +8,9 @@ use std::{
 #[cfg(windows)]
 use std::ffi::OsStr;
 
-use pinset_core::{CommandResolution, pinset_home_from_env, resolve_command};
+use pinset_core::{
+    CommandResolution, path_with_selected_runtime, pinset_home_from_env, resolve_command,
+};
 
 const SHIM_DEPTH_ENV: &str = "PINSET_SHIM_DEPTH";
 const SELECTED_TOOL_ENV: &str = "PINSET_SELECTED_TOOL";
@@ -33,8 +35,10 @@ fn run() -> Result<i32, Box<dyn std::error::Error>> {
     let resolution = resolve_command(&invocation.command, &invocation.cwd, &home)?;
     reject_shim_directory_target(&resolution, &home)?;
 
+    let runtime_path = path_with_selected_runtime(&resolution.executable)?;
     let mut child = command_for_runtime(&resolution.executable, &invocation.arguments);
     child
+        .env("PATH", runtime_path)
         .env(SHIM_DEPTH_ENV, "1")
         .env(SELECTED_TOOL_ENV, &resolution.tool)
         .env(SELECTED_VERSION_ENV, &resolution.version)

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -14,8 +14,9 @@ use pinset_core::{
     Error, InstallLimits, Installer, NodeMetadataClient, SUPPORTED_SOURCE_PROVIDERS,
     ShimInstallMethod, SourceView, create_project_config, current_target, find_project_config,
     install_locked_node, install_shims, load_lockfile, load_project_config, load_source_config,
-    lockfile_path, node_command_directory, pinset_home, resolve_command, save_lockfile,
-    save_project_config, save_source_config, source_config_path, validate_lock_matches_project,
+    lockfile_path, node_command_directory, path_with_selected_runtime, pinset_home,
+    resolve_command, save_lockfile, save_project_config, save_source_config, source_config_path,
+    validate_lock_matches_project,
 };
 
 #[derive(Debug, Parser)]
@@ -305,10 +306,12 @@ fn execute_selected(
         .and_then(|value| value.to_str())
         .ok_or("command name must be valid UTF-8")?;
     let resolution = resolve_command(command_name, cwd, &pinset_home()?)?;
+    let runtime_path = path_with_selected_runtime(&resolution.executable)?;
     let mut child = command_for_runtime(&resolution.executable);
     child
         .args(&command[1..])
         .current_dir(cwd)
+        .env("PATH", runtime_path)
         .env("PINSET_SELECTED_TOOL", &resolution.tool)
         .env("PINSET_SELECTED_VERSION", &resolution.version)
         .env("PINSET_CONFIG_PATH", &resolution.config_path);

--- a/crates/pinset/tests/mvp_cli.rs
+++ b/crates/pinset/tests/mvp_cli.rs
@@ -30,6 +30,13 @@ fn current_which_exec_and_doctor_share_the_locked_fake_runtime() {
     let exec = pinset(&project, &home, &["exec", "--", "node", "hello", "mvp"]);
     assert_success_contains(&exec, "24.0.0:hello mvp");
 
+    #[cfg(not(windows))]
+    {
+        let npm = pinset(&project, &home, &["exec", "--", "npm", "--version"]);
+        assert_success_contains(&npm, "24.0.0:");
+        assert_success_contains(&npm, "npm --version");
+    }
+
     let doctor = pinset(&project, &home, &["doctor"]);
     assert_success_contains(&doctor, "lockfile");
     assert_success_contains(&doctor, "matches node@24.0.0");
@@ -130,6 +137,11 @@ fn create_fake_node(home: &Path, version: &str) -> PathBuf {
             .permissions();
         permissions.set_mode(0o755);
         fs::set_permissions(&executable, permissions).expect("fake node permissions");
+        let npm = command_dir.join("npm");
+        fs::write(&npm, "#!/usr/bin/env node\n").expect("fake npm");
+        let mut npm_permissions = fs::metadata(&npm).expect("fake npm metadata").permissions();
+        npm_permissions.set_mode(0o755);
+        fs::set_permissions(&npm, npm_permissions).expect("fake npm permissions");
         executable
     }
 }

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -34,10 +34,10 @@
 | D-028 | Accepted | 先发布 Node-only `0.1.0-alpha.1` MVP，再扩展 Python 与 Flutter | 先证明锁定、镜像、校验、事务安装和项目执行的完整闭环，避免三个 provider 同时扩张 |
 | D-029 | Accepted | Node MVP 只接受精确稳定版本并锁定四个平台产物 | 避免浮动版本在不同时间解析出不同结果，同时允许同一锁文件跨团队平台复用 |
 | D-030 | Provisional | Node MVP 以官方 HTTPS `SHASUMS256.txt` 的 SHA-256 为信任值 | 已阻止镜像改变哈希；PGP 签名验证仍是进入稳定版前的供应链增强项 |
+| D-031 | Accepted | Pinset 使用 MIT License 开源 | 授权简洁、采用门槛低，允许个人与商业项目使用、修改和分发，同时保留版权与免责声明 |
 
 ## 尚待决策
 
-- 开源许可证：MIT、Apache-2.0 或双许可证；
 - 默认数据目录的精确跨平台约定；
 - Node 发布密钥轮换和离线密钥环；
 - Python provider 清单的发布/签名方式；

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,39 @@
+# Pinset 发布流程
+
+Pinset 使用版本标签驱动的 GitHub Actions 自动发布，不手工上传 Release 资产。
+
+## 发布前
+
+1. 更新 workspace `version` 和 `Cargo.lock`；
+2. 更新 README、使用文档和变更说明中的版本；
+3. 在 Pull Request 中通过 Quality；
+4. 合并到 `main` 并确认主分支 Quality 成功；
+5. 确认目标版本在 Windows x64、Linux x64、macOS arm64 的已知限制。
+
+## 触发发布
+
+标签必须与 workspace 版本完全一致：
+
+```shell
+git tag -a v0.1.0-alpha.1 -m "Pinset 0.1.0-alpha.1"
+git push origin v0.1.0-alpha.1
+```
+
+Release workflow 会自动：
+
+1. 校验标签与 Cargo workspace 版本；
+2. 运行格式、Clippy、Rust 测试和离线 curl 安装器测试；
+3. 构建 Linux x64、Windows x64、macOS arm64；
+4. 生成三个平台归档；
+5. 发布 `install.sh`、平台归档和 `SHA256SUMS`；
+6. 带连字符的版本自动标记为 GitHub Prerelease。
+
+任一步失败都不会创建新的完整 Release。失败时修复代码并发布新版本，不覆盖已经公开使用的版本标签。
+
+## 发布后验证
+
+- 检查 Release 中五个资产是否齐全；
+- 核对 `SHA256SUMS`；
+- 在 Linux/WSL 使用固定版本 curl 命令安装到临时目录；
+- 运行 `pinset --version`；
+- 记录未执行的真实运行时或平台验证。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -266,5 +266,5 @@ Phase 0 总体 go/no-go：
 3. 冻结本机 source config schema 和 `pinset source` CLI；
 4. 接入一个固定 Node.js Windows x64 官方 ZIP，并用显式社区镜像验证相同 lock/哈希；
 5. 准备 Python、Flutter 固定真实产物及验证规则；
-6. 决定开源许可证；
+6. ~~决定开源许可证；~~ 已选择 MIT License；
 7. 每个 spike 完成后写 ADR，再冻结 v0.1 实现计划。

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -17,6 +17,44 @@ WSL 是独立的 Linux 环境，不与 Windows 原生安装目录或 PATH 混用
 
 ## 2. 安装 Pinset
 
+### curl 安装（Linux x64 / macOS Apple Silicon）
+
+当前预发布版：
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/Future-Element/pinset/releases/download/v0.1.0-alpha.1/install.sh |
+  sh -s -- --version 0.1.0-alpha.1
+```
+
+稳定版发布后安装 latest：
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/Future-Element/pinset/releases/latest/download/install.sh | sh
+```
+
+指定安装目录：
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/Future-Element/pinset/releases/latest/download/install.sh |
+  sh -s -- --install-dir "$HOME/bin"
+```
+
+默认安装目录是 `$HOME/.local/bin`。脚本会：
+
+- 只接受 HTTPS；
+- 识别当前支持的平台和架构；
+- 同时下载平台归档与 `SHA256SUMS`；
+- 在解压前强制核对 SHA-256；
+- 只接受包含 `pinset` 与 `pinset-shim` 两个普通文件的归档；
+- 不请求 `sudo`，不修改 PATH/shell profile，不安装任何语言运行时。
+
+`latest` 只代表 GitHub 的最新稳定 Release；alpha/beta 等预发布版必须使用固定版本命令。
+
+### 手动安装
+
 在 GitHub Releases 下载当前平台的归档和 `SHA256SUMS`：
 
 - Windows x64：`pinset-windows-x86_64.zip`

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,236 @@
+#!/bin/sh
+
+set -eu
+
+REPOSITORY="Future-Element/pinset"
+VERSION="${PINSET_VERSION:-}"
+INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
+TEMP_ROOT=""
+PINSET_TEMP=""
+SHIM_TEMP=""
+
+usage() {
+    cat <<'EOF'
+Install Pinset from a GitHub Release.
+
+Usage:
+  install.sh [--version VERSION] [--install-dir DIRECTORY]
+
+Options:
+  --version VERSION       Install an exact release, for example 0.1.0.
+                          Without this option, install the latest stable release.
+  --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
+  -h, --help              Show this help.
+
+Environment equivalents:
+  PINSET_VERSION
+  PINSET_INSTALL_DIR
+EOF
+}
+
+fail() {
+    printf 'pinset installer: %s\n' "$*" >&2
+    exit 1
+}
+
+cleanup() {
+    if [ -n "$PINSET_TEMP" ]; then
+        rm -f -- "$PINSET_TEMP"
+    fi
+    if [ -n "$SHIM_TEMP" ]; then
+        rm -f -- "$SHIM_TEMP"
+    fi
+    if [ -n "$TEMP_ROOT" ]; then
+        rm -rf -- "$TEMP_ROOT"
+    fi
+}
+
+on_signal() {
+    trap - EXIT HUP INT TERM
+    cleanup
+    exit 130
+}
+
+trap cleanup EXIT
+trap on_signal HUP INT TERM
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --version)
+            [ "$#" -ge 2 ] || fail "--version requires a value"
+            VERSION=$2
+            shift 2
+            ;;
+        --install-dir)
+            [ "$#" -ge 2 ] || fail "--install-dir requires a value"
+            INSTALL_DIR=$2
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "unknown option: $1"
+            ;;
+    esac
+done
+
+if [ -z "$INSTALL_DIR" ]; then
+    [ -n "${HOME:-}" ] || fail "HOME is not set; pass --install-dir"
+    INSTALL_DIR="$HOME/.local/bin"
+fi
+
+case "$INSTALL_DIR" in
+    /*) ;;
+    *) fail "install directory must be an absolute path: $INSTALL_DIR" ;;
+esac
+
+if [ -n "$VERSION" ]; then
+    VERSION=${VERSION#v}
+    case "$VERSION" in
+        ''|[!0-9A-Za-z]*|*[!0-9A-Za-z.-]*) fail "invalid version: $VERSION" ;;
+    esac
+    RELEASE_BASE_URL="https://github.com/$REPOSITORY/releases/download/v$VERSION"
+    RELEASE_LABEL="v$VERSION"
+else
+    RELEASE_BASE_URL="https://github.com/$REPOSITORY/releases/latest/download"
+    RELEASE_LABEL="latest stable release"
+fi
+
+# Reserved for the repository's offline installer tests. It is deliberately
+# unavailable unless test mode is explicitly enabled.
+if [ "${PINSET_INSTALL_TEST_MODE:-}" = "1" ]; then
+    [ -n "${PINSET_TEST_RELEASE_BASE_URL:-}" ] || fail "test release URL is missing"
+    RELEASE_BASE_URL=$PINSET_TEST_RELEASE_BASE_URL
+fi
+
+OS=$(uname -s)
+ARCH=$(uname -m)
+if [ "${PINSET_INSTALL_TEST_MODE:-}" = "1" ]; then
+    OS=${PINSET_TEST_UNAME_S:-$OS}
+    ARCH=${PINSET_TEST_UNAME_M:-$ARCH}
+fi
+case "$OS:$ARCH" in
+    Linux:x86_64|Linux:amd64)
+        ARCHIVE="pinset-linux-x86_64.tar.gz"
+        ;;
+    Darwin:arm64|Darwin:aarch64)
+        ARCHIVE="pinset-macos-aarch64.tar.gz"
+        ;;
+    Darwin:x86_64|Darwin:amd64)
+        fail "macOS Intel is not published yet; use an Apple Silicon shell or build from source"
+        ;;
+    Linux:aarch64|Linux:arm64)
+        fail "Linux arm64 is not published yet"
+        ;;
+    *)
+        fail "unsupported platform: $OS $ARCH"
+        ;;
+esac
+
+for command in curl tar awk mktemp chmod mv cp mkdir rm; do
+    command -v "$command" >/dev/null 2>&1 || fail "required command not found: $command"
+done
+
+download() {
+    url=$1
+    destination=$2
+    case "$url" in
+        https://*)
+            curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
+                --output "$destination" "$url"
+            ;;
+        file://*)
+            [ "${PINSET_INSTALL_TEST_MODE:-}" = "1" ] || fail "non-HTTPS download URL rejected"
+            curl --fail --location --silent --show-error --output "$destination" "$url"
+            ;;
+        *)
+            fail "non-HTTPS download URL rejected"
+            ;;
+    esac
+}
+
+TEMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/pinset-install.XXXXXX")
+ARCHIVE_PATH="$TEMP_ROOT/$ARCHIVE"
+CHECKSUMS_PATH="$TEMP_ROOT/SHA256SUMS"
+EXTRACT_DIR="$TEMP_ROOT/extract"
+mkdir -p "$EXTRACT_DIR"
+
+printf 'Downloading Pinset %s for %s %s...\n' "$RELEASE_LABEL" "$OS" "$ARCH"
+download "$RELEASE_BASE_URL/$ARCHIVE" "$ARCHIVE_PATH"
+download "$RELEASE_BASE_URL/SHA256SUMS" "$CHECKSUMS_PATH"
+
+EXPECTED_HASH=$(awk -v archive="$ARCHIVE" '
+    $2 == archive {
+        if (found) exit 2
+        print $1
+        found = 1
+    }
+    END { if (!found) exit 1 }
+' "$CHECKSUMS_PATH") || fail "SHA256SUMS does not contain exactly one entry for $ARCHIVE"
+
+printf '%s\n' "$EXPECTED_HASH" | awk '
+    length($0) == 64 && $0 !~ /[^0-9A-Fa-f]/ { valid = 1 }
+    END { exit !valid }
+' || fail "invalid SHA-256 value for $ARCHIVE"
+
+if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL_HASH=$(sha256sum "$ARCHIVE_PATH" | awk '{ print $1 }')
+elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL_HASH=$(shasum -a 256 "$ARCHIVE_PATH" | awk '{ print $1 }')
+elif command -v openssl >/dev/null 2>&1; then
+    ACTUAL_HASH=$(openssl dgst -sha256 "$ARCHIVE_PATH" | awk '{ print $NF }')
+else
+    fail "sha256sum, shasum, or openssl is required to verify the release"
+fi
+
+EXPECTED_HASH=$(printf '%s' "$EXPECTED_HASH" | awk '{ print tolower($0) }')
+ACTUAL_HASH=$(printf '%s' "$ACTUAL_HASH" | awk '{ print tolower($0) }')
+[ "$ACTUAL_HASH" = "$EXPECTED_HASH" ] || fail "SHA-256 mismatch for $ARCHIVE"
+
+ENTRY_LIST="$TEMP_ROOT/archive-entries"
+tar -tzf "$ARCHIVE_PATH" > "$ENTRY_LIST" || fail "cannot list $ARCHIVE"
+awk '
+    $0 == "pinset" { pinset += 1; next }
+    $0 == "pinset-shim" { shim += 1; next }
+    { exit 2 }
+    END { if (NR != 2 || pinset != 1 || shim != 1) exit 1 }
+' "$ENTRY_LIST" || fail "release archive must contain exactly pinset and pinset-shim"
+
+tar -xzf "$ARCHIVE_PATH" -C "$EXTRACT_DIR"
+for binary in pinset pinset-shim; do
+    [ -f "$EXTRACT_DIR/$binary" ] || fail "release archive is missing $binary"
+    [ ! -L "$EXTRACT_DIR/$binary" ] || fail "release archive contains a symbolic-link binary: $binary"
+done
+
+mkdir -p "$INSTALL_DIR"
+[ -d "$INSTALL_DIR" ] || fail "install destination is not a directory: $INSTALL_DIR"
+[ -w "$INSTALL_DIR" ] || fail "install destination is not writable: $INSTALL_DIR"
+
+PINSET_TEMP=$(mktemp "$INSTALL_DIR/.pinset.XXXXXX")
+SHIM_TEMP=$(mktemp "$INSTALL_DIR/.pinset-shim.XXXXXX")
+cp "$EXTRACT_DIR/pinset" "$PINSET_TEMP"
+cp "$EXTRACT_DIR/pinset-shim" "$SHIM_TEMP"
+chmod 755 "$PINSET_TEMP" "$SHIM_TEMP"
+
+# Publish the companion first and the CLI last. Both files were fully copied
+# and verified before either existing executable is replaced.
+mv -f "$SHIM_TEMP" "$INSTALL_DIR/pinset-shim"
+SHIM_TEMP=""
+mv -f "$PINSET_TEMP" "$INSTALL_DIR/pinset"
+PINSET_TEMP=""
+
+printf 'Installed %s\n' "$INSTALL_DIR/pinset"
+printf 'Installed %s\n' "$INSTALL_DIR/pinset-shim"
+"$INSTALL_DIR/pinset" --version
+
+case ":${PATH:-}:" in
+    *":$INSTALL_DIR:"*) ;;
+    *)
+        printf '\nAdd Pinset to the current shell:\n'
+        printf '  export PATH="%s:$PATH"\n' "$INSTALL_DIR"
+        ;;
+esac
+
+printf '\nPinset does not modify shell profiles or install language runtimes automatically.\n'

--- a/scripts/tests/install_sh_test.sh
+++ b/scripts/tests/install_sh_test.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/pinset-install-test.XXXXXX")
+
+cleanup() {
+    rm -rf -- "$TEST_ROOT"
+}
+on_signal() {
+    trap - EXIT HUP INT TERM
+    cleanup
+    exit 130
+}
+trap cleanup EXIT
+trap on_signal HUP INT TERM
+
+case "$(uname -s):$(uname -m)" in
+    Linux:x86_64|Linux:amd64) ARCHIVE="pinset-linux-x86_64.tar.gz" ;;
+    Darwin:arm64|Darwin:aarch64) ARCHIVE="pinset-macos-aarch64.tar.gz" ;;
+    *)
+        printf 'installer test skipped on unsupported host\n'
+        exit 0
+        ;;
+esac
+
+RELEASE_DIR="$TEST_ROOT/release"
+PACKAGE_DIR="$TEST_ROOT/package"
+INSTALL_DIR="$TEST_ROOT/install dir"
+mkdir -p "$RELEASE_DIR" "$PACKAGE_DIR"
+
+cat > "$PACKAGE_DIR/pinset" <<'EOF'
+#!/bin/sh
+printf 'pinset 9.8.7-test\n'
+EOF
+cat > "$PACKAGE_DIR/pinset-shim" <<'EOF'
+#!/bin/sh
+printf 'fake shim\n'
+EOF
+chmod 755 "$PACKAGE_DIR/pinset" "$PACKAGE_DIR/pinset-shim"
+tar -czf "$RELEASE_DIR/$ARCHIVE" -C "$PACKAGE_DIR" pinset pinset-shim
+
+if command -v sha256sum >/dev/null 2>&1; then
+    HASH=$(sha256sum "$RELEASE_DIR/$ARCHIVE" | awk '{ print $1 }')
+else
+    HASH=$(shasum -a 256 "$RELEASE_DIR/$ARCHIVE" | awk '{ print $1 }')
+fi
+printf '%s  %s\n' "$HASH" "$ARCHIVE" > "$RELEASE_DIR/SHA256SUMS"
+
+PINSET_INSTALL_TEST_MODE=1 \
+PINSET_TEST_RELEASE_BASE_URL="file://$RELEASE_DIR" \
+sh "$ROOT/install.sh" --version 9.8.7-test --install-dir "$INSTALL_DIR"
+
+[ -x "$INSTALL_DIR/pinset" ]
+[ -x "$INSTALL_DIR/pinset-shim" ]
+[ "$("$INSTALL_DIR/pinset" --version)" = "pinset 9.8.7-test" ]
+
+BAD_RELEASE_DIR="$TEST_ROOT/bad-release"
+BAD_INSTALL_DIR="$TEST_ROOT/bad-install"
+mkdir -p "$BAD_RELEASE_DIR"
+cp "$RELEASE_DIR/$ARCHIVE" "$BAD_RELEASE_DIR/$ARCHIVE"
+printf '%064d  %s\n' 0 "$ARCHIVE" > "$BAD_RELEASE_DIR/SHA256SUMS"
+
+if PINSET_INSTALL_TEST_MODE=1 \
+    PINSET_TEST_RELEASE_BASE_URL="file://$BAD_RELEASE_DIR" \
+    sh "$ROOT/install.sh" --version 9.8.7-test --install-dir "$BAD_INSTALL_DIR"
+then
+    printf 'checksum mismatch unexpectedly succeeded\n' >&2
+    exit 1
+fi
+[ ! -e "$BAD_INSTALL_DIR/pinset" ]
+[ ! -e "$BAD_INSTALL_DIR/pinset-shim" ]
+
+EXTRA_RELEASE_DIR="$TEST_ROOT/extra-release"
+EXTRA_INSTALL_DIR="$TEST_ROOT/extra-install"
+mkdir -p "$EXTRA_RELEASE_DIR"
+printf 'unexpected\n' > "$PACKAGE_DIR/unexpected"
+tar -czf "$EXTRA_RELEASE_DIR/$ARCHIVE" -C "$PACKAGE_DIR" pinset pinset-shim unexpected
+if command -v sha256sum >/dev/null 2>&1; then
+    EXTRA_HASH=$(sha256sum "$EXTRA_RELEASE_DIR/$ARCHIVE" | awk '{ print $1 }')
+else
+    EXTRA_HASH=$(shasum -a 256 "$EXTRA_RELEASE_DIR/$ARCHIVE" | awk '{ print $1 }')
+fi
+printf '%s  %s\n' "$EXTRA_HASH" "$ARCHIVE" > "$EXTRA_RELEASE_DIR/SHA256SUMS"
+
+if PINSET_INSTALL_TEST_MODE=1 \
+    PINSET_TEST_RELEASE_BASE_URL="file://$EXTRA_RELEASE_DIR" \
+    sh "$ROOT/install.sh" --version 9.8.7-test --install-dir "$EXTRA_INSTALL_DIR"
+then
+    printf 'archive with an extra entry unexpectedly succeeded\n' >&2
+    exit 1
+fi
+[ ! -e "$EXTRA_INSTALL_DIR/pinset" ]
+[ ! -e "$EXTRA_INSTALL_DIR/pinset-shim" ]
+
+if PINSET_INSTALL_TEST_MODE=1 \
+    PINSET_TEST_UNAME_S=Linux \
+    PINSET_TEST_UNAME_M=aarch64 \
+    PINSET_TEST_RELEASE_BASE_URL="file://$RELEASE_DIR" \
+    sh "$ROOT/install.sh" --version 9.8.7-test --install-dir "$TEST_ROOT/unsupported"
+then
+    printf 'unsupported platform unexpectedly succeeded\n' >&2
+    exit 1
+fi
+
+printf 'install.sh offline tests passed\n'


### PR DESCRIPTION
## Summary
- carry forward the Node manifest, TAR.XZ symlink, and runtime PATH fixes found during WSL smoke testing
- adopt the MIT License and add contribution/security documentation
- add a checksum-enforcing `curl | sh` installer for Linux x64 and macOS arm64
- publish the installer with every tagged GitHub Release and test it offline on Unix runners
- separate low-cost quality CI from tag-driven three-platform release builds

## Local verification
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `dash -n install.sh scripts/tests/install_sh_test.sh`
- `sh scripts/tests/install_sh_test.sh` in WSL

The installer tests use fake binaries and local files only. They verify successful installation, checksum failure, unexpected archive entries, unsupported platforms, and install paths containing spaces. No language runtime was installed.

## Release plan
- merge after Quality succeeds
- make the reviewed repository public
- enable branch protection and private vulnerability reporting
- tag `v0.1.0-alpha.1`
- verify the three archives, `install.sh`, `SHA256SUMS`, and a fixed-version curl installation