### PR TITLE
chore: prepare v0.1.0-alpha.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,7 +927,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "clap",
  "pinset-core",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "atomic-write-file",
  "hex",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.85"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 authors = ["Future Element"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Pinset 是一个面向多语言项目的本地优先运行时版本管理 CLI。它希望用一套一致的命令替代 fnm/nvm、uv、FVM 等工具在“选择和安装运行时版本”上的重叠工作。
 
-当前 `0.1.0-alpha.1` 是 Node-first MVP：
+当前 `0.1.0-alpha.2` 是 Node-first 预发布版：
 
 - 支持 Node.js 精确版本 `x.y.z`；
 - 支持 Windows x64、Linux x64、macOS x64/arm64 的官方预编译产物；
@@ -13,11 +13,20 @@ Pinset 是一个面向多语言项目的本地优先运行时版本管理 CLI。
 - 从 Node 官方 HTTPS `SHASUMS256.txt` 取得哈希，镜像只改变传输位置；
 - 校验 SHA-256 后安全解压 ZIP/TAR.XZ，并以事务方式提交安装；
 - 提供 `use`、`install`、`current`、`which`、`exec`、`doctor` 和 shim；
-- 支持配置国内、企业内网或其他自定义镜像及有序回退。
+- 支持配置国内、企业内网或其他自定义镜像及有序回退；
+- 支持独立的全局 Node 选择、项目覆盖和安全系统 PATH 透传；
+- 支持英文与简体中文界面，并可按用户持久保存语言偏好。
 
 Python、Flutter、浮动版本选择器、PGP 验签、缓存管理和中央包管理器分发不属于这个 MVP，后续按路线图实现。项目不维护第三方 Homebrew Tap 或 Scoop Bucket。
 
-当前 alpha.2 开发分支新增全局/项目/系统 PATH 解析和中英文提示。保存中文界面语言：
+设置全局 Node 后，普通目录使用全局版本，项目中的 `pinset.toml` 仍具有更高优先级：
+
+```shell
+pinset use node@24.0.0 --global
+pinset current
+```
+
+保存中文界面语言：
 
 ```shell
 pinset --lang zh-CN
@@ -32,8 +41,8 @@ pinset --lang zh-CN
 
 ```bash
 curl --proto '=https' --tlsv1.2 -LsSf \
-  https://github.com/Future-Element/pinset/releases/download/v0.1.0-alpha.1/install.sh |
-  sh -s -- --version 0.1.0-alpha.1
+  https://github.com/Future-Element/pinset/releases/download/v0.1.0-alpha.2/install.sh |
+  sh -s -- --version 0.1.0-alpha.2
 ```
 
 安装器识别平台，从同一个 GitHub Release 下载归档和 `SHA256SUMS`，强制核对 SHA-256，然后把 `pinset` 与 `pinset-shim` 原子安装到 `$HOME/.local/bin`。它不使用 `sudo`、不改 shell profile，也不安装 Node。

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -1,9 +1,9 @@
 # Pinset Plans
 
-当前发布版本：`v0.1.0-alpha.1`
-当前开发目标：`v0.1.0-alpha.2`
+当前发布候选：`v0.1.0-alpha.2`
+下一开发目标：`v0.1.0-alpha.3`
 目标稳定版本：`v0.1.0`
-状态：`alpha.2 implementation — Draft PR #4`
+状态：`alpha.2 release candidate — publishing pending`
 更新时间：2026-08-12
 
 ## 文档边界
@@ -57,6 +57,19 @@
 ## 2. v0.1.0-alpha.2 — Global and Project Resolution
 
 主题：`Predictable Node selection everywhere`
+
+状态：**发布候选**
+
+交付结果：
+
+- [x] 独立、原子写入的全局选择与全局锁。
+- [x] 项目、全局、排除 Pinset shim 后系统 PATH 的统一解析顺序。
+- [x] 项目或全局已声明但不可用时失败关闭。
+- [x] `current`、`which`、`exec`、`doctor` 与 shim 共用来源感知解析。
+- [x] npm、npx、corepack 使用所选 Node 的子进程 PATH。
+- [x] 英文与简体中文提示、帮助、参数错误和常见运行错误。
+- [x] 临时目录中的 78 项测试、三平台构建和隔离 Ubuntu 真实 Node 验收。
+- [ ] 发布 `v0.1.0-alpha.2` 标签并复核公开 Release 资产与固定版本安装。
 
 目标是在不改变现有项目文件语义的前提下，为同一用户提供正式默认 Node 版本，让项目配置
 稳定覆盖全局选择，并让 `node`、`npm`、`npx`、`corepack`、`exec` 与诊断命令得到同一个

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,8 +1,8 @@
 # Pinset PRD
 
 文档状态：`产品基线`
-当前发布版本：`v0.1.0-alpha.1`
-更新时间：2026-08-11
+当前发布候选：`v0.1.0-alpha.2`
+更新时间：2026-08-12
 
 ## 文档关系
 
@@ -10,7 +10,7 @@
   如何工作以及明确不做什么。
 - [Plans](PLANS.md) 定义各版本范围、实施顺序和发布门禁。
 - [发布说明](RELEASE_NOTES.md) 只记录已经交付的用户可见变化。
-- 本文件中的“当前”均指 `v0.1.0-alpha.1`；标记为“计划”的契约尚不能当作可用命令。
+- 本文件中的“当前”均指 `v0.1.0-alpha.2` 发布候选；标记为“计划”的契约尚不能当作可用命令。
 
 ## 1. 产品定位
 
@@ -264,7 +264,7 @@ shim 让现有的 `node`、`npm`、`python`、`flutter` 等命令根据当前目
 
 Pinset 的产品目标平台是 Windows、macOS 和 Linux；WSL 按独立 Linux 环境处理。
 
-当前 `v0.1.0-alpha.1`：
+当前 `v0.1.0-alpha.2` 发布候选：
 
 | 能力 | Windows x64 | Linux x64 | macOS x64 | macOS arm64 |
 | --- | --- | --- | --- | --- |
@@ -310,24 +310,23 @@ Pinset 默认无遥测，因此产品验证主要来自公开 Issue、用户主�
 
 ## 13. 当前版本边界
 
-`v0.1.0-alpha.1` 已经完成 Node 项目级精确版本闭环和公开三平台 CI/CD，但尚未完成
-正式全局选择、系统 PATH 透传、浮动版本、卸载、CPython 和 Flutter。
-
-下一版本 `v0.1.0-alpha.2` 只聚焦全局/项目/系统解析，不同时扩展新的 provider。完整范围
-和发布门禁见 [Plans](PLANS.md#2-v010-alpha2--global-and-project-resolution)。
+`v0.1.0-alpha.2` 发布候选已经完成 Node 项目级精确版本闭环、正式全局选择、安全系统 PATH
+透传、来源感知诊断、中英文界面和公开三平台 CI/CD。浮动版本、卸载、CPython 与 Flutter
+仍未交付。完整范围和发布门禁见
+[Plans](PLANS.md#2-v010-alpha2--global-and-project-resolution)。
 
 ## 14. 命令契约与交付状态
 
-| 命令 | alpha.1 | 目标契约 |
+| 命令 | 交付状态 | 目标契约 |
 | --- | --- | --- |
 | `pinset init` | 已实现 | 创建最小项目配置，已有文件时拒绝覆盖 |
 | `pinset use node@x.y.z` | 已实现 | 更新项目配置与锁，并安装当前平台 |
 | `pinset use node@x.y.z --no-install` | 已实现 | 只更新项目配置和锁 |
-| `pinset use node@x.y.z --global` | alpha.2 | 更新用户级全局选择，不修改项目 |
+| `pinset use node@x.y.z --global` | 已实现 | 更新用户级全局选择，不修改项目 |
 | `pinset install --locked` | 已实现 | 配置与锁不匹配时失败，安装当前目标 |
-| `pinset install --global --locked` | alpha.2 | 根据全局锁恢复当前目标 |
+| `pinset install --global --locked` | 已实现 | 根据全局锁恢复当前目标 |
 | `pinset current` | 已实现 | 显示项目选择和安装路径 |
-| `pinset current [tool]` | alpha.2 | 显示工具、精确版本、来源和路径 |
+| `pinset current [tool]` | 已实现 | 显示工具、精确版本、来源和路径 |
 | `pinset which <command>` | 已实现 | 显示将执行的真实文件 |
 | `pinset which <command> --sdk` | Flutter 阶段 | 返回 SDK 根路径供 IDE/脚本使用 |
 | `pinset exec -- <command>` | 已实现 | 使用当前项目运行时执行并返回子进程退出码 |
@@ -337,7 +336,7 @@ Pinset 默认无遥测，因此产品验证主要来自公开 Issue、用户主�
 | `pinset source list/add/use/fallback/remove` | 已实现 | 管理本机传输源，不修改项目锁 |
 | `pinset source test` | alpha.3 | 只读检测 DNS/TLS/HTTP/路径和校验能力 |
 | `pinset list`、`uninstall`、`import` | alpha.3+ | 版本生命周期和显式迁移 |
-| `pinset --lang <en\|zh-CN>` | alpha.2 | 无子命令时保存界面语言，带子命令时仅覆盖本次输出 |
+| `pinset --lang <en\|zh-CN>` | 已实现 | 无子命令时保存界面语言，带子命令时仅覆盖本次输出 |
 
 计划命令只有在对应版本发布后才成为兼容承诺。脚本不得依赖未冻结的参数、输出文本或退出码。
 
@@ -358,7 +357,7 @@ Pinset 默认无遥测，因此产品验证主要来自公开 Issue、用户主�
 
 ### 15.1 当前项目配置
 
-`pinset.toml` 是不可执行数据，应提交版本控制。alpha.1 只接受精确 Node 版本：
+`pinset.toml` 是不可执行数据，应提交版本控制。当前只接受精确 Node 版本：
 
 ```toml
 schema = 1
@@ -386,7 +385,7 @@ node = "24.0.0"
 
 ```toml
 schema = 1
-generated_by = "pinset 0.1.0-alpha.1"
+generated_by = "pinset 0.1.0-alpha.2"
 
 [[tool]]
 name = "node"
@@ -524,7 +523,7 @@ Node semver、Python 构建标签和 Flutter channel/ref 不能强制共用同�
 ### 17.1 安装 Pinset
 
 Linux x64 和 macOS Apple Silicon 的固定预发布安装命令、Release 资产和校验方式见
-[v0.1.0-alpha.1 发布说明](RELEASE_NOTES.md#linux-x64--macos-apple-silicon-安装)。
+[v0.1.0-alpha.2 发布说明](RELEASE_NOTES.md#linux-x64--macos-apple-silicon-安装)。
 
 默认安装器把 `pinset` 与 `pinset-shim` 放到 `$HOME/.local/bin`，不使用 `sudo`，不修改
 PATH，也不安装 Node。
@@ -553,7 +552,7 @@ pinset install --locked
 
 ### 17.3 执行与查询
 
-不安装 shim 也可以完整使用 alpha.1：
+不安装 shim 也可以完整使用 alpha.2：
 
 ```bash
 pinset current
@@ -700,8 +699,8 @@ cargo test --workspace --all-features
 pinset doctor
 ```
 
-alpha.1 会只读检查数据目录、最近项目配置、锁匹配、当前目标安装、shim PATH 和其他 Node
-候选。常见问题：
+alpha.2 会只读检查数据目录、最近项目配置、正式全局状态、锁匹配、当前目标安装、shim PATH
+和其他 Node 候选。常见问题：
 
 - `pinset.toml was not found`：进入项目目录或先执行 `pinset init`。
 - `lockfile does not match`：执行 `pinset use node@完整版本 --no-install` 并审查锁文件。

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -3,6 +3,106 @@
 本文档记录 Pinset 各版本已经交付的主要变化。未来范围与开发状态请参阅
 [Plans](PLANS.md)，计划中的功能不会提前写成已发布能力。
 
+## v0.1.0-alpha.2
+
+- 版本日期：2026-08-12
+- 发布阶段：Alpha 预发布候选
+- 许可证：MIT License
+- Pinset CLI 产物：Linux x64、Windows x64、macOS Apple Silicon
+- Node.js 运行时目标：Windows x64、Linux x64、macOS x64、macOS arm64
+- GitHub Release：[v0.1.0-alpha.2](https://github.com/Future-Element/pinset/releases/tag/v0.1.0-alpha.2)
+
+### 更新内容
+
+- 新增正式全局 Node 选择：
+
+  ```shell
+  pinset use node@24.0.0 --global
+  pinset install --global --locked
+  ```
+
+  全局状态保存在 `$PINSET_HOME/state/global.toml` 和 `global.lock`，不会写入当前项目或
+  `$HOME/pinset.toml`。
+- 统一 Node 解析顺序：最近项目配置优先，其次是 Pinset 全局选择，最后才是排除 Pinset
+  shim 后的系统 PATH。离开项目后自动恢复全局选择。
+- 项目或全局已经声明 Node、但对应安装缺失或损坏时失败关闭，不会静默使用低优先级版本。
+- `current`、`which`、`exec`、`doctor` 和 shim 共用同一来源感知解析结果，可区分
+  `project`、`global` 与 `system`。
+- `node`、`npm`、`npx` 和 `corepack` 使用同一所选 Node 命令目录；子进程 PATH 支持
+  `/usr/bin/env node` 启动方式。
+- 系统 Node 透传会排除 Pinset shim 目录和当前 shim 文件，防止直接或间接递归。
+- 新增英文与简体中文界面。无子命令时持久保存语言：
+
+  ```shell
+  pinset --lang zh-CN
+  ```
+
+  带子命令时只覆盖本次输出：`pinset --lang en doctor`。也可使用 `PINSET_LANG` 覆盖当前
+  进程；持久设置保存在 `$PINSET_HOME/settings.toml`，不修改项目文件。
+- 正常提示、诊断、帮助、参数错误和常见运行错误均接入同一语言目录；路径、版本和底层系统
+  错误仍保留原始技术值。
+- 保持 alpha.1 的 `schema = 1` 项目配置和锁文件兼容，不要求迁移现有项目。
+- CI 新增仅手动触发的隔离 Ubuntu 真实运行时验收，普通 PR 不重复下载真实 Node。
+
+### 验证范围
+
+- 78 项 workspace 测试、格式、Clippy、锁定 Release 构建、curl 安装器离线测试与 shim
+  轻依赖检查通过。
+- Linux x64、Windows x64、macOS arm64 Release 归档构建通过。
+- 一次性 Ubuntu Runner 使用临时 `PINSET_HOME` 安装 Node 24.0.0 全局版本与 Node 22.0.0
+  项目版本，验证项目覆盖、离开项目恢复全局版本、node/npm/corepack 和中文提示。
+- 未在开发者 Windows 或 WSL 环境安装真实运行时。
+- 尚未完成 Windows 与 macOS 真实 Node 的人工流程验收；三平台构建通过不等同于三平台
+  真实运行时安装均已验收。
+
+### Linux x64 / macOS Apple Silicon 安装
+
+该版本发布后使用固定预发布 URL：
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/Future-Element/pinset/releases/download/v0.1.0-alpha.2/install.sh |
+  sh -s -- --version 0.1.0-alpha.2
+```
+
+默认安装到 `$HOME/.local/bin`。安装器不使用 `sudo`、不修改 shell profile 或 PATH、
+不安装 Node，并强制校验 Release 的 SHA-256。
+
+### 全局与项目版本
+
+设置全局版本：
+
+```shell
+pinset use node@24.0.0 --global
+pinset current
+pinset exec -- node --version
+```
+
+在项目中覆盖全局版本：
+
+```shell
+mkdir demo && cd demo
+pinset init
+pinset use node@22.0.0
+pinset current
+pinset exec -- node --version
+```
+
+离开项目后，`pinset current` 与 shim 会重新解析到全局版本。若没有项目和全局声明，Pinset
+才会安全透传系统 PATH 中的相应 Node 命令。
+
+### 说明与已知限制
+
+- 仍只接受完整精确版本 `x.y.z`，不支持 `node@24`、`lts`、`latest` 或 `current`。
+- Python、Flutter、版本列表、卸载、浮动选择器和旧管理器导入尚未发布。
+- macOS x64 Node 产物可以写入锁文件，但本版本没有 macOS Intel Pinset CLI 归档。
+- curl 安装器支持 Linux x64 和 macOS Apple Silicon；Windows 使用 Release ZIP。
+- shim 仍需用户显式安装到自有目录并加入 PATH；Pinset 不修改 shell profile。
+- `$HOME/pinset.toml` 仍按普通最近项目配置处理，不会自动迁移或删除。
+- 系统 PATH 透传限于当前 Node-first 命令集合，不代表任意工具或 Shell activation。
+- Node 信任值仍来自官方 HTTPS `SHASUMS256.txt`；PGP 验签属于稳定版前的供应链增强。
+- 项目不维护第三方 Homebrew Tap、Scoop Bucket 或社区镜像 preset。
+
 ## v0.1.0-alpha.1
 
 - 版本日期：2026-08-11


### PR DESCRIPTION
## Summary

- bump the workspace and lockfile version to `0.1.0-alpha.2`
- update README installation, global selection, and language examples
- freeze the alpha.2 PRD and Plans delivery boundary
- add alpha.2 release notes, validation evidence, upgrade compatibility, and known limitations

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features --locked` (78 tests)
- `cargo build --release --locked -p pinset-cli -p pinset-shim`
- `target/release/pinset --version` reports `pinset 0.1.0-alpha.2`
- no real runtime was installed on the developer machine

## Release boundary

- this PR does not create or push `v0.1.0-alpha.2`
- tag publication and public Release verification remain a separate approval gate
- Windows and macOS real Node smoke testing remains explicitly unperformed