### PR TITLE
Release Pinset 0.2.0 with pnpm and Bun management

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
             artifact: pinset-macos-aarch64
             archive: pinset-macos-aarch64.tar.gz
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 60
     permissions:
       contents: read
       id-token: write
@@ -126,22 +126,26 @@ jobs:
       - name: Build release binaries
         run: cargo build --release --locked -p pinset-cli -p pinset-shim
 
-      - name: Run real Node acceptance on Linux and macOS
+      - name: Run real Node, pnpm and Bun acceptance on Linux and macOS
         if: runner.os != 'Windows'
         shell: bash
         env:
           PINSET_BIN: ${{ github.workspace }}/target/release/pinset
           PINSET_GLOBAL_VERSION: 24.0.0
           PINSET_PROJECT_VERSION: 22.0.0
+          PINSET_PNPM_VERSION: 11.21.0
+          PINSET_BUN_VERSION: 1.3.14
         run: bash scripts/tests/ubuntu_runtime_acceptance.sh
 
-      - name: Run real Node acceptance on Windows
+      - name: Run real Node, pnpm and Bun acceptance on Windows
         if: runner.os == 'Windows'
         shell: pwsh
         env:
           PINSET_BIN: ${{ github.workspace }}\target\release\pinset.exe
           PINSET_GLOBAL_VERSION: 24.0.0
           PINSET_PROJECT_VERSION: 22.0.0
+          PINSET_PNPM_VERSION: 11.21.0
+          PINSET_BUN_VERSION: 1.3.14
         run: ./scripts/tests/windows_runtime_acceptance.ps1
 
       - name: Test Unix curl installer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Pinset
 
-感谢你帮助改进 Pinset。项目当前处于 Node-first alpha 阶段，优先保证跨平台行为、安全边界和可复现安装，而不是快速扩大 provider 数量。
+感谢你帮助改进 Pinset。项目当前支持 Node、pnpm 与 Bun Provider，优先保证跨平台行为、安全边界和可复现安装。
 
 ## 开发环境
 
@@ -27,7 +27,7 @@ Windows 完整卸载脚本使用独立 PowerShell 临时目录测试：
 ./scripts/tests/uninstall_ps1_test.ps1
 ```
 
-这些测试不会安装真实 Node、Python 或 Flutter。真实运行时烟雾测试应在明确隔离的临时环境中进行，并在 PR 中说明平台与结果。
+这些测试不会安装真实 Node、pnpm、Bun、Python 或 Flutter。真实运行时烟雾测试应在明确隔离的临时环境中进行，并在 PR 中说明平台与结果。
 
 ## Pull Request
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +83,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,10 +134,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
@@ -120,11 +159,41 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -170,7 +239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -240,6 +309,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +366,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -290,12 +392,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -311,13 +446,25 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -336,6 +483,40 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "equivalent"
@@ -360,6 +541,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +572,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
+ "crc32fast",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -460,6 +652,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
+ "zeroize",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +702,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +729,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "http"
@@ -924,6 +1147,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,7 +1181,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "0.1.0-beta.1"
+version = "0.2.0"
 dependencies = [
  "clap",
  "pinset-core",
@@ -951,16 +1195,20 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "0.1.0-beta.1"
+version = "0.2.0"
 dependencies = [
  "atomic-write-file",
+ "base64",
+ "flate2",
  "fs4",
  "hex",
+ "p256",
  "reqwest",
  "same-file",
+ "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tar",
  "tempfile",
  "thiserror",
@@ -972,10 +1220,20 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "0.1.0-beta.1"
+version = "0.2.0"
 dependencies = [
  "pinset-core",
  "tempfile",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -1000,6 +1258,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1122,6 +1389,15 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
@@ -1179,6 +1455,16 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -1323,6 +1609,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,13 +1705,24 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1419,6 +1730,16 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -1462,6 +1783,16 @@ checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -1649,6 +1980,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,12 +2052,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1804,6 +2153,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,19 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.85"
-version = "0.1.0-beta.1"
+version = "0.2.0"
 authors = ["Future Element"]
 
 [workspace.dependencies]
 atomic-write-file = "0.3"
+base64 = "0.22"
 clap = { version = "4.5", features = ["derive"] }
+flate2 = "1"
 hex = "0.4"
 fs4 = "1.1.0"
-reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "rustls", "system-proxy"] }
+p256 = { version = "0.13", features = ["ecdsa", "pem"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "brotli", "gzip", "rustls", "system-proxy"] }
+semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 same-file = "1"

--- a/README.md
+++ b/README.md
@@ -5,17 +5,18 @@
 
 Pinset 是一个本地优先的多语言运行时版本管理 CLI。目标是用一致的命令管理 Node.js、Python、Flutter 等运行时，减少在 fnm、nvm、uv、FVM 之间切换的学习和维护成本。
 
-`v0.1.0-beta.1` 目前专注 Node.js，Python 和 Flutter 尚未支持。当前功能包括：
+`v0.2.0` 在已验证的 Node.js 管理基础上新增独立的 pnpm 与 Bun Provider。Python 和 Flutter 尚未支持。当前功能包括：
 
 - 全局 Node 默认版本、项目级 Node 覆盖，以及离开项目后恢复全局版本；
 - `node@24.0.0`、`node@24`、`node@24.12`、`node@lts`、`node@current`；
+- pnpm 10/11 与 Bun 1.x 的精确、主版本、主次版本、`latest`/`current` 选择器；
 - Windows x64、Linux x64、macOS Apple Silicon 的 Pinset Release；
-- `node`、`npm`、`npx`、`corepack` 统一路由，无需把每个工具复制进安装脚本；
+- `node`、`npm`、`npx`、`corepack`、`pnpm`、`bun`、`bunx` 统一路由；
 - 可提交的 `pinset.toml` 和 `pinset.lock`；
-- SHA-256 校验、安全解压、事务安装、并发安装锁、断点续传和内容寻址缓存；
+- Node SHA-256、npm SHA-512 SRI 与 registry ECDSA 签名校验、安全解压、事务安装、并发安装锁、断点续传和内容寻址缓存；
 - 国内或企业镜像、有序回退、可选的可信元数据镜像和离线缓存导入；
 - 中英文提示、旧 Node 管理器配置导入、诊断、安全卸载；
-- 三平台自动构建、真实 Node 验收、CycloneDX SBOM 和 GitHub 构建来源证明。
+- 三平台自动构建、真实 Node/pnpm/Bun 验收、CycloneDX SBOM 和 GitHub 构建来源证明。
 
 ## 快速安装
 
@@ -36,10 +37,10 @@ pinset --version
 
 长期使用可自行把 `export PATH=...` 写入 `~/.bashrc` 或 `~/.zshrc`。Pinset 不会擅自修改这些文件。
 
-安装指定版本：
+固定安装 `v0.2.0`：
 
 ```bash
-curl -fsSL https://github.com/Future-Element/pinset/releases/download/v0.1.0-beta.1/install.sh | sh
+curl -fsSL https://github.com/Future-Element/pinset/releases/download/v0.2.0/install.sh | sh
 ```
 
 自定义安装目录：
@@ -123,13 +124,15 @@ node --version
 
 ```toml
 # pinset.toml
-schema = 1
+schema = 2
 
 [tools]
-node = "22"
+node = "22.0.0"
+pnpm = "11.21.0"
+bun = "1.3.14"
 ```
 
-`pinset.lock` 保存解析后的精确版本、平台归档、SHA-256 和来源信息。建议把 `pinset.toml` 与 `pinset.lock` 一起提交。
+`pinset.lock` 保存解析后的精确版本、平台归档、完整性值和来源信息。Node 使用官方 SHA-256；pnpm/Bun 使用 npm 包的 SHA-512 SRI，并在生成锁文件前验证 registry ECDSA 签名。建议把 `pinset.toml` 与 `pinset.lock` 一起提交。
 
 在项目目录中，项目版本优先于全局版本；离开项目目录后自动恢复全局版本。如果项目或全局声明了版本但安装缺失，Pinset 会明确报错，不会静默换成系统 Node。
 
@@ -167,6 +170,36 @@ pinset unset node --global
 | `node@current` | 最新 Current 版本 |
 
 浮动选择器只用于输入；Pinset 在锁文件中始终记录精确版本。
+
+## pnpm 与 Bun
+
+pnpm 和 Bun 与 Node 一样既可设为项目版本，也可设为全局默认，而且都支持查看官方可用版本：
+
+```shell
+pinset list pnpm --available
+pinset list bun --available
+
+pinset use pnpm@11
+pinset use bun@1.3
+pinset install --locked
+
+pinset current pnpm
+pinset current bun
+pnpm --version
+bun --version
+bunx --version
+```
+
+当前支持范围：
+
+| Provider | 稳定版本 | 命令 | 分发来源 |
+| --- | --- | --- | --- |
+| pnpm | 10、11 | `pnpm` | `@pnpm/exe` 对应的官方平台包 |
+| Bun | 1.x | `bun`、`bunx` | `bun` 对应的 `@oven` 官方平台包 |
+
+pnpm 与 Bun 是独立运行时，不依赖已选择的 Node，也不通过 Corepack 安装。Bun 在 x64 上会根据当前 CPU 自动选择 AVX2 或 baseline 包，并把变体写入安装目标。多个 Provider 同时选择时，Pinset 为子进程构造组合 PATH；所选运行时目录排在前面，Pinset 自己的 shim 目录会被排除，因此 pnpm 脚本调用 Node、Node 脚本调用 Bun 时不会递归进入 shim。
+
+精确版本可离线解析选择器，但生成可安装锁仍需读取官方 npm 单版本元数据并验证包签名。`list --available` 使用 npm abbreviated metadata，过滤预发布版本以及缺少任一受支持平台包的版本。
 
 ### 解析优先级
 
@@ -209,9 +242,9 @@ pinset exec node@24.0.0 -- node --version
 pinset install node@20
 ```
 
-### 直接运行 node、npm、npx、corepack
+### 直接运行 Provider 命令
 
-正常执行 `global`、`use` 或 `install` 后，Node Provider 会一起注册四个命令的通用路由，不再要求用户先执行 `pinset shim install`。curl 安装器本身仍然保持运行时中立，只安装 Pinset 和通用调度器。
+正常执行 `global`、`use` 或 `install` 后，各 Provider 会注册自己的通用路由：Node 注册四个命令，pnpm 注册 `pnpm`，Bun 注册 `bun` 和 `bunx`。curl 安装器本身仍然保持运行时中立，只安装 Pinset 和通用调度器。
 
 如果使用源码构建、定制安装目录，或当前终端还没有路由目录，可以临时激活：
 
@@ -231,6 +264,8 @@ pinset activate powershell | Out-String | Invoke-Expression
 ```shell
 pinset shim path
 pinset shim install --provider node
+pinset shim install --provider pnpm
+pinset shim install --provider bun
 pinset shim migrate --provider node
 ```
 
@@ -286,7 +321,7 @@ pinset source add node lan \
 正在下载 node-v24.0.0-linux-x64.tar.xz [==========          ] 50% 15.0 MiB/30.0 MiB
 ```
 
-网络中断后再次执行相同安装命令，Pinset 会从内容寻址的 `.part` 文件继续下载，并校验服务端 `Content-Range`。服务端不支持 Range 时会安全地从头下载。只有完整 SHA-256 校验通过后才会进入安装和完成提示。
+网络中断后再次执行相同安装命令，Pinset 会从按算法分仓的内容寻址 `.part` 文件继续下载，并校验服务端 `Content-Range`。服务端不支持 Range 时会安全地从头下载。只有完整 SHA-256 或 SHA-512 校验通过后才会进入安装和完成提示。
 
 ### 离线缓存
 
@@ -308,6 +343,14 @@ pinset install --locked
 ```
 
 导入只接受普通文件，限制大小，并在原子写入内容寻址缓存前重新计算 SHA-256。哈希应来自已审阅的 `pinset.lock` 或上游校验清单。
+
+pnpm/Bun 的 npm SRI 可直接从锁文件导入：
+
+```shell
+pinset cache import ./platform-package.tgz \
+  --integrity 'sha512-<base64>'
+pinset install --locked
+```
 
 ## 查询、诊断、迁移和卸载
 
@@ -426,7 +469,7 @@ cargo test --workspace --all-features
 cargo build --release --locked -p pinset-cli -p pinset-shim
 ```
 
-本地 Rust 测试只使用临时目录、假归档、本地 HTTP 服务和假运行时，不会安装真实 Node。Release 工作流会在 Linux、Windows、macOS 的隔离 GitHub Runner 中安装两个真实 Node 版本，验证全局/项目切换以及 `node`、`npm`、`npx`、`corepack` 的两种调用方式。
+本地 Rust 测试只使用临时目录、假归档、本地 HTTP 服务和假运行时，不会安装真实运行时。Release 工作流会在 Linux、Windows、macOS 的隔离 GitHub Runner 中安装两个真实 Node 版本、一个 pnpm 版本和一个 Bun 版本，验证全局/项目组合、项目覆盖、跨 Provider 子进程 PATH，以及七个受管命令的 `pinset exec`/shim 调用方式。
 
 Linux/WSL 构建产物：
 
@@ -439,10 +482,10 @@ Windows 构建产物是 `.exe`，不能直接作为 WSL/Linux 程序使用；需
 
 ## Beta 限制
 
-- 当前只完整支持 Node.js；Python、Flutter 和其他 Provider 尚未开放。
+- 当前支持 Node.js、pnpm 和 Bun；Python、Flutter 和其他 Provider 尚未开放。
 - Pinset Release 暂无 Linux arm64、macOS Intel 安装包。
 - 项目不维护第三方 Homebrew Tap 或 Scoop Bucket；使用 curl、Release 归档或源码构建。
-- Pinset 会校验 Node 官方 HTTPS `SHASUMS256.txt` 中的 SHA-256，但 Beta 尚未验证该清单的上游 OpenPGP 签名。
+- Pinset 会校验 Node 官方 HTTPS `SHASUMS256.txt` 中的 SHA-256，但 Beta 尚未验证该清单的上游 OpenPGP 签名；pnpm/Bun 则校验 npm SHA-512 SRI 和 registry ECDSA 签名。
 - Pinset 不自动修改 shell profile、系统 PATH 或 IDE 配置。
 - 这是预发布版本，配置 schema 仍可能在稳定版前调整；任何迁移都会在 Release Notes 中说明。
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-Pinset 仍处于 alpha 阶段，目前只对最新 GitHub Release 提供安全修复。预发布版本可能包含不兼容变更。
+Pinset 仍处于预发布阶段，目前只对最新 GitHub Release 提供安全修复。预发布版本可能包含不兼容变更。
 
 ## Reporting a vulnerability
 

--- a/crates/pinset-core/Cargo.toml
+++ b/crates/pinset-core/Cargo.toml
@@ -9,6 +9,8 @@ publish = false
 [features]
 default = []
 installer = [
+    "dep:base64",
+    "dep:flate2",
     "dep:fs4",
     "dep:hex",
     "dep:reqwest",
@@ -18,9 +20,17 @@ installer = [
     "dep:xz2",
     "dep:zip",
 ]
-lockfile = ["node-provider", "dep:atomic-write-file"]
+lockfile = ["node-provider", "dep:atomic-write-file", "dep:base64", "dep:hex"]
 node-metadata = ["lockfile", "dep:reqwest", "dep:serde_json"]
 node-provider = ["sources"]
+npm-metadata = [
+    "lockfile",
+    "sources",
+    "dep:p256",
+    "dep:reqwest",
+    "dep:semver",
+    "dep:serde_json",
+]
 project-write = ["dep:atomic-write-file", "dep:tempfile"]
 state-write = ["dep:atomic-write-file"]
 sources = [
@@ -30,10 +40,14 @@ sources = [
 
 [dependencies]
 atomic-write-file = { workspace = true, optional = true }
+base64 = { workspace = true, optional = true }
+flate2 = { workspace = true, optional = true }
 hex = { workspace = true, optional = true }
 fs4 = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
+p256 = { workspace = true, optional = true }
 same-file.workspace = true
+semver = { workspace = true, optional = true }
 serde.workspace = true
 serde_json = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }

--- a/crates/pinset-core/src/config.rs
+++ b/crates/pinset-core/src/config.rs
@@ -14,8 +14,9 @@ use serde::{Deserialize, Serialize};
 use crate::{Error, Result};
 
 pub const PROJECT_CONFIG_FILENAME: &str = "pinset.toml";
+pub const PROJECT_CONFIG_SCHEMA: u32 = 2;
 #[cfg(feature = "project-write")]
-const MINIMAL_PROJECT_CONFIG: &[u8] = b"schema = 1\n\n[tools]\n";
+const MINIMAL_PROJECT_CONFIG: &[u8] = b"schema = 2\n\n[tools]\n";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -69,7 +70,7 @@ pub fn load_project_config(path: &Path) -> Result<ProjectConfig> {
             source,
         })?;
 
-    if config.schema != 1 {
+    if !matches!(config.schema, 1 | PROJECT_CONFIG_SCHEMA) {
         return Err(Error::UnsupportedSchema {
             actual: config.schema,
         });
@@ -111,12 +112,14 @@ pub fn create_project_config(directory: &Path) -> Result<PathBuf> {
 
 #[cfg(feature = "project-write")]
 pub fn save_project_config(path: &Path, config: &ProjectConfig) -> Result<()> {
-    if config.schema != 1 {
+    if !matches!(config.schema, 1 | PROJECT_CONFIG_SCHEMA) {
         return Err(Error::UnsupportedSchema {
             actual: config.schema,
         });
     }
-    let serialized = toml::to_string_pretty(config)
+    let mut normalized = config.clone();
+    normalized.schema = PROJECT_CONFIG_SCHEMA;
+    let serialized = toml::to_string_pretty(&normalized)
         .map_err(|source| Error::SerializeProjectConfig { source })?;
     let mut file =
         AtomicWriteFile::options()
@@ -185,10 +188,10 @@ mod tests {
     fn rejects_unknown_schema() {
         let root = tempdir().expect("temp directory");
         let config_path = root.path().join("pinset.toml");
-        fs::write(&config_path, "schema = 2\n[tools]\nnode = \"20\"\n").expect("config");
+        fs::write(&config_path, "schema = 3\n[tools]\nnode = \"20\"\n").expect("config");
 
         let error = load_project_config(&config_path).expect_err("schema must fail");
-        assert!(matches!(error, Error::UnsupportedSchema { actual: 2 }));
+        assert!(matches!(error, Error::UnsupportedSchema { actual: 3 }));
     }
 
     #[cfg(feature = "project-write")]
@@ -201,13 +204,13 @@ mod tests {
         assert_eq!(
             load_project_config(&path).expect("load created config"),
             ProjectConfig {
-                schema: 1,
+                schema: PROJECT_CONFIG_SCHEMA,
                 tools: BTreeMap::new(),
             }
         );
         assert_eq!(
             fs::read_to_string(path).expect("created config"),
-            "schema = 1\n\n[tools]\n"
+            "schema = 2\n\n[tools]\n"
         );
     }
 

--- a/crates/pinset-core/src/download_cache.rs
+++ b/crates/pinset-core/src/download_cache.rs
@@ -5,20 +5,18 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use sha2::{Digest, Sha256};
 use tempfile::Builder;
 
-use crate::{Error, Result};
+use crate::{ArtifactIntegrity, Error, IntegrityAlgorithm, Result};
 
 const CACHE_DIRECTORY: &str = "downloads";
-const SHA256_DIRECTORY: &str = "sha256";
 const PARTIAL_DIRECTORY: &str = "partial";
 const ARCHIVE_SUFFIX: &str = ".archive";
 const MAX_CACHE_IMPORT_BYTES: u64 = 1_073_741_824;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DownloadCacheEntry {
-    pub sha256: String,
+    pub integrity: String,
     pub size: u64,
     pub path: PathBuf,
 }
@@ -30,37 +28,60 @@ pub struct DownloadCacheCleanOutcome {
 }
 
 pub fn download_cache_path(pinset_home: &Path, sha256: &str) -> Result<PathBuf> {
-    if !is_sha256(sha256) {
+    let integrity = ArtifactIntegrity::parse(sha256).map_err(|_| Error::InvalidSha256 {
+        value: sha256.to_owned(),
+    })?;
+    if integrity.algorithm() != IntegrityAlgorithm::Sha256 {
         return Err(Error::InvalidSha256 {
             value: sha256.to_owned(),
         });
     }
+    download_cache_path_for_integrity(pinset_home, &integrity)
+}
+
+pub(crate) fn download_cache_path_for_integrity(
+    pinset_home: &Path,
+    integrity: &ArtifactIntegrity,
+) -> Result<PathBuf> {
     Ok(pinset_home
         .join(CACHE_DIRECTORY)
-        .join(SHA256_DIRECTORY)
-        .join(format!("{}.archive", sha256.to_ascii_lowercase())))
+        .join(integrity.algorithm().as_str())
+        .join(format!("{}.archive", integrity.cache_key())))
 }
 
 pub fn list_download_cache(pinset_home: &Path) -> Result<Vec<DownloadCacheEntry>> {
-    let root = pinset_home.join(CACHE_DIRECTORY).join(SHA256_DIRECTORY);
+    let mut cached = Vec::new();
+    for algorithm in [IntegrityAlgorithm::Sha256, IntegrityAlgorithm::Sha512] {
+        list_download_cache_algorithm(pinset_home, algorithm, &mut cached)?;
+    }
+    cached.sort_by_key(|entry| Reverse(entry.integrity.clone()));
+    Ok(cached)
+}
+
+fn list_download_cache_algorithm(
+    pinset_home: &Path,
+    algorithm: IntegrityAlgorithm,
+    cached: &mut Vec<DownloadCacheEntry>,
+) -> Result<()> {
+    let root = pinset_home.join(CACHE_DIRECTORY).join(algorithm.as_str());
     let entries = match fs::read_dir(&root) {
         Ok(entries) => entries,
-        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(source) => return Err(Error::ReadDownloadCache { path: root, source }),
     };
-    let mut cached = Vec::new();
     for entry in entries {
         let entry = entry.map_err(|source| Error::ReadDownloadCache {
             path: root.clone(),
             source,
         })?;
         let name = entry.file_name().to_string_lossy().into_owned();
-        let Some(sha256) = name.strip_suffix(ARCHIVE_SUFFIX) else {
+        let Some(hash) = name.strip_suffix(ARCHIVE_SUFFIX) else {
             continue;
         };
-        if !is_sha256(sha256) {
+        let candidate = format!("{}:{hash}", algorithm.as_str());
+        let Ok(integrity) = ArtifactIntegrity::parse(&candidate) else {
             continue;
-        }
+        };
         let metadata = entry
             .metadata()
             .map_err(|source| Error::ReadDownloadCache {
@@ -79,13 +100,12 @@ pub fn list_download_cache(pinset_home: &Path) -> Result<Vec<DownloadCacheEntry>
             return Err(Error::UnsafeDownloadCacheEntry { path: entry.path() });
         }
         cached.push(DownloadCacheEntry {
-            sha256: sha256.to_owned(),
+            integrity: integrity.canonical(),
             size: metadata.len(),
             path: entry.path(),
         });
     }
-    cached.sort_by_key(|entry| Reverse(entry.sha256.clone()));
-    Ok(cached)
+    Ok(())
 }
 
 pub fn clean_download_cache(pinset_home: &Path) -> Result<DownloadCacheCleanOutcome> {
@@ -103,21 +123,30 @@ pub fn clean_download_cache(pinset_home: &Path) -> Result<DownloadCacheCleanOutc
         outcome.bytes = outcome.bytes.saturating_add(entry.size);
     }
     let partial_root = pinset_home.join(CACHE_DIRECTORY).join(PARTIAL_DIRECTORY);
-    for entry in list_partial_downloads(&partial_root)? {
-        fs::remove_file(&entry.path).map_err(|source| Error::RemoveDownloadCacheEntry {
-            path: entry.path,
-            source,
-        })?;
-        outcome.entries += 1;
-        outcome.bytes = outcome.bytes.saturating_add(entry.size);
+    for algorithm in [IntegrityAlgorithm::Sha256, IntegrityAlgorithm::Sha512] {
+        let root = partial_root.join(algorithm.as_str());
+        for entry in list_partial_downloads(&root, algorithm)? {
+            fs::remove_file(&entry.path).map_err(|source| Error::RemoveDownloadCacheEntry {
+                path: entry.path,
+                source,
+            })?;
+            outcome.entries += 1;
+            outcome.bytes = outcome.bytes.saturating_add(entry.size);
+        }
+        remove_if_empty(&root)?;
     }
-    remove_if_empty(&pinset_home.join(CACHE_DIRECTORY).join(SHA256_DIRECTORY))?;
+    for algorithm in [IntegrityAlgorithm::Sha256, IntegrityAlgorithm::Sha512] {
+        remove_if_empty(&pinset_home.join(CACHE_DIRECTORY).join(algorithm.as_str()))?;
+    }
     remove_if_empty(&partial_root)?;
     remove_if_empty(&pinset_home.join(CACHE_DIRECTORY))?;
     Ok(outcome)
 }
 
-fn list_partial_downloads(root: &Path) -> Result<Vec<DownloadCacheEntry>> {
+fn list_partial_downloads(
+    root: &Path,
+    algorithm: IntegrityAlgorithm,
+) -> Result<Vec<DownloadCacheEntry>> {
     let entries = match fs::read_dir(root) {
         Ok(entries) => entries,
         Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
@@ -135,12 +164,13 @@ fn list_partial_downloads(root: &Path) -> Result<Vec<DownloadCacheEntry>> {
             source,
         })?;
         let name = entry.file_name().to_string_lossy().into_owned();
-        let Some(sha256) = name.strip_suffix(".part") else {
+        let Some(hash) = name.strip_suffix(".part") else {
             continue;
         };
-        if !is_sha256(sha256) {
+        let candidate = format!("{}:{hash}", algorithm.as_str());
+        let Ok(integrity) = ArtifactIntegrity::parse(&candidate) else {
             continue;
-        }
+        };
         let file_type = entry
             .file_type()
             .map_err(|source| Error::ReadDownloadCache {
@@ -157,7 +187,7 @@ fn list_partial_downloads(root: &Path) -> Result<Vec<DownloadCacheEntry>> {
                 source,
             })?;
         partials.push(DownloadCacheEntry {
-            sha256: sha256.to_owned(),
+            integrity: integrity.canonical(),
             size: metadata.len(),
             path: entry.path(),
         });
@@ -165,16 +195,28 @@ fn list_partial_downloads(root: &Path) -> Result<Vec<DownloadCacheEntry>> {
     Ok(partials)
 }
 
+#[cfg(test)]
 pub(crate) fn download_partial_path(pinset_home: &Path, sha256: &str) -> Result<PathBuf> {
-    if !is_sha256(sha256) {
+    let integrity = ArtifactIntegrity::parse(sha256).map_err(|_| Error::InvalidSha256 {
+        value: sha256.to_owned(),
+    })?;
+    if integrity.algorithm() != IntegrityAlgorithm::Sha256 {
         return Err(Error::InvalidSha256 {
             value: sha256.to_owned(),
         });
     }
+    download_partial_path_for_integrity(pinset_home, &integrity)
+}
+
+pub(crate) fn download_partial_path_for_integrity(
+    pinset_home: &Path,
+    integrity: &ArtifactIntegrity,
+) -> Result<PathBuf> {
     Ok(pinset_home
         .join(CACHE_DIRECTORY)
         .join(PARTIAL_DIRECTORY)
-        .join(format!("{}.part", sha256.to_ascii_lowercase())))
+        .join(integrity.algorithm().as_str())
+        .join(format!("{}.part", integrity.cache_key())))
 }
 
 pub fn import_download_cache(
@@ -182,8 +224,25 @@ pub fn import_download_cache(
     archive: &Path,
     expected_sha256: &str,
 ) -> Result<DownloadCacheEntry> {
-    let destination = download_cache_path(pinset_home, expected_sha256)?;
-    let expected_sha256 = expected_sha256.to_ascii_lowercase();
+    let integrity =
+        ArtifactIntegrity::parse(expected_sha256).map_err(|_| Error::InvalidSha256 {
+            value: expected_sha256.to_owned(),
+        })?;
+    if integrity.algorithm() != IntegrityAlgorithm::Sha256 {
+        return Err(Error::InvalidSha256 {
+            value: expected_sha256.to_owned(),
+        });
+    }
+    import_download_cache_with_integrity(pinset_home, archive, &integrity)
+}
+
+pub fn import_download_cache_with_integrity(
+    pinset_home: &Path,
+    archive: &Path,
+    integrity: &ArtifactIntegrity,
+) -> Result<DownloadCacheEntry> {
+    let destination = download_cache_path_for_integrity(pinset_home, integrity)?;
+    let expected = integrity.canonical();
     let metadata = fs::symlink_metadata(archive).map_err(|source| Error::ReadDownloadCache {
         path: archive.to_path_buf(),
         source,
@@ -201,15 +260,12 @@ pub fn import_download_cache(
     }
 
     if destination.exists() {
-        let (actual, size) = hash_file(&destination)?;
-        if actual != expected_sha256 {
-            return Err(Error::ChecksumMismatch {
-                expected: expected_sha256,
-                actual,
-            });
+        let (actual, size) = hash_file(&destination, integrity)?;
+        if actual != expected {
+            return Err(Error::ChecksumMismatch { expected, actual });
         }
         return Ok(DownloadCacheEntry {
-            sha256: actual,
+            integrity: actual,
             size,
             path: destination,
         });
@@ -233,7 +289,7 @@ pub fn import_download_cache(
             path: destination.clone(),
             source,
         })?;
-    let mut hasher = Sha256::new();
+    let mut hasher = integrity.hasher();
     let mut size = 0_u64;
     let mut buffer = [0_u8; 64 * 1024];
     loop {
@@ -261,12 +317,9 @@ pub fn import_download_cache(
                 source,
             })?;
     }
-    let actual = hex::encode(hasher.finalize());
-    if actual != expected_sha256 {
-        return Err(Error::ChecksumMismatch {
-            expected: expected_sha256,
-            actual,
-        });
+    let actual = integrity.canonical_digest(&hasher.finalize());
+    if actual != expected {
+        return Err(Error::ChecksumMismatch { expected, actual });
     }
     temporary
         .as_file()
@@ -278,7 +331,7 @@ pub fn import_download_cache(
     match temporary.persist_noclobber(&destination) {
         Ok(_) => {}
         Err(error) if error.error.kind() == io::ErrorKind::AlreadyExists => {
-            let (existing_hash, _) = hash_file(&destination)?;
+            let (existing_hash, _) = hash_file(&destination, integrity)?;
             if existing_hash != actual {
                 return Err(Error::ChecksumMismatch {
                     expected: actual,
@@ -294,13 +347,13 @@ pub fn import_download_cache(
         }
     }
     Ok(DownloadCacheEntry {
-        sha256: actual,
+        integrity: actual,
         size,
         path: destination,
     })
 }
 
-fn hash_file(path: &Path) -> Result<(String, u64)> {
+fn hash_file(path: &Path, integrity: &ArtifactIntegrity) -> Result<(String, u64)> {
     let metadata = fs::symlink_metadata(path).map_err(|source| Error::ReadDownloadCache {
         path: path.to_path_buf(),
         source,
@@ -314,7 +367,7 @@ fn hash_file(path: &Path) -> Result<(String, u64)> {
         path: path.to_path_buf(),
         source,
     })?;
-    let mut hasher = Sha256::new();
+    let mut hasher = integrity.hasher();
     let mut size = 0_u64;
     let mut buffer = [0_u8; 64 * 1024];
     loop {
@@ -330,7 +383,7 @@ fn hash_file(path: &Path) -> Result<(String, u64)> {
         size = size.saturating_add(count as u64);
         hasher.update(&buffer[..count]);
     }
-    Ok((hex::encode(hasher.finalize()), size))
+    Ok((integrity.canonical_digest(&hasher.finalize()), size))
 }
 
 fn remove_if_empty(path: &Path) -> Result<()> {
@@ -351,13 +404,10 @@ fn remove_if_empty(path: &Path) -> Result<()> {
     }
 }
 
-fn is_sha256(value: &str) -> bool {
-    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sha2::{Digest, Sha256};
 
     #[test]
     fn lists_and_cleans_only_content_addressed_cache_entries() {
@@ -370,7 +420,7 @@ mod tests {
 
         let entries = list_download_cache(home.path()).expect("cache entries");
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].sha256, hash);
+        assert_eq!(entries[0].integrity, format!("sha256:{hash}"));
         assert_eq!(entries[0].size, 6);
 
         let outcome = clean_download_cache(home.path()).expect("clean cache");
@@ -412,7 +462,7 @@ mod tests {
 
         let imported =
             import_download_cache(home.path(), &source, &expected).expect("cache import");
-        assert_eq!(imported.sha256, expected);
+        assert_eq!(imported.integrity, format!("sha256:{expected}"));
         assert_eq!(
             fs::read(&imported.path).expect("cached"),
             b"offline node archive"

--- a/crates/pinset-core/src/error.rs
+++ b/crates/pinset-core/src/error.rs
@@ -368,6 +368,38 @@ pub enum Error {
         source: std::io::Error,
     },
 
+    #[error("failed to read {tool} installation directory {path}: {source}")]
+    ReadToolInstallDirectory {
+        tool: String,
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("{tool} {version} is not installed by Pinset")]
+    ToolVersionNotInstalled { tool: String, version: String },
+
+    #[error("invalid {tool} version {version:?}")]
+    InvalidToolVersion { tool: String, version: String },
+
+    #[error("refusing to uninstall {tool} {version}; it is selected by {references}")]
+    ToolVersionInUse {
+        tool: String,
+        version: String,
+        references: String,
+    },
+
+    #[error("unsafe or unowned {tool} installation entry: {path}")]
+    UnsafeToolInstallEntry { tool: String, path: PathBuf },
+
+    #[error("failed to remove {tool} installation {path}: {source}")]
+    RemoveToolInstall {
+        tool: String,
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
     #[cfg(feature = "node-metadata")]
     #[error("failed to request official Node.js metadata {url}: {source}")]
     NodeMetadataRequest {
@@ -403,6 +435,48 @@ pub enum Error {
     #[cfg(feature = "node-metadata")]
     #[error("Node.js {version} SHASUMS does not contain {filename}")]
     NodeChecksumMissing { version: String, filename: String },
+
+    #[cfg(feature = "npm-metadata")]
+    #[error(
+        "invalid {tool} selector {selector:?}; expected an exact, major, minor, latest or current selector"
+    )]
+    InvalidNpmToolSelector { tool: String, selector: String },
+
+    #[cfg(feature = "npm-metadata")]
+    #[error("no supported {tool} release matches selector {selector:?}")]
+    NpmToolSelectorNotFound { tool: String, selector: String },
+
+    #[cfg(feature = "npm-metadata")]
+    #[error("failed to request npm registry metadata {url}: {source}")]
+    NpmMetadataRequest {
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+
+    #[cfg(feature = "npm-metadata")]
+    #[error("failed while reading npm registry metadata {url}: {source}")]
+    NpmMetadataRead {
+        url: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[cfg(feature = "npm-metadata")]
+    #[error("npm registry metadata exceeds {limit} bytes")]
+    NpmMetadataTooLarge { limit: u64 },
+
+    #[cfg(feature = "npm-metadata")]
+    #[error("invalid npm registry metadata for {package}: {reason}")]
+    InvalidNpmMetadata { package: String, reason: String },
+
+    #[cfg(feature = "npm-metadata")]
+    #[error("npm registry signature verification failed for {package}@{version}: {reason}")]
+    NpmSignatureVerification {
+        package: String,
+        version: String,
+        reason: String,
+    },
 
     #[error("failed to create shim directory {path}: {source}")]
     CreateShimDirectory {
@@ -470,7 +544,17 @@ pub enum Error {
     #[error("invalid SHA-256 value \"{value}\"; expected 64 hexadecimal characters")]
     InvalidSha256 { value: String },
 
-    #[cfg(any(feature = "installer", feature = "node-metadata"))]
+    #[cfg(any(feature = "installer", feature = "lockfile", feature = "npm-metadata"))]
+    #[error(
+        "invalid artifact integrity \"{value}\"; expected sha256:<hex>, sha512:<hex> or npm sha512-<base64>"
+    )]
+    InvalidArtifactIntegrity { value: String },
+
+    #[cfg(any(
+        feature = "installer",
+        feature = "node-metadata",
+        feature = "npm-metadata"
+    ))]
     #[error("failed to build the HTTP client: {source}")]
     HttpClient {
         #[source]
@@ -526,7 +610,7 @@ pub enum Error {
     },
 
     #[cfg(feature = "installer")]
-    #[error("artifact SHA-256 mismatch: expected {expected}, got {actual}")]
+    #[error("artifact integrity mismatch: expected {expected}, got {actual}")]
     ChecksumMismatch { expected: String, actual: String },
 
     #[cfg(feature = "installer")]
@@ -637,6 +721,15 @@ pub enum Error {
     #[error("failed to atomically commit installation from {staging} to {destination}: {source}")]
     CommitInstall {
         staging: PathBuf,
+        destination: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[cfg(feature = "installer")]
+    #[error("failed to create runtime command alias {destination} from {source_path}: {source}")]
+    CreateRuntimeAlias {
+        source_path: PathBuf,
         destination: PathBuf,
         #[source]
         source: std::io::Error,

--- a/crates/pinset-core/src/global_state.rs
+++ b/crates/pinset-core/src/global_state.rs
@@ -14,9 +14,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Error, Result};
 #[cfg(all(feature = "state-write", feature = "lockfile"))]
-use crate::{Lockfile, save_lockfile, validate_lock_matches_selection};
+use crate::{Lockfile, save_lockfile, validate_lock_matches_tools};
 
-pub const GLOBAL_STATE_SCHEMA: u32 = 1;
+pub const GLOBAL_STATE_SCHEMA: u32 = 2;
 pub const GLOBAL_CONFIG_FILENAME: &str = "global.toml";
 pub const GLOBAL_LOCKFILE_FILENAME: &str = "global.lock";
 
@@ -89,7 +89,7 @@ pub fn load_optional_global_config(path: &Path) -> Result<Option<GlobalConfig>> 
 }
 
 fn validate_global_config(config: &GlobalConfig) -> Result<()> {
-    if config.schema != GLOBAL_STATE_SCHEMA {
+    if !matches!(config.schema, 1 | GLOBAL_STATE_SCHEMA) {
         return Err(Error::UnsupportedGlobalConfigSchema {
             actual: config.schema,
         });
@@ -100,8 +100,10 @@ fn validate_global_config(config: &GlobalConfig) -> Result<()> {
 #[cfg(feature = "state-write")]
 pub fn save_global_config(path: &Path, config: &GlobalConfig) -> Result<()> {
     validate_global_config(config)?;
-    let serialized =
-        toml::to_string_pretty(config).map_err(|source| Error::SerializeGlobalConfig { source })?;
+    let mut normalized = config.clone();
+    normalized.schema = GLOBAL_STATE_SCHEMA;
+    let serialized = toml::to_string_pretty(&normalized)
+        .map_err(|source| Error::SerializeGlobalConfig { source })?;
     let parent = path
         .parent()
         .ok_or_else(|| Error::CreateGlobalStateDirectory {
@@ -137,14 +139,7 @@ pub fn save_global_state(
     lockfile: &Lockfile,
 ) -> Result<()> {
     let config_path = global_config_path(pinset_home);
-    let configured = config
-        .tools
-        .get("node")
-        .ok_or_else(|| Error::ToolNotConfigured {
-            tool: "node".to_owned(),
-            config_path: config_path.clone(),
-        })?;
-    validate_lock_matches_selection(lockfile, configured, &config_path)?;
+    validate_lock_matches_tools(lockfile, &config.tools, &config_path)?;
 
     let _guard = GLOBAL_STATE_WRITE_LOCK
         .lock()
@@ -202,10 +197,10 @@ mod tests {
             Err(Error::ParseGlobalConfig { .. })
         ));
 
-        fs::write(&path, "schema = 2\n[tools]\n").expect("unsupported config");
+        fs::write(&path, "schema = 3\n[tools]\n").expect("unsupported config");
         assert!(matches!(
             load_global_config(&path),
-            Err(Error::UnsupportedGlobalConfigSchema { actual: 2 })
+            Err(Error::UnsupportedGlobalConfigSchema { actual: 3 })
         ));
     }
 
@@ -279,7 +274,7 @@ mod tests {
         let config = load_global_config(&config_path).expect("global config");
         let selected = config.tools.get("node").expect("node selection");
         let lockfile = crate::load_lockfile(&global_lockfile_path(&home)).expect("global lockfile");
-        validate_lock_matches_selection(&lockfile, selected, &config_path)
+        crate::validate_lock_matches_selection(&lockfile, selected, &config_path)
             .expect("matching global state");
     }
 
@@ -296,6 +291,7 @@ mod tests {
                     canonical_url: plan.canonical_url,
                     artifact_path: plan.artifact_path,
                     sha256: "ab".repeat(32),
+                    integrity: None,
                     format: match plan.format {
                         crate::NodeArchiveFormat::Zip => crate::LockedArtifactFormat::Zip,
                         crate::NodeArchiveFormat::TarXz => crate::LockedArtifactFormat::TarXz,

--- a/crates/pinset-core/src/installer.rs
+++ b/crates/pinset-core/src/installer.rs
@@ -7,6 +7,7 @@ use std::{
     time::Duration,
 };
 
+use flate2::read::GzDecoder;
 use reqwest::{
     StatusCode,
     blocking::Client,
@@ -18,12 +19,16 @@ use tempfile::Builder;
 use xz2::read::XzDecoder;
 use zip::ZipArchive;
 
-use crate::{Error, Result, download_cache::download_partial_path, download_cache_path};
+use crate::download_cache::{
+    download_cache_path_for_integrity, download_partial_path_for_integrity,
+};
+use crate::{ArtifactIntegrity, Error, Result};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ArtifactFormat {
     Zip,
     TarXz,
+    TarGz,
 }
 
 impl ArtifactFormat {
@@ -31,6 +36,7 @@ impl ArtifactFormat {
         match self {
             Self::Zip => "zip",
             Self::TarXz => "tar.xz",
+            Self::TarGz => "tar.gz",
         }
     }
 }
@@ -61,7 +67,7 @@ pub struct ArtifactSource {
 pub struct ArtifactSpec {
     pub canonical_url: String,
     pub sources: Vec<ArtifactSource>,
-    pub sha256: String,
+    pub integrity: String,
     pub format: ArtifactFormat,
 }
 
@@ -80,7 +86,7 @@ pub struct InstallRequest {
 pub struct InstallOutcome {
     pub install_dir: PathBuf,
     pub bytes_downloaded: u64,
-    pub sha256: String,
+    pub integrity: String,
     pub source_id: String,
     pub reused_existing: bool,
 }
@@ -133,7 +139,7 @@ struct SelectedArtifact {
     source_url: String,
     path: PathBuf,
     bytes_downloaded: u64,
-    actual_hash: String,
+    actual_integrity: String,
 }
 
 struct InstallLock {
@@ -170,7 +176,7 @@ impl Installer {
     pub fn install(&self, request: &InstallRequest) -> Result<InstallOutcome> {
         validate_request(request)?;
         let _install_lock = acquire_install_lock(request)?;
-        let expected_hash = parse_sha256(&request.artifact.sha256)?;
+        let expected_integrity = ArtifactIntegrity::parse(&request.artifact.integrity)?;
         let final_dir = request
             .pinset_home
             .join("installs")
@@ -200,27 +206,36 @@ impl Installer {
             source,
         })?;
 
-        let expected_hex = hex::encode(expected_hash);
-        let cache_path = download_cache_path(&request.pinset_home, &expected_hex)?;
-        let selected = if self.cached_artifact_is_valid(&cache_path, &expected_hash)? {
+        let cache_path =
+            download_cache_path_for_integrity(&request.pinset_home, &expected_integrity)?;
+        let selected = if self.cached_artifact_is_valid(&cache_path, &expected_integrity)? {
             SelectedArtifact {
                 source_id: "cache".to_owned(),
                 source_kind: "cache".to_owned(),
-                source_url: format!("cache:sha256:{expected_hex}"),
+                source_url: format!(
+                    "cache:{}:{}",
+                    expected_integrity.algorithm().as_str(),
+                    expected_integrity.cache_key()
+                ),
                 path: cache_path,
                 bytes_downloaded: 0,
-                actual_hash: expected_hex,
+                actual_integrity: expected_integrity.canonical(),
             }
         } else {
             let mut attempted = Vec::with_capacity(request.artifact.sources.len());
             let mut last_retryable_error = None;
             let mut selected = None;
-            let download_path = download_partial_path(&request.pinset_home, &expected_hex)?;
+            let download_path =
+                download_partial_path_for_integrity(&request.pinset_home, &expected_integrity)?;
             for source in &request.artifact.sources {
                 attempted.push(source.id.clone());
-                match self.download_verified(&source.url, &expected_hash, &download_path) {
-                    Ok((bytes_downloaded, actual_hash)) => {
-                        self.persist_cache_artifact(&download_path, &cache_path, &expected_hash)?;
+                match self.download_verified(&source.url, &expected_integrity, &download_path) {
+                    Ok((bytes_downloaded, actual_integrity)) => {
+                        self.persist_cache_artifact(
+                            &download_path,
+                            &cache_path,
+                            &expected_integrity,
+                        )?;
                         fs::remove_file(&download_path).map_err(|source| Error::WriteDownload {
                             path: download_path.clone(),
                             source,
@@ -231,7 +246,7 @@ impl Installer {
                             source_url: redacted_url(&source.url),
                             path: cache_path.clone(),
                             bytes_downloaded,
-                            actual_hash,
+                            actual_integrity,
                         });
                         break;
                     }
@@ -252,9 +267,18 @@ impl Installer {
             ArtifactFormat::Zip => {
                 self.extract_zip(&selected.path, &staging_dir, request.strip_components)?
             }
-            ArtifactFormat::TarXz => {
-                self.extract_tar_xz(&selected.path, &staging_dir, request.strip_components)?
-            }
+            ArtifactFormat::TarXz => self.extract_tar(
+                &selected.path,
+                &staging_dir,
+                request.strip_components,
+                ArtifactFormat::TarXz,
+            )?,
+            ArtifactFormat::TarGz => self.extract_tar(
+                &selected.path,
+                &staging_dir,
+                request.strip_components,
+                ArtifactFormat::TarGz,
+            )?,
         }
         validate_required_paths(&staging_dir, &request.required_paths)?;
         write_receipt(&staging_dir, request, &selected)?;
@@ -278,13 +302,17 @@ impl Installer {
         Ok(InstallOutcome {
             install_dir: final_dir,
             bytes_downloaded: selected.bytes_downloaded,
-            sha256: selected.actual_hash,
+            integrity: selected.actual_integrity,
             source_id: selected.source_id,
             reused_existing: false,
         })
     }
 
-    fn cached_artifact_is_valid(&self, path: &Path, expected_hash: &[u8; 32]) -> Result<bool> {
+    fn cached_artifact_is_valid(
+        &self,
+        path: &Path,
+        expected_integrity: &ArtifactIntegrity,
+    ) -> Result<bool> {
         let metadata = match fs::symlink_metadata(path) {
             Ok(metadata) => metadata,
             Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(false),
@@ -311,7 +339,7 @@ impl Installer {
             path: path.to_path_buf(),
             source,
         })?;
-        let mut hasher = Sha256::new();
+        let mut hasher = expected_integrity.hasher();
         let mut buffer = [0_u8; 64 * 1024];
         loop {
             let count = file
@@ -325,8 +353,8 @@ impl Installer {
             }
             hasher.update(&buffer[..count]);
         }
-        let actual: [u8; 32] = hasher.finalize().into();
-        if actual == *expected_hash {
+        let actual = hasher.finalize();
+        if actual == expected_integrity.expected_bytes() {
             return Ok(true);
         }
         fs::remove_file(path).map_err(|source| Error::RemoveDownloadCacheEntry {
@@ -340,7 +368,7 @@ impl Installer {
         &self,
         source: &Path,
         destination: &Path,
-        expected_hash: &[u8; 32],
+        expected_integrity: &ArtifactIntegrity,
     ) -> Result<()> {
         let parent = destination
             .parent()
@@ -372,7 +400,7 @@ impl Installer {
                 Ok(_) => return Ok(()),
                 Err(error) if error.error.kind() == io::ErrorKind::AlreadyExists => {
                     candidate = error.file;
-                    if self.cached_artifact_is_valid(destination, expected_hash)? {
+                    if self.cached_artifact_is_valid(destination, expected_integrity)? {
                         return Ok(());
                     }
                 }
@@ -396,10 +424,10 @@ impl Installer {
     fn download_verified(
         &self,
         url: &str,
-        expected_hash: &[u8; 32],
+        expected_integrity: &ArtifactIntegrity,
         destination: &Path,
     ) -> Result<(u64, String)> {
-        let result = self.download_verified_inner(url, expected_hash, destination);
+        let result = self.download_verified_inner(url, expected_integrity, destination);
         if result.is_err() {
             self.report_progress(DownloadProgressEvent::Failed);
         }
@@ -409,7 +437,7 @@ impl Installer {
     fn download_verified_inner(
         &self,
         url: &str,
-        expected_hash: &[u8; 32],
+        expected_integrity: &ArtifactIntegrity,
         destination: &Path,
     ) -> Result<(u64, String)> {
         let display_url = redacted_url(url);
@@ -448,7 +476,7 @@ impl Installer {
             }
         };
 
-        let mut hasher = Sha256::new();
+        let mut hasher = expected_integrity.hasher();
         if resume_from > 0 {
             let mut existing =
                 File::open(destination).map_err(|source| Error::ReadDownloadCache {
@@ -469,8 +497,8 @@ impl Installer {
                 }
                 hasher.update(&buffer[..count]);
             }
-            let existing_hash: [u8; 32] = hasher.clone().finalize().into();
-            if existing_hash == *expected_hash {
+            let existing_hash = hasher.clone().finalize();
+            if existing_hash == expected_integrity.expected_bytes() {
                 self.report_progress(DownloadProgressEvent::Started {
                     url: display_url,
                     total_bytes: Some(resume_from),
@@ -478,7 +506,7 @@ impl Installer {
                 self.report_progress(DownloadProgressEvent::Finished {
                     downloaded_bytes: resume_from,
                 });
-                return Ok((resume_from, hex::encode(existing_hash)));
+                return Ok((resume_from, expected_integrity.canonical()));
             }
         }
 
@@ -492,14 +520,14 @@ impl Installer {
         })?;
         if resume_from > 0 && response.status() == StatusCode::OK {
             resume_from = 0;
-            hasher = Sha256::new();
+            hasher = expected_integrity.hasher();
         } else if resume_from > 0 && response.status() == StatusCode::RANGE_NOT_SATISFIABLE {
             fs::remove_file(destination).map_err(|source| Error::WriteDownload {
                 path: destination.to_path_buf(),
                 source,
             })?;
             resume_from = 0;
-            hasher = Sha256::new();
+            hasher = expected_integrity.hasher();
             response = self
                 .client
                 .get(url)
@@ -521,7 +549,7 @@ impl Installer {
                     source,
                 })?;
                 resume_from = 0;
-                hasher = Sha256::new();
+                hasher = expected_integrity.hasher();
                 response =
                     self.client
                         .get(url)
@@ -605,16 +633,20 @@ impl Installer {
             source,
         })?;
 
-        let actual: [u8; 32] = hasher.finalize().into();
-        let actual_hex = hex::encode(actual);
-        if actual != *expected_hash {
+        let actual = hasher.finalize();
+        let actual_integrity = format!(
+            "{}:{}",
+            expected_integrity.algorithm().as_str(),
+            hex::encode(&actual)
+        );
+        if actual != expected_integrity.expected_bytes() {
             fs::remove_file(destination).map_err(|source| Error::WriteDownload {
                 path: destination.to_path_buf(),
                 source,
             })?;
             return Err(Error::ChecksumMismatch {
-                expected: hex::encode(expected_hash),
-                actual: actual_hex,
+                expected: expected_integrity.canonical(),
+                actual: actual_integrity,
             });
         }
 
@@ -622,7 +654,7 @@ impl Installer {
             downloaded_bytes: total,
         });
 
-        Ok((total, actual_hex))
+        Ok((total, expected_integrity.canonical()))
     }
 
     fn report_progress(&self, event: DownloadProgressEvent) {
@@ -764,19 +796,24 @@ impl Installer {
         Ok(())
     }
 
-    fn extract_tar_xz(
+    fn extract_tar(
         &self,
         archive_path: &Path,
         destination: &Path,
         strip_components: usize,
+        format: ArtifactFormat,
     ) -> Result<()> {
         let file = File::open(archive_path).map_err(|source| Error::ExtractArchiveEntry {
             entry: "<archive>".to_owned(),
             path: archive_path.to_path_buf(),
             source,
         })?;
-        let decoder = XzDecoder::new(file);
-        let mut archive = tar::Archive::new(decoder);
+        let reader: Box<dyn Read> = match format {
+            ArtifactFormat::TarXz => Box::new(XzDecoder::new(file)),
+            ArtifactFormat::TarGz => Box::new(GzDecoder::new(file)),
+            ArtifactFormat::Zip => unreachable!("ZIP archives use extract_zip"),
+        };
+        let mut archive = tar::Archive::new(reader);
         let entries = archive.entries().map_err(|source| Error::ReadTarArchive {
             path: archive_path.to_path_buf(),
             source,
@@ -979,11 +1016,19 @@ fn acquire_install_lock(request: &InstallRequest) -> Result<InstallLock> {
 fn existing_install_outcome(final_dir: &Path, request: &InstallRequest) -> Option<InstallOutcome> {
     let content = fs::read_to_string(final_dir.join(".pinset-install.toml")).ok()?;
     let receipt: ExistingInstallReceipt = toml::from_str(&content).ok()?;
+    let receipt_integrity = receipt
+        .artifact_integrity
+        .or(receipt.artifact_sha256)
+        .and_then(|value| ArtifactIntegrity::parse(&value).ok())?
+        .canonical();
+    let expected_integrity = ArtifactIntegrity::parse(&request.artifact.integrity)
+        .ok()?
+        .canonical();
     if !receipt.complete
         || receipt.tool != request.tool
         || receipt.version != request.version
         || receipt.target != request.target
-        || receipt.artifact_sha256 != request.artifact.sha256.to_ascii_lowercase()
+        || receipt_integrity != expected_integrity
     {
         return None;
     }
@@ -993,7 +1038,7 @@ fn existing_install_outcome(final_dir: &Path, request: &InstallRequest) -> Optio
     Some(InstallOutcome {
         install_dir: final_dir.to_path_buf(),
         bytes_downloaded: 0,
-        sha256: receipt.artifact_sha256,
+        integrity: receipt_integrity,
         source_id: receipt.selected_source,
         reused_existing: true,
     })
@@ -1001,15 +1046,6 @@ fn existing_install_outcome(final_dir: &Path, request: &InstallRequest) -> Optio
 
 pub fn sha256_hex(bytes: &[u8]) -> String {
     hex::encode(Sha256::digest(bytes))
-}
-
-fn parse_sha256(value: &str) -> Result<[u8; 32]> {
-    let decoded = hex::decode(value).map_err(|_| Error::InvalidSha256 {
-        value: value.to_owned(),
-    })?;
-    decoded.try_into().map_err(|_| Error::InvalidSha256 {
-        value: value.to_owned(),
-    })
 }
 
 fn validate_request(request: &InstallRequest) -> Result<()> {
@@ -1212,7 +1248,9 @@ struct InstallReceipt<'a> {
     selected_source: &'a str,
     selected_source_kind: &'a str,
     selected_url: &'a str,
-    artifact_sha256: &'a str,
+    artifact_integrity: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    artifact_sha256: Option<&'a str>,
     artifact_format: &'a str,
     bytes_downloaded: u64,
 }
@@ -1224,7 +1262,10 @@ struct ExistingInstallReceipt {
     version: String,
     target: String,
     selected_source: String,
-    artifact_sha256: String,
+    #[serde(default)]
+    artifact_integrity: Option<String>,
+    #[serde(default)]
+    artifact_sha256: Option<String>,
 }
 
 fn write_receipt(
@@ -1233,8 +1274,9 @@ fn write_receipt(
     selected: &SelectedArtifact,
 ) -> Result<()> {
     let canonical_url = redacted_url(&request.artifact.canonical_url);
+    let legacy_sha256 = selected.actual_integrity.strip_prefix("sha256:");
     let receipt = InstallReceipt {
-        schema: 1,
+        schema: 2,
         complete: true,
         tool: &request.tool,
         version: &request.version,
@@ -1243,7 +1285,8 @@ fn write_receipt(
         selected_source: &selected.source_id,
         selected_source_kind: &selected.source_kind,
         selected_url: &selected.source_url,
-        artifact_sha256: &selected.actual_hash,
+        artifact_integrity: &selected.actual_integrity,
+        artifact_sha256: legacy_sha256,
         artifact_format: request.artifact.format.receipt_name(),
         bytes_downloaded: selected.bytes_downloaded,
     };
@@ -1272,11 +1315,15 @@ mod tests {
         thread,
     };
 
+    use base64::Engine as _;
+    use flate2::{Compression, write::GzEncoder};
+    use sha2::Sha512;
     use tempfile::tempdir;
     use xz2::write::XzEncoder;
     use zip::{ZipWriter, write::SimpleFileOptions};
 
     use super::*;
+    use crate::{download_cache::download_partial_path, download_cache_path};
 
     #[test]
     fn installs_verified_zip_atomically_from_local_http() {
@@ -1371,10 +1418,7 @@ mod tests {
         let root = tempdir().expect("temp root");
         let archive = zip_bytes(&[("bin/node.exe", b"fake node")]);
         let hash = sha256_hex(&archive);
-        let expected: [u8; 32] = hex::decode(&hash)
-            .expect("hash")
-            .try_into()
-            .expect("sha256");
+        let expected = ArtifactIntegrity::parse(&hash).expect("sha256");
         let destination = download_cache_path(root.path(), &hash).expect("cache path");
         let installer = Arc::new(test_installer());
         let barrier = Arc::new(Barrier::new(2));
@@ -1385,6 +1429,7 @@ mod tests {
             let installer = Arc::clone(&installer);
             let barrier = Arc::clone(&barrier);
             let destination = destination.clone();
+            let expected = expected.clone();
             workers.push(thread::spawn(move || {
                 barrier.wait();
                 installer.persist_cache_artifact(&source, &destination, &expected)
@@ -1488,6 +1533,38 @@ mod tests {
             );
         }
         assert_transaction_root_is_empty(root.path());
+    }
+
+    #[test]
+    fn installs_tar_gz_with_npm_sha512_integrity() {
+        let archive = tar_gz_bytes(&[("package/pnpm.exe", b"fake pnpm", 0o755)]);
+        let integrity = format!(
+            "sha512-{}",
+            base64::engine::general_purpose::STANDARD.encode(Sha512::digest(&archive))
+        );
+        let (url, server) = serve_once(archive.clone(), archive.len());
+        let root = tempdir().expect("temp root");
+        let mut request = request(root.path(), url, integrity.clone());
+        request.tool = "pnpm".to_owned();
+        request.version = "11.21.0".to_owned();
+        request.target = "windows-x86_64".to_owned();
+        request.artifact.format = ArtifactFormat::TarGz;
+        request.strip_components = 1;
+        request.required_paths = vec![PathBuf::from("pnpm.exe")];
+
+        let outcome = test_installer().install(&request).expect("install tar.gz");
+        server.join().expect("server");
+
+        assert_eq!(outcome.integrity, integrity);
+        assert_eq!(
+            fs::read(outcome.install_dir.join("pnpm.exe")).expect("pnpm"),
+            b"fake pnpm"
+        );
+        assert!(root.path().join("downloads/sha512").is_dir());
+        let receipt =
+            fs::read_to_string(outcome.install_dir.join(".pinset-install.toml")).expect("receipt");
+        assert!(receipt.contains("schema = 2"));
+        assert!(receipt.contains("artifact_integrity = \"sha512-"));
     }
 
     #[cfg(unix)]
@@ -1717,7 +1794,7 @@ mod tests {
                     url,
                     kind: ArtifactSourceKind::Mirror,
                 }],
-                sha256,
+                integrity: sha256,
                 format: ArtifactFormat::Zip,
             },
             strip_components: 0,
@@ -1767,6 +1844,23 @@ mod tests {
         }
         let encoder = builder.into_inner().expect("tar finish");
         encoder.finish().expect("xz finish")
+    }
+
+    fn tar_gz_bytes(entries: &[(&str, &[u8], u32)]) -> Vec<u8> {
+        let encoder = GzEncoder::new(Vec::new(), Compression::default());
+        let mut builder = tar::Builder::new(encoder);
+        for (path, content, mode) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_path(path).expect("tar path");
+            header.set_size(content.len() as u64);
+            header.set_mode(*mode);
+            header.set_cksum();
+            builder
+                .append(&header, Cursor::new(*content))
+                .expect("tar entry");
+        }
+        let encoder = builder.into_inner().expect("tar finish");
+        encoder.finish().expect("gzip finish")
     }
 
     fn tar_xz_with_symlink(link_target: &str) -> Vec<u8> {

--- a/crates/pinset-core/src/integrity.rs
+++ b/crates/pinset-core/src/integrity.rs
@@ -1,0 +1,162 @@
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+
+use crate::{Error, Result};
+
+#[cfg(feature = "installer")]
+use sha2::{Digest, Sha256, Sha512};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IntegrityAlgorithm {
+    Sha256,
+    Sha512,
+}
+
+impl IntegrityAlgorithm {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Sha256 => "sha256",
+            Self::Sha512 => "sha512",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArtifactIntegrity {
+    algorithm: IntegrityAlgorithm,
+    bytes: Vec<u8>,
+}
+
+impl ArtifactIntegrity {
+    pub fn parse(value: &str) -> Result<Self> {
+        if is_hex(value, 64) {
+            return Self::from_hex(IntegrityAlgorithm::Sha256, value);
+        }
+        if let Some(value) = value.strip_prefix("sha256:") {
+            return Self::from_hex(IntegrityAlgorithm::Sha256, value);
+        }
+        if let Some(value) = value.strip_prefix("sha512:") {
+            return Self::from_hex(IntegrityAlgorithm::Sha512, value);
+        }
+        if let Some(value) = value.strip_prefix("sha512-") {
+            let bytes = STANDARD
+                .decode(value)
+                .map_err(|_| Error::InvalidArtifactIntegrity {
+                    value: format!("sha512-{value}"),
+                })?;
+            if bytes.len() != 64 {
+                return Err(Error::InvalidArtifactIntegrity {
+                    value: format!("sha512-{value}"),
+                });
+            }
+            return Ok(Self {
+                algorithm: IntegrityAlgorithm::Sha512,
+                bytes,
+            });
+        }
+        Err(Error::InvalidArtifactIntegrity {
+            value: value.to_owned(),
+        })
+    }
+
+    fn from_hex(algorithm: IntegrityAlgorithm, value: &str) -> Result<Self> {
+        let expected_length = match algorithm {
+            IntegrityAlgorithm::Sha256 => 64,
+            IntegrityAlgorithm::Sha512 => 128,
+        };
+        if !is_hex(value, expected_length) {
+            return Err(Error::InvalidArtifactIntegrity {
+                value: format!("{}:{value}", algorithm.as_str()),
+            });
+        }
+        let bytes = hex::decode(value).map_err(|_| Error::InvalidArtifactIntegrity {
+            value: format!("{}:{value}", algorithm.as_str()),
+        })?;
+        Ok(Self { algorithm, bytes })
+    }
+
+    pub const fn algorithm(&self) -> IntegrityAlgorithm {
+        self.algorithm
+    }
+
+    pub fn expected_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub fn cache_key(&self) -> String {
+        hex::encode(&self.bytes)
+    }
+
+    pub fn canonical(&self) -> String {
+        self.canonical_digest(&self.bytes)
+    }
+
+    #[cfg(feature = "installer")]
+    pub(crate) fn canonical_digest(&self, bytes: &[u8]) -> String {
+        match self.algorithm {
+            IntegrityAlgorithm::Sha256 => format!("sha256:{}", hex::encode(bytes)),
+            IntegrityAlgorithm::Sha512 => format!("sha512-{}", STANDARD.encode(bytes)),
+        }
+    }
+
+    #[cfg(feature = "installer")]
+    pub(crate) fn hasher(&self) -> IntegrityHasher {
+        match self.algorithm {
+            IntegrityAlgorithm::Sha256 => IntegrityHasher::Sha256(Sha256::new()),
+            IntegrityAlgorithm::Sha512 => IntegrityHasher::Sha512(Sha512::new()),
+        }
+    }
+}
+
+fn is_hex(value: &str, length: usize) -> bool {
+    value.len() == length && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[cfg(feature = "installer")]
+#[derive(Clone)]
+pub(crate) enum IntegrityHasher {
+    Sha256(Sha256),
+    Sha512(Sha512),
+}
+
+#[cfg(feature = "installer")]
+impl IntegrityHasher {
+    pub fn update(&mut self, bytes: &[u8]) {
+        match self {
+            Self::Sha256(hasher) => hasher.update(bytes),
+            Self::Sha512(hasher) => hasher.update(bytes),
+        }
+    }
+
+    pub fn finalize(self) -> Vec<u8> {
+        match self {
+            Self::Sha256(hasher) => hasher.finalize().to_vec(),
+            Self::Sha512(hasher) => hasher.finalize().to_vec(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_legacy_sha256_and_npm_sha512() {
+        let sha256 = ArtifactIntegrity::parse(&"ab".repeat(32)).expect("legacy sha256");
+        assert_eq!(sha256.algorithm(), IntegrityAlgorithm::Sha256);
+        assert_eq!(sha256.canonical(), format!("sha256:{}", "ab".repeat(32)));
+
+        let bytes = vec![7_u8; 64];
+        let value = format!("sha512-{}", STANDARD.encode(&bytes));
+        let sha512 = ArtifactIntegrity::parse(&value).expect("npm integrity");
+        assert_eq!(sha512.algorithm(), IntegrityAlgorithm::Sha512);
+        assert_eq!(sha512.expected_bytes(), bytes);
+        assert_eq!(sha512.canonical(), value);
+    }
+
+    #[test]
+    fn rejects_malformed_integrity_values() {
+        for value in ["", "sha256:no", "sha512-no", "md5:abcd"] {
+            assert!(ArtifactIntegrity::parse(value).is_err(), "{value}");
+        }
+    }
+}

--- a/crates/pinset-core/src/lib.rs
+++ b/crates/pinset-core/src/lib.rs
@@ -5,6 +5,8 @@ mod error;
 mod global_state;
 #[cfg(feature = "installer")]
 mod installer;
+#[cfg(any(feature = "installer", feature = "lockfile", feature = "npm-metadata"))]
+mod integrity;
 #[cfg(feature = "lockfile")]
 mod lockfile;
 #[cfg(feature = "node-provider")]
@@ -15,7 +17,12 @@ mod node_metadata;
 mod node_provider;
 #[cfg(all(feature = "installer", feature = "lockfile"))]
 mod node_runtime;
+#[cfg(feature = "npm-metadata")]
+mod npm_metadata;
+#[cfg(all(feature = "installer", feature = "npm-metadata"))]
+mod npm_runtime;
 mod resolver;
+mod runtime_lifecycle;
 mod runtime_provider;
 mod shim_install;
 #[cfg(feature = "sources")]
@@ -24,15 +31,15 @@ mod target;
 mod user_settings;
 
 pub use config::{
-    PROJECT_CONFIG_FILENAME, ProjectConfig, find_optional_project_config, find_project_config,
-    load_project_config,
+    PROJECT_CONFIG_FILENAME, PROJECT_CONFIG_SCHEMA, ProjectConfig, find_optional_project_config,
+    find_project_config, load_project_config,
 };
 #[cfg(feature = "project-write")]
 pub use config::{create_project_config, save_project_config};
 #[cfg(feature = "installer")]
 pub use download_cache::{
     DownloadCacheCleanOutcome, DownloadCacheEntry, clean_download_cache, download_cache_path,
-    import_download_cache, list_download_cache,
+    import_download_cache, import_download_cache_with_integrity, list_download_cache,
 };
 pub use error::{Error, Result};
 #[cfg(feature = "state-write")]
@@ -49,11 +56,14 @@ pub use installer::{
     ArtifactFormat, ArtifactSource, ArtifactSourceKind, ArtifactSpec, DownloadProgressEvent,
     InstallLimits, InstallOutcome, InstallRequest, Installer, sha256_hex,
 };
+#[cfg(any(feature = "installer", feature = "lockfile", feature = "npm-metadata"))]
+pub use integrity::{ArtifactIntegrity, IntegrityAlgorithm};
 #[cfg(feature = "lockfile")]
 pub use lockfile::{
     LOCKFILE_FILENAME, LOCKFILE_SCHEMA, LockedArtifact, LockedArtifactFormat, LockedTool, Lockfile,
     MVP_NODE_TARGETS, load_lockfile, load_optional_lockfile, lockfile_path, save_lockfile,
-    validate_lock_matches_project, validate_lock_matches_selection,
+    validate_lock_matches_project, validate_lock_matches_selection, validate_lock_matches_tool,
+    validate_lock_matches_tools,
 };
 #[cfg(feature = "node-provider")]
 pub use node_lifecycle::{
@@ -68,13 +78,25 @@ pub use node_provider::{
 };
 #[cfg(all(feature = "installer", feature = "lockfile"))]
 pub use node_runtime::{install_locked_node, node_command_directory};
+#[cfg(feature = "npm-metadata")]
+pub use npm_metadata::{
+    BUN_TARGETS, NpmMetadataClient, NpmToolRelease, NpmToolTarget, PNPM_TARGETS, tool_targets,
+};
+#[cfg(all(feature = "installer", feature = "npm-metadata"))]
+pub use npm_runtime::install_locked_npm_tool;
 pub use resolver::{
     CommandResolution, SelectionSource, ToolSelection, command_tool, find_system_commands,
-    path_with_selected_runtime, pinset_home, pinset_home_from_env, resolve_command,
-    resolve_command_with_path, resolve_from_env, resolve_tool_selection,
+    path_with_selected_runtime, path_with_selected_tools, pinset_home, pinset_home_from_env,
+    resolve_command, resolve_command_with_path, resolve_from_env, resolve_tool_selection,
+    runtime_command_directory,
+};
+pub use runtime_lifecycle::{
+    InstalledToolVersion, ToolVersionReference, UninstallToolOutcome, find_tool_version_references,
+    list_installed_tool_versions, uninstall_tool_version,
 };
 pub use runtime_provider::{
-    RuntimeProvider, runtime_provider, runtime_provider_for_command, runtime_providers,
+    RuntimeCommandLayout, RuntimeProvider, runtime_provider, runtime_provider_for_command,
+    runtime_providers,
 };
 pub use shim_install::{
     ShimInstallMethod, ShimInstallResult, ensure_shims, install_shims, is_managed_command_shim,
@@ -85,7 +107,7 @@ pub use source_config::{
     ResolvedArtifactSource, SUPPORTED_SOURCE_PROVIDERS, SourceConfig, SourceKind, SourceView,
     load_source_config, save_source_config, source_config_path,
 };
-pub use target::current_target;
+pub use target::{current_target, current_target_for_tool};
 #[cfg(feature = "state-write")]
 pub use user_settings::save_user_settings;
 pub use user_settings::{UserSettings, load_user_settings, user_settings_path};

--- a/crates/pinset-core/src/lockfile.rs
+++ b/crates/pinset-core/src/lockfile.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::{BTreeMap, HashSet},
     fs,
     io::{ErrorKind, Write},
     path::{Path, PathBuf},
@@ -8,10 +8,12 @@ use std::{
 use atomic_write_file::AtomicWriteFile;
 use serde::{Deserialize, Serialize};
 
-use crate::{Error, NodeArchiveFormat, Result, SourceConfig, plan_node_artifact};
+use crate::{
+    ArtifactIntegrity, Error, NodeArchiveFormat, Result, SourceConfig, plan_node_artifact,
+};
 
 pub const LOCKFILE_FILENAME: &str = "pinset.lock";
-pub const LOCKFILE_SCHEMA: u32 = 1;
+pub const LOCKFILE_SCHEMA: u32 = 2;
 pub const MVP_NODE_TARGETS: [&str; 4] = [
     "windows-x86_64",
     "macos-aarch64",
@@ -45,7 +47,10 @@ pub struct LockedArtifact {
     pub target: String,
     pub canonical_url: String,
     pub artifact_path: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub sha256: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub integrity: Option<String>,
     pub format: LockedArtifactFormat,
     pub archive_root: String,
     pub verification: String,
@@ -57,6 +62,8 @@ pub enum LockedArtifactFormat {
     Zip,
     #[serde(rename = "tar.xz")]
     TarXz,
+    #[serde(rename = "tar.gz")]
+    TarGz,
 }
 
 impl LockedArtifactFormat {
@@ -64,6 +71,7 @@ impl LockedArtifactFormat {
         match self {
             Self::Zip => "zip",
             Self::TarXz => "tar.xz",
+            Self::TarGz => "tar.gz",
         }
     }
 }
@@ -86,6 +94,20 @@ impl Lockfile {
     pub fn tool(&self, name: &str) -> Option<&LockedTool> {
         self.tools.iter().find(|tool| tool.name == name)
     }
+
+    pub fn upsert_tool(&mut self, tool: LockedTool) {
+        if let Some(existing) = self.tools.iter_mut().find(|item| item.name == tool.name) {
+            *existing = tool;
+        } else {
+            self.tools.push(tool);
+        }
+        self.schema = LOCKFILE_SCHEMA;
+    }
+
+    pub fn remove_tool(&mut self, name: &str) {
+        self.tools.retain(|tool| tool.name != name);
+        self.schema = LOCKFILE_SCHEMA;
+    }
 }
 
 impl LockedTool {
@@ -93,6 +115,17 @@ impl LockedTool {
         self.artifacts
             .iter()
             .find(|artifact| artifact.target == target)
+    }
+}
+
+impl LockedArtifact {
+    pub fn artifact_integrity(&self) -> Result<ArtifactIntegrity> {
+        let value = self
+            .integrity
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .unwrap_or(&self.sha256);
+        ArtifactIntegrity::parse(value)
     }
 }
 
@@ -119,6 +152,7 @@ pub fn load_lockfile(path: &Path) -> Result<Lockfile> {
 pub fn save_lockfile(path: &Path, lockfile: &Lockfile) -> Result<()> {
     validate_lockfile(lockfile)?;
     let mut normalized = lockfile.clone();
+    normalized.schema = LOCKFILE_SCHEMA;
     normalized
         .tools
         .sort_by(|left, right| left.name.cmp(&right.name));
@@ -169,8 +203,49 @@ pub fn validate_lock_matches_selection<'a>(
     Ok(tool)
 }
 
+pub fn validate_lock_matches_tool<'a>(
+    lockfile: &'a Lockfile,
+    tool_name: &str,
+    selected_version: &str,
+    selection_path: &Path,
+) -> Result<&'a LockedTool> {
+    let tool = lockfile
+        .tool(tool_name)
+        .ok_or_else(|| Error::LockedToolMissing {
+            tool: tool_name.to_owned(),
+        })?;
+    if tool.requested != selected_version || tool.version != selected_version {
+        return Err(Error::LockfileMismatch {
+            selection_path: selection_path.to_path_buf(),
+            tool: tool_name.to_owned(),
+            configured: selected_version.to_owned(),
+            locked: tool.version.clone(),
+        });
+    }
+    Ok(tool)
+}
+
+pub fn validate_lock_matches_tools(
+    lockfile: &Lockfile,
+    configured_tools: &BTreeMap<String, String>,
+    selection_path: &Path,
+) -> Result<()> {
+    for (tool, version) in configured_tools {
+        validate_lock_matches_tool(lockfile, tool, version, selection_path)?;
+    }
+    for locked in &lockfile.tools {
+        if !configured_tools.contains_key(&locked.name) {
+            return Err(Error::ToolNotConfigured {
+                tool: locked.name.clone(),
+                config_path: selection_path.to_path_buf(),
+            });
+        }
+    }
+    Ok(())
+}
+
 fn validate_lockfile(lockfile: &Lockfile) -> Result<()> {
-    if lockfile.schema != LOCKFILE_SCHEMA {
+    if !matches!(lockfile.schema, 1 | LOCKFILE_SCHEMA) {
         return Err(Error::UnsupportedLockfileSchema {
             actual: lockfile.schema,
         });
@@ -189,11 +264,20 @@ fn validate_lockfile(lockfile: &Lockfile) -> Result<()> {
         }
         validate_locked_tool(tool)?;
     }
+    if lockfile.schema == 1 && lockfile.tools.iter().any(|tool| tool.name != "node") {
+        return Err(Error::InvalidLockfile {
+            reason: "schema 1 lockfiles can contain only Node.js".to_owned(),
+        });
+    }
     Ok(())
 }
 
 fn validate_locked_tool(tool: &LockedTool) -> Result<()> {
-    if tool.name != "node" || tool.provider != "nodejs-official" {
+    let provider_supported = matches!(
+        (tool.name.as_str(), tool.provider.as_str()),
+        ("node", "nodejs-official") | ("pnpm", "pnpm-npm") | ("bun", "bun-npm")
+    );
+    if !provider_supported {
         return Err(Error::InvalidLockfile {
             reason: format!(
                 "unsupported tool/provider pair {}/{}",
@@ -203,8 +287,10 @@ fn validate_locked_tool(tool: &LockedTool) -> Result<()> {
     }
     if tool.requested != tool.version {
         return Err(Error::InvalidLockfile {
-            reason: "Node MVP requires requested and version to be the same exact version"
-                .to_owned(),
+            reason: format!(
+                "{} requires requested and version to be the same exact version",
+                tool.name
+            ),
         });
     }
     let mut targets = HashSet::with_capacity(tool.artifacts.len());
@@ -214,19 +300,43 @@ fn validate_locked_tool(tool: &LockedTool) -> Result<()> {
                 reason: format!("duplicate artifact target {}", artifact.target),
             });
         }
-        validate_locked_artifact(&tool.version, artifact)?;
+        match tool.name.as_str() {
+            "node" => validate_locked_node_artifact(&tool.version, artifact)?,
+            "pnpm" | "bun" => validate_locked_npm_artifact(tool, artifact)?,
+            _ => unreachable!("provider pair checked above"),
+        }
     }
-    for target in MVP_NODE_TARGETS {
-        if !targets.contains(target) {
+    if tool.name == "node" {
+        for target in MVP_NODE_TARGETS {
+            if !targets.contains(target) {
+                return Err(Error::InvalidLockfile {
+                    reason: format!("missing Node MVP artifact for {target}"),
+                });
+            }
+        }
+    } else {
+        for (target, _) in npm_tool_targets(&tool.name) {
+            if !targets.contains(target) {
+                return Err(Error::InvalidLockfile {
+                    reason: format!("missing {} artifact for {target}", tool.name),
+                });
+            }
+        }
+        if targets.len() != npm_tool_targets(&tool.name).len() {
             return Err(Error::InvalidLockfile {
-                reason: format!("missing Node MVP artifact for {target}"),
+                reason: format!("{} lock contains an unsupported artifact target", tool.name),
             });
         }
+    }
+    if tool.artifacts.is_empty() {
+        return Err(Error::InvalidLockfile {
+            reason: format!("{} has no artifacts", tool.name),
+        });
     }
     Ok(())
 }
 
-fn validate_locked_artifact(version: &str, artifact: &LockedArtifact) -> Result<()> {
+fn validate_locked_node_artifact(version: &str, artifact: &LockedArtifact) -> Result<()> {
     let plan = plan_node_artifact(&SourceConfig::default(), version, &artifact.target)?;
     let expected_format = match plan.format {
         NodeArchiveFormat::Zip => LockedArtifactFormat::Zip,
@@ -244,8 +354,7 @@ fn validate_locked_artifact(version: &str, artifact: &LockedArtifact) -> Result<
             ),
         });
     }
-    if artifact.sha256.len() != 64 || !artifact.sha256.bytes().all(|byte| byte.is_ascii_hexdigit())
-    {
+    if artifact.artifact_integrity()?.algorithm() != crate::IntegrityAlgorithm::Sha256 {
         return Err(Error::InvalidLockfile {
             reason: format!("invalid SHA-256 for {}", artifact.target),
         });
@@ -256,6 +365,60 @@ fn validate_locked_artifact(version: &str, artifact: &LockedArtifact) -> Result<
         });
     }
     Ok(())
+}
+
+fn validate_locked_npm_artifact(tool: &LockedTool, artifact: &LockedArtifact) -> Result<()> {
+    if artifact.format != LockedArtifactFormat::TarGz {
+        return Err(Error::InvalidLockfile {
+            reason: format!("{} artifact {} must be tar.gz", tool.name, artifact.target),
+        });
+    }
+    let package = npm_tool_targets(&tool.name)
+        .iter()
+        .find_map(|(target, package)| (*target == artifact.target).then_some(*package))
+        .ok_or_else(|| Error::InvalidLockfile {
+            reason: format!("unsupported {} target {}", tool.name, artifact.target),
+        })?;
+    let package_base = package.rsplit('/').next().expect("npm package is nonempty");
+    let artifact_path = format!("{package}/-/{package_base}-{}.tgz", tool.version);
+    let canonical_url = format!("https://registry.npmjs.org/{artifact_path}");
+    if artifact.archive_root != "package"
+        || artifact.canonical_url != canonical_url
+        || artifact.artifact_path != artifact_path
+    {
+        return Err(Error::InvalidLockfile {
+            reason: format!("invalid npm artifact identity for {}", artifact.target),
+        });
+    }
+    if artifact.artifact_integrity()?.algorithm() != crate::IntegrityAlgorithm::Sha512 {
+        return Err(Error::InvalidLockfile {
+            reason: format!("npm artifact {} must use SHA-512", artifact.target),
+        });
+    }
+    if artifact.verification != "npm-registry-signature-sha512" {
+        return Err(Error::InvalidLockfile {
+            reason: format!("unsupported npm verification for {}", artifact.target),
+        });
+    }
+    Ok(())
+}
+
+fn npm_tool_targets(tool: &str) -> &'static [(&'static str, &'static str)] {
+    match tool {
+        "pnpm" => &[
+            ("windows-x86_64", "@pnpm/win-x64"),
+            ("linux-x86_64", "@pnpm/linux-x64"),
+            ("macos-aarch64", "@pnpm/macos-arm64"),
+        ],
+        "bun" => &[
+            ("windows-x86_64-avx2", "@oven/bun-windows-x64"),
+            ("windows-x86_64-baseline", "@oven/bun-windows-x64-baseline"),
+            ("linux-x86_64-avx2", "@oven/bun-linux-x64"),
+            ("linux-x86_64-baseline", "@oven/bun-linux-x64-baseline"),
+            ("macos-aarch64", "@oven/bun-darwin-aarch64"),
+        ],
+        _ => &[],
+    }
 }
 
 pub fn load_optional_lockfile(path: &Path) -> Result<Option<Lockfile>> {
@@ -345,6 +508,7 @@ mod tests {
             canonical_url: plan.canonical_url,
             artifact_path: plan.artifact_path,
             sha256: "ab".repeat(32),
+            integrity: None,
             format: match plan.format {
                 NodeArchiveFormat::Zip => LockedArtifactFormat::Zip,
                 NodeArchiveFormat::TarXz => LockedArtifactFormat::TarXz,

--- a/crates/pinset-core/src/node_lifecycle.rs
+++ b/crates/pinset-core/src/node_lifecycle.rs
@@ -210,7 +210,7 @@ fn has_matching_complete_receipt(directory: &Path, version: &str, target: &str) 
     let Ok(receipt) = toml::from_str::<InstallReceiptIdentity>(&content) else {
         return false;
     };
-    receipt.schema == 1
+    matches!(receipt.schema, 1 | 2)
         && receipt.complete
         && receipt.tool == "node"
         && receipt.version == version

--- a/crates/pinset-core/src/node_metadata.rs
+++ b/crates/pinset-core/src/node_metadata.rs
@@ -107,6 +107,7 @@ impl NodeMetadataClient {
                         canonical_url: plan.canonical_url,
                         artifact_path: plan.artifact_path,
                         sha256,
+                        integrity: None,
                         format: match plan.format {
                             NodeArchiveFormat::Zip => LockedArtifactFormat::Zip,
                             NodeArchiveFormat::TarXz => LockedArtifactFormat::TarXz,

--- a/crates/pinset-core/src/node_runtime.rs
+++ b/crates/pinset-core/src/node_runtime.rs
@@ -38,10 +38,11 @@ pub fn install_locked_node(
         artifact: ArtifactSpec {
             canonical_url: artifact.canonical_url.clone(),
             sources,
-            sha256: artifact.sha256.clone(),
+            integrity: artifact.artifact_integrity()?.canonical(),
             format: match artifact.format {
                 LockedArtifactFormat::Zip => ArtifactFormat::Zip,
                 LockedArtifactFormat::TarXz => ArtifactFormat::TarXz,
+                LockedArtifactFormat::TarGz => ArtifactFormat::TarGz,
             },
         },
         strip_components: 1,

--- a/crates/pinset-core/src/npm_metadata.rs
+++ b/crates/pinset-core/src/npm_metadata.rs
@@ -1,0 +1,506 @@
+use std::{cmp::Reverse, collections::BTreeMap, io::Read, time::Duration};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use p256::{
+    ecdsa::{Signature, VerifyingKey, signature::Verifier},
+    pkcs8::DecodePublicKey,
+};
+use reqwest::header::ACCEPT;
+use reqwest::{Url, blocking::Client};
+use semver::Version;
+use serde::Deserialize;
+
+use crate::{Error, LockedArtifact, LockedArtifactFormat, LockedTool, Result};
+
+const OFFICIAL_NPM_REGISTRY: &str = "https://registry.npmjs.org/";
+const MAX_METADATA_BYTES: u64 = 32 * 1024 * 1024;
+const SIGNATURE_VERIFICATION: &str = "npm-registry-signature-sha512";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NpmToolRelease {
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NpmToolTarget {
+    pub target: &'static str,
+    pub package: &'static str,
+    pub required_path: &'static str,
+}
+
+pub const PNPM_TARGETS: &[NpmToolTarget] = &[
+    NpmToolTarget {
+        target: "windows-x86_64",
+        package: "@pnpm/win-x64",
+        required_path: "pnpm.exe",
+    },
+    NpmToolTarget {
+        target: "linux-x86_64",
+        package: "@pnpm/linux-x64",
+        required_path: "pnpm",
+    },
+    NpmToolTarget {
+        target: "macos-aarch64",
+        package: "@pnpm/macos-arm64",
+        required_path: "pnpm",
+    },
+];
+
+pub const BUN_TARGETS: &[NpmToolTarget] = &[
+    NpmToolTarget {
+        target: "windows-x86_64-avx2",
+        package: "@oven/bun-windows-x64",
+        required_path: "bin/bun.exe",
+    },
+    NpmToolTarget {
+        target: "windows-x86_64-baseline",
+        package: "@oven/bun-windows-x64-baseline",
+        required_path: "bin/bun.exe",
+    },
+    NpmToolTarget {
+        target: "linux-x86_64-avx2",
+        package: "@oven/bun-linux-x64",
+        required_path: "bin/bun",
+    },
+    NpmToolTarget {
+        target: "linux-x86_64-baseline",
+        package: "@oven/bun-linux-x64-baseline",
+        required_path: "bin/bun",
+    },
+    NpmToolTarget {
+        target: "macos-aarch64",
+        package: "@oven/bun-darwin-aarch64",
+        required_path: "bin/bun",
+    },
+];
+
+#[derive(Debug)]
+pub struct NpmMetadataClient {
+    client: Client,
+    registry: Url,
+}
+
+#[derive(Debug, Deserialize)]
+struct PackageDocument {
+    #[serde(default)]
+    versions: BTreeMap<String, PackageVersion>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PackageVersion {
+    name: String,
+    version: String,
+    #[serde(rename = "optionalDependencies", default)]
+    optional_dependencies: BTreeMap<String, String>,
+    dist: PackageDist,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PackageDist {
+    tarball: String,
+    integrity: String,
+    #[serde(default)]
+    signatures: Vec<PackageSignature>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PackageSignature {
+    keyid: String,
+    sig: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegistryKeys {
+    keys: Vec<RegistryKey>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegistryKey {
+    keyid: String,
+    key: String,
+}
+
+impl NpmMetadataClient {
+    pub fn official() -> Result<Self> {
+        Self::for_registry(OFFICIAL_NPM_REGISTRY)
+    }
+
+    pub fn for_registry(registry: &str) -> Result<Self> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|source| Error::HttpClient { source })?;
+        let registry = Url::parse(registry).map_err(|source| Error::InvalidNpmMetadata {
+            package: "<registry>".to_owned(),
+            reason: source.to_string(),
+        })?;
+        if !registry.path().ends_with('/') {
+            return Err(Error::InvalidNpmMetadata {
+                package: "<registry>".to_owned(),
+                reason: "registry URL must end with /".to_owned(),
+            });
+        }
+        Ok(Self { client, registry })
+    }
+
+    pub fn available_releases(&self, tool: &str) -> Result<Vec<NpmToolRelease>> {
+        let package = wrapper_package(tool)?;
+        let document: PackageDocument =
+            self.download_json_abbreviated(self.package_url(package)?)?;
+        let targets = tool_targets(tool)?;
+        let mut releases = Vec::new();
+        for (declared_version, manifest) in document.versions {
+            let Ok(version) = Version::parse(&declared_version) else {
+                continue;
+            };
+            if manifest.version != declared_version
+                || manifest.name != package
+                || !supported_version(tool, &version)
+                || !version.pre.is_empty()
+                || !targets
+                    .iter()
+                    .all(|target| manifest.optional_dependencies.contains_key(target.package))
+            {
+                continue;
+            }
+            releases.push((
+                version,
+                NpmToolRelease {
+                    version: declared_version,
+                },
+            ));
+        }
+        releases.sort_by_key(|(version, _)| Reverse(version.clone()));
+        if releases.is_empty() {
+            return Err(Error::InvalidNpmMetadata {
+                package: package.to_owned(),
+                reason: "package contains no stable release for every supported Pinset target"
+                    .to_owned(),
+            });
+        }
+        Ok(releases.into_iter().map(|(_, release)| release).collect())
+    }
+
+    pub fn resolve_version_selector(&self, tool: &str, selector: &str) -> Result<String> {
+        if let Ok(version) = Version::parse(selector) {
+            if version.pre.is_empty()
+                && version.build.is_empty()
+                && supported_version(tool, &version)
+            {
+                return Ok(version.to_string());
+            }
+            return Err(Error::InvalidNpmToolSelector {
+                tool: tool.to_owned(),
+                selector: selector.to_owned(),
+            });
+        }
+        let normalized = selector.trim().to_ascii_lowercase();
+        let parts = normalized.split('.').collect::<Vec<_>>();
+        let numeric = matches!(parts.len(), 1 | 2)
+            && parts
+                .iter()
+                .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()));
+        if !numeric && !matches!(normalized.as_str(), "latest" | "current") {
+            return Err(Error::InvalidNpmToolSelector {
+                tool: tool.to_owned(),
+                selector: selector.to_owned(),
+            });
+        }
+        let requested = numeric
+            .then(|| {
+                parts
+                    .iter()
+                    .map(|part| part.parse::<u64>())
+                    .collect::<std::result::Result<Vec<_>, _>>()
+            })
+            .transpose()
+            .map_err(|_| Error::InvalidNpmToolSelector {
+                tool: tool.to_owned(),
+                selector: selector.to_owned(),
+            })?;
+        self.available_releases(tool)?
+            .into_iter()
+            .find(|release| {
+                if matches!(normalized.as_str(), "latest" | "current") {
+                    return true;
+                }
+                let version = Version::parse(&release.version)
+                    .expect("available npm releases contain valid semver");
+                let requested = requested.as_ref().expect("numeric selector parsed");
+                version.major == requested[0]
+                    && (requested.len() == 1 || version.minor == requested[1])
+            })
+            .map(|release| release.version)
+            .ok_or_else(|| Error::NpmToolSelectorNotFound {
+                tool: tool.to_owned(),
+                selector: selector.to_owned(),
+            })
+    }
+
+    pub fn resolve_tool(&self, tool: &str, version: &str) -> Result<LockedTool> {
+        let parsed = Version::parse(version).map_err(|_| Error::InvalidNpmToolSelector {
+            tool: tool.to_owned(),
+            selector: version.to_owned(),
+        })?;
+        if !parsed.pre.is_empty() || !parsed.build.is_empty() || !supported_version(tool, &parsed) {
+            return Err(Error::InvalidNpmToolSelector {
+                tool: tool.to_owned(),
+                selector: version.to_owned(),
+            });
+        }
+        let wrapper = wrapper_package(tool)?;
+        let manifest = self.package_version(wrapper, version)?;
+        validate_manifest_identity(wrapper, version, &manifest)?;
+        let keys = self.registry_keys()?;
+        let mut artifacts = Vec::new();
+        for target in tool_targets(tool)? {
+            let dependency = manifest
+                .optional_dependencies
+                .get(target.package)
+                .ok_or_else(|| Error::InvalidNpmMetadata {
+                    package: wrapper.to_owned(),
+                    reason: format!("{version} does not declare {}", target.package),
+                })?;
+            let package_version =
+                exact_dependency_version(dependency).ok_or_else(|| Error::InvalidNpmMetadata {
+                    package: wrapper.to_owned(),
+                    reason: format!("{} has non-exact version {dependency:?}", target.package),
+                })?;
+            let platform = self.package_version(target.package, package_version)?;
+            validate_manifest_identity(target.package, package_version, &platform)?;
+            verify_package_signature(&platform, &keys)?;
+            let tarball =
+                Url::parse(&platform.dist.tarball).map_err(|source| Error::InvalidNpmMetadata {
+                    package: target.package.to_owned(),
+                    reason: format!("invalid tarball URL: {source}"),
+                })?;
+            if tarball.scheme() != "https"
+                || tarball.host_str() != Some("registry.npmjs.org")
+                || !tarball.username().is_empty()
+                || tarball.password().is_some()
+            {
+                return Err(Error::InvalidNpmMetadata {
+                    package: target.package.to_owned(),
+                    reason: "tarball must use the official HTTPS npm registry".to_owned(),
+                });
+            }
+            crate::ArtifactIntegrity::parse(&platform.dist.integrity)?;
+            artifacts.push(LockedArtifact {
+                target: target.target.to_owned(),
+                canonical_url: tarball.to_string(),
+                artifact_path: tarball.path().trim_start_matches('/').to_owned(),
+                sha256: String::new(),
+                integrity: Some(platform.dist.integrity),
+                format: LockedArtifactFormat::TarGz,
+                archive_root: "package".to_owned(),
+                verification: SIGNATURE_VERIFICATION.to_owned(),
+            });
+        }
+        Ok(LockedTool {
+            name: tool.to_owned(),
+            requested: version.to_owned(),
+            version: version.to_owned(),
+            provider: format!("{tool}-npm"),
+            artifacts,
+        })
+    }
+
+    fn package_version(&self, package: &str, version: &str) -> Result<PackageVersion> {
+        let url = self
+            .package_url(package)?
+            .join(version)
+            .expect("validated semver is a safe URL segment");
+        self.download_json(url)
+    }
+
+    fn registry_keys(&self) -> Result<RegistryKeys> {
+        let url = self
+            .registry
+            .join("-/npm/v1/keys")
+            .expect("built-in npm keys endpoint is valid");
+        self.download_json(url)
+    }
+
+    fn package_url(&self, package: &str) -> Result<Url> {
+        let encoded = package.replace('/', "%2f");
+        Url::parse(&format!("{}{encoded}/", self.registry)).map_err(|source| {
+            Error::InvalidNpmMetadata {
+                package: package.to_owned(),
+                reason: source.to_string(),
+            }
+        })
+    }
+
+    fn download_json<T: for<'de> Deserialize<'de>>(&self, url: Url) -> Result<T> {
+        self.download_json_with_accept(url, None)
+    }
+
+    fn download_json_abbreviated<T: for<'de> Deserialize<'de>>(&self, url: Url) -> Result<T> {
+        self.download_json_with_accept(url, Some("application/vnd.npm.install-v1+json"))
+    }
+
+    fn download_json_with_accept<T: for<'de> Deserialize<'de>>(
+        &self,
+        url: Url,
+        accept: Option<&str>,
+    ) -> Result<T> {
+        let display_url = url.to_string();
+        let mut request = self.client.get(url);
+        if let Some(accept) = accept {
+            request = request.header(ACCEPT, accept);
+        }
+        let mut response = request
+            .send()
+            .and_then(reqwest::blocking::Response::error_for_status)
+            .map_err(|source| Error::NpmMetadataRequest {
+                url: display_url.clone(),
+                source,
+            })?;
+        if response
+            .content_length()
+            .is_some_and(|length| length > MAX_METADATA_BYTES)
+        {
+            return Err(Error::NpmMetadataTooLarge {
+                limit: MAX_METADATA_BYTES,
+            });
+        }
+        let mut bytes = Vec::new();
+        (&mut response)
+            .take(MAX_METADATA_BYTES + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|source| Error::NpmMetadataRead {
+                url: display_url.clone(),
+                source,
+            })?;
+        if bytes.len() as u64 > MAX_METADATA_BYTES {
+            return Err(Error::NpmMetadataTooLarge {
+                limit: MAX_METADATA_BYTES,
+            });
+        }
+        serde_json::from_slice(&bytes).map_err(|source| Error::InvalidNpmMetadata {
+            package: display_url,
+            reason: source.to_string(),
+        })
+    }
+}
+
+pub fn tool_targets(tool: &str) -> Result<&'static [NpmToolTarget]> {
+    match tool {
+        "pnpm" => Ok(PNPM_TARGETS),
+        "bun" => Ok(BUN_TARGETS),
+        _ => Err(Error::UnsupportedSourceProvider {
+            provider: tool.to_owned(),
+        }),
+    }
+}
+
+fn wrapper_package(tool: &str) -> Result<&'static str> {
+    match tool {
+        "pnpm" => Ok("@pnpm/exe"),
+        "bun" => Ok("bun"),
+        _ => Err(Error::UnsupportedSourceProvider {
+            provider: tool.to_owned(),
+        }),
+    }
+}
+
+fn supported_version(tool: &str, version: &Version) -> bool {
+    match tool {
+        "pnpm" => matches!(version.major, 10 | 11),
+        "bun" => version.major == 1,
+        _ => false,
+    }
+}
+
+fn exact_dependency_version(value: &str) -> Option<&str> {
+    let value = value.strip_prefix('=').unwrap_or(value);
+    Version::parse(value).ok().map(|_| value)
+}
+
+fn validate_manifest_identity(
+    package: &str,
+    version: &str,
+    manifest: &PackageVersion,
+) -> Result<()> {
+    if manifest.name != package || manifest.version != version {
+        return Err(Error::InvalidNpmMetadata {
+            package: package.to_owned(),
+            reason: format!(
+                "requested {package}@{version}, received {}@{}",
+                manifest.name, manifest.version
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn verify_package_signature(manifest: &PackageVersion, keys: &RegistryKeys) -> Result<()> {
+    let message = format!(
+        "{}@{}:{}",
+        manifest.name, manifest.version, manifest.dist.integrity
+    );
+    let mut failures = Vec::new();
+    for signature in &manifest.dist.signatures {
+        let Some(key) = keys.keys.iter().find(|key| key.keyid == signature.keyid) else {
+            failures.push(format!("unknown key {}", signature.keyid));
+            continue;
+        };
+        let public_key = STANDARD
+            .decode(&key.key)
+            .ok()
+            .and_then(|bytes| VerifyingKey::from_public_key_der(&bytes).ok());
+        let signature = STANDARD
+            .decode(&signature.sig)
+            .ok()
+            .and_then(|bytes| Signature::from_der(&bytes).ok());
+        if let (Some(public_key), Some(signature)) = (public_key, signature)
+            && public_key.verify(message.as_bytes(), &signature).is_ok()
+        {
+            return Ok(());
+        }
+        failures.push(format!("invalid signature for key {}", key.keyid));
+    }
+    Err(Error::NpmSignatureVerification {
+        package: manifest.name.clone(),
+        version: manifest.version.clone(),
+        reason: if failures.is_empty() {
+            "package metadata contains no signatures".to_owned()
+        } else {
+            failures.join(", ")
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn target_manifests_cover_current_release_platforms_and_bun_cpu_variants() {
+        assert_eq!(PNPM_TARGETS.len(), 3);
+        assert!(
+            BUN_TARGETS
+                .iter()
+                .any(|target| target.target.ends_with("-avx2"))
+        );
+        assert!(
+            BUN_TARGETS
+                .iter()
+                .any(|target| target.target.ends_with("-baseline"))
+        );
+        assert!(
+            PNPM_TARGETS
+                .iter()
+                .all(|target| !target.required_path.is_empty())
+        );
+    }
+
+    #[test]
+    fn stable_support_windows_are_deliberately_narrow() {
+        assert!(supported_version("pnpm", &Version::new(10, 0, 0)));
+        assert!(supported_version("pnpm", &Version::new(11, 0, 0)));
+        assert!(!supported_version("pnpm", &Version::new(12, 0, 0)));
+        assert!(supported_version("bun", &Version::new(1, 3, 0)));
+        assert!(!supported_version("bun", &Version::new(2, 0, 0)));
+    }
+}

--- a/crates/pinset-core/src/npm_runtime.rs
+++ b/crates/pinset-core/src/npm_runtime.rs
@@ -1,0 +1,130 @@
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use crate::{
+    ArtifactFormat, ArtifactSource, ArtifactSourceKind, ArtifactSpec, Error, InstallOutcome,
+    InstallRequest, Installer, LockedArtifactFormat, LockedTool, Result, tool_targets,
+};
+
+pub fn install_locked_npm_tool(
+    installer: &Installer,
+    pinset_home: &Path,
+    locked_tool: &LockedTool,
+    target: &str,
+) -> Result<InstallOutcome> {
+    if !matches!(locked_tool.name.as_str(), "pnpm" | "bun") {
+        return Err(Error::InvalidLockfile {
+            reason: format!("{} is not an npm-distributed tool", locked_tool.name),
+        });
+    }
+    let artifact = locked_tool
+        .artifact(target)
+        .ok_or_else(|| Error::LockedArtifactMissing {
+            tool: locked_tool.name.clone(),
+            target: target.to_owned(),
+        })?;
+    let target_manifest = tool_targets(&locked_tool.name)?
+        .iter()
+        .find(|candidate| candidate.target == target)
+        .ok_or_else(|| Error::LockedArtifactMissing {
+            tool: locked_tool.name.clone(),
+            target: target.to_owned(),
+        })?;
+    let format = match artifact.format {
+        LockedArtifactFormat::TarGz => ArtifactFormat::TarGz,
+        LockedArtifactFormat::Zip => ArtifactFormat::Zip,
+        LockedArtifactFormat::TarXz => ArtifactFormat::TarXz,
+    };
+    let request = InstallRequest {
+        pinset_home: pinset_home.to_path_buf(),
+        tool: locked_tool.name.clone(),
+        version: locked_tool.version.clone(),
+        target: target.to_owned(),
+        artifact: ArtifactSpec {
+            canonical_url: artifact.canonical_url.clone(),
+            sources: vec![ArtifactSource {
+                id: "npm-official".to_owned(),
+                url: artifact.canonical_url.clone(),
+                kind: ArtifactSourceKind::Official,
+            }],
+            integrity: artifact.artifact_integrity()?.canonical(),
+            format,
+        },
+        strip_components: 1,
+        required_paths: vec![PathBuf::from(target_manifest.required_path)],
+    };
+    let outcome = installer.install(&request)?;
+    if locked_tool.name == "bun" {
+        ensure_bunx_alias(&outcome.install_dir, target)?;
+    }
+    Ok(outcome)
+}
+
+fn ensure_bunx_alias(install_dir: &Path, target: &str) -> Result<()> {
+    let (source, destination) = if target.starts_with("windows-") {
+        (
+            install_dir.join("bin/bun.exe"),
+            install_dir.join("bin/bunx.exe"),
+        )
+    } else {
+        (install_dir.join("bin/bun"), install_dir.join("bin/bunx"))
+    };
+    if destination.is_file() {
+        return Ok(());
+    }
+    match fs::hard_link(&source, &destination) {
+        Ok(()) => Ok(()),
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::Unsupported | io::ErrorKind::PermissionDenied | io::ErrorKind::Other
+            ) =>
+        {
+            fs::copy(&source, &destination)
+                .map(|_| ())
+                .map_err(|source_error| Error::CreateRuntimeAlias {
+                    source_path: source,
+                    destination,
+                    source: source_error,
+                })
+        }
+        Err(source_error) => Err(Error::CreateRuntimeAlias {
+            source_path: source,
+            destination,
+            source: source_error,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bunx_alias_is_idempotent() {
+        let root = tempfile::tempdir().expect("root");
+        let bin = root.path().join("bin");
+        fs::create_dir(&bin).expect("bin");
+        let source = if cfg!(windows) {
+            bin.join("bun.exe")
+        } else {
+            bin.join("bun")
+        };
+        fs::write(&source, b"bun").expect("bun fixture");
+        let target = if cfg!(windows) {
+            "windows-x86_64-avx2"
+        } else {
+            "linux-x86_64-avx2"
+        };
+        ensure_bunx_alias(root.path(), target).expect("first alias");
+        ensure_bunx_alias(root.path(), target).expect("second alias");
+        let alias = if cfg!(windows) {
+            bin.join("bunx.exe")
+        } else {
+            bin.join("bunx")
+        };
+        assert_eq!(fs::read(alias).expect("alias"), b"bun");
+    }
+}

--- a/crates/pinset-core/src/resolver.rs
+++ b/crates/pinset-core/src/resolver.rs
@@ -5,10 +5,12 @@ use std::{
     path::{Path, PathBuf},
 };
 
+#[cfg(test)]
+use crate::current_target;
 use crate::{
-    Error, Result, current_target, find_optional_project_config, global_config_path,
-    is_managed_command_shim, load_optional_global_config, load_project_config,
-    runtime_provider_for_command,
+    Error, Result, RuntimeCommandLayout, current_target_for_tool, find_optional_project_config,
+    global_config_path, is_managed_command_shim, load_optional_global_config, load_project_config,
+    runtime_provider, runtime_provider_for_command, runtime_providers,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -137,8 +139,8 @@ pub fn resolve_command_with_path(
         .join("installs")
         .join(tool)
         .join(&version)
-        .join(current_target());
-    let bin_dir = runtime_command_dir(&install_dir);
+        .join(current_target_for_tool(tool));
+    let bin_dir = runtime_command_directory(tool, &install_dir);
     let candidates = executable_candidates(&bin_dir, command);
     let executable = candidates
         .iter()
@@ -298,12 +300,61 @@ pub fn path_with_selected_runtime(executable: &Path) -> Result<OsString> {
     env::join_paths(entries).map_err(|source| Error::RuntimePathJoin { source })
 }
 
-fn runtime_command_dir(install_dir: &Path) -> PathBuf {
-    if cfg!(windows) {
-        install_dir.to_path_buf()
-    } else {
-        install_dir.join("bin")
+pub fn path_with_selected_tools(
+    executable: &Path,
+    cwd: &Path,
+    pinset_home: &Path,
+) -> Result<OsString> {
+    let selected_dir = executable
+        .parent()
+        .ok_or_else(|| Error::RuntimeCommandDirectoryMissing {
+            path: executable.to_path_buf(),
+        })?
+        .to_path_buf();
+    let shim_dir = pinset_home.join("shims");
+    let mut entries = vec![selected_dir.clone()];
+    for provider in runtime_providers() {
+        let Ok(selection) = resolve_tool_selection(provider.tool, cwd, pinset_home) else {
+            continue;
+        };
+        let install_dir = pinset_home
+            .join("installs")
+            .join(provider.tool)
+            .join(selection.version)
+            .join(current_target_for_tool(provider.tool));
+        let command_dir = runtime_command_directory(provider.tool, &install_dir);
+        if command_dir.is_dir()
+            && !paths_equal(&command_dir, &selected_dir)
+            && !entries.iter().any(|entry| paths_equal(entry, &command_dir))
+        {
+            entries.push(command_dir);
+        }
     }
+    if let Some(inherited) = env::var_os("PATH") {
+        for entry in env::split_paths(&inherited) {
+            if !paths_equal(&entry, &shim_dir)
+                && !entries.iter().any(|existing| paths_equal(existing, &entry))
+            {
+                entries.push(entry);
+            }
+        }
+    }
+    env::join_paths(entries).map_err(|source| Error::RuntimePathJoin { source })
+}
+
+pub fn runtime_command_directory(tool: &str, install_dir: &Path) -> PathBuf {
+    match runtime_provider(tool).map(|provider| provider.command_layout) {
+        Some(RuntimeCommandLayout::NodeNative) if cfg!(windows) => install_dir.to_path_buf(),
+        Some(RuntimeCommandLayout::NodeNative | RuntimeCommandLayout::Bin) => {
+            install_dir.join("bin")
+        }
+        Some(RuntimeCommandLayout::Root) | None => install_dir.to_path_buf(),
+    }
+}
+
+#[cfg(test)]
+fn runtime_command_dir(install_dir: &Path) -> PathBuf {
+    runtime_command_directory("node", install_dir)
 }
 
 fn executable_candidates(bin_dir: &Path, command: &str) -> Vec<PathBuf> {

--- a/crates/pinset-core/src/runtime_lifecycle.rs
+++ b/crates/pinset-core/src/runtime_lifecycle.rs
@@ -1,0 +1,310 @@
+use std::{
+    cmp::Reverse,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde::Deserialize;
+
+use crate::{
+    Error, Result, find_optional_project_config, global_config_path, load_optional_global_config,
+    load_project_config, runtime_provider,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstalledToolVersion {
+    pub tool: String,
+    pub version: String,
+    pub targets: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolVersionReference {
+    pub scope: &'static str,
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UninstallToolOutcome {
+    pub tool: String,
+    pub version: String,
+    pub targets: Vec<String>,
+}
+
+pub fn list_installed_tool_versions(
+    pinset_home: &Path,
+    tool: &str,
+) -> Result<Vec<InstalledToolVersion>> {
+    validate_tool_and_version(tool, "0.0.0")?;
+    let root = pinset_home.join("installs").join(tool);
+    let entries = match fs::read_dir(&root) {
+        Ok(entries) => entries,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(source) => {
+            return Err(Error::ReadToolInstallDirectory {
+                tool: tool.to_owned(),
+                path: root,
+                source,
+            });
+        }
+    };
+    let mut versions = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|source| Error::ReadToolInstallDirectory {
+            tool: tool.to_owned(),
+            path: root.clone(),
+            source,
+        })?;
+        let version = entry.file_name().to_string_lossy().into_owned();
+        if !valid_version_segment(&version) || !entry.path().is_dir() {
+            continue;
+        }
+        let mut targets = Vec::new();
+        for target_entry in
+            fs::read_dir(entry.path()).map_err(|source| Error::ReadToolInstallDirectory {
+                tool: tool.to_owned(),
+                path: entry.path(),
+                source,
+            })?
+        {
+            let target_entry = target_entry.map_err(|source| Error::ReadToolInstallDirectory {
+                tool: tool.to_owned(),
+                path: entry.path(),
+                source,
+            })?;
+            let target = target_entry.file_name().to_string_lossy().into_owned();
+            if target_entry.path().is_dir()
+                && has_matching_complete_receipt(&target_entry.path(), tool, &version, &target)
+            {
+                targets.push(target);
+            }
+        }
+        targets.sort();
+        if !targets.is_empty() {
+            versions.push(InstalledToolVersion {
+                tool: tool.to_owned(),
+                version,
+                targets,
+            });
+        }
+    }
+    versions.sort_by_key(|entry| Reverse(version_key(&entry.version)));
+    Ok(versions)
+}
+
+pub fn find_tool_version_references(
+    pinset_home: &Path,
+    cwd: &Path,
+    tool: &str,
+    version: &str,
+) -> Result<Vec<ToolVersionReference>> {
+    validate_tool_and_version(tool, version)?;
+    let mut references = Vec::new();
+    if let Some(path) = find_optional_project_config(cwd)? {
+        let config = load_project_config(&path)?;
+        if config
+            .tools
+            .get(tool)
+            .is_some_and(|selected| selected == version)
+        {
+            references.push(ToolVersionReference {
+                scope: "project",
+                path,
+            });
+        }
+    }
+    let path = global_config_path(pinset_home);
+    if let Some(config) = load_optional_global_config(&path)?
+        && config
+            .tools
+            .get(tool)
+            .is_some_and(|selected| selected == version)
+    {
+        references.push(ToolVersionReference {
+            scope: "global",
+            path,
+        });
+    }
+    Ok(references)
+}
+
+pub fn uninstall_tool_version(
+    pinset_home: &Path,
+    cwd: &Path,
+    tool: &str,
+    version: &str,
+    force: bool,
+) -> Result<UninstallToolOutcome> {
+    validate_tool_and_version(tool, version)?;
+    let references = find_tool_version_references(pinset_home, cwd, tool, version)?;
+    if !force && !references.is_empty() {
+        return Err(Error::ToolVersionInUse {
+            tool: tool.to_owned(),
+            version: version.to_owned(),
+            references: references
+                .iter()
+                .map(|reference| format!("{}:{}", reference.scope, reference.path.display()))
+                .collect::<Vec<_>>()
+                .join(", "),
+        });
+    }
+    let version_root = pinset_home.join("installs").join(tool).join(version);
+    let metadata = match fs::symlink_metadata(&version_root) {
+        Ok(metadata) => metadata,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+            return Err(Error::ToolVersionNotInstalled {
+                tool: tool.to_owned(),
+                version: version.to_owned(),
+            });
+        }
+        Err(source) => {
+            return Err(Error::ReadToolInstallDirectory {
+                tool: tool.to_owned(),
+                path: version_root,
+                source,
+            });
+        }
+    };
+    if !metadata.file_type().is_dir() || metadata.file_type().is_symlink() {
+        return Err(Error::UnsafeToolInstallEntry {
+            tool: tool.to_owned(),
+            path: version_root,
+        });
+    }
+    let mut targets = Vec::new();
+    for entry in fs::read_dir(&version_root).map_err(|source| Error::ReadToolInstallDirectory {
+        tool: tool.to_owned(),
+        path: version_root.clone(),
+        source,
+    })? {
+        let entry = entry.map_err(|source| Error::ReadToolInstallDirectory {
+            tool: tool.to_owned(),
+            path: version_root.clone(),
+            source,
+        })?;
+        let file_type = entry
+            .file_type()
+            .map_err(|source| Error::ReadToolInstallDirectory {
+                tool: tool.to_owned(),
+                path: entry.path(),
+                source,
+            })?;
+        let target = entry.file_name().to_string_lossy().into_owned();
+        if !file_type.is_dir()
+            || file_type.is_symlink()
+            || !has_matching_complete_receipt(&entry.path(), tool, version, &target)
+        {
+            return Err(Error::UnsafeToolInstallEntry {
+                tool: tool.to_owned(),
+                path: entry.path(),
+            });
+        }
+        targets.push((target, entry.path()));
+    }
+    if targets.is_empty() {
+        return Err(Error::ToolVersionNotInstalled {
+            tool: tool.to_owned(),
+            version: version.to_owned(),
+        });
+    }
+    targets.sort_by(|left, right| left.0.cmp(&right.0));
+    for (_, path) in &targets {
+        fs::remove_dir_all(path).map_err(|source| Error::RemoveToolInstall {
+            tool: tool.to_owned(),
+            path: path.clone(),
+            source,
+        })?;
+    }
+    fs::remove_dir(&version_root).map_err(|source| Error::RemoveToolInstall {
+        tool: tool.to_owned(),
+        path: version_root,
+        source,
+    })?;
+    Ok(UninstallToolOutcome {
+        tool: tool.to_owned(),
+        version: version.to_owned(),
+        targets: targets.into_iter().map(|(target, _)| target).collect(),
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct InstallReceiptIdentity {
+    schema: u32,
+    complete: bool,
+    tool: String,
+    version: String,
+    target: String,
+}
+
+fn has_matching_complete_receipt(
+    directory: &Path,
+    tool: &str,
+    version: &str,
+    target: &str,
+) -> bool {
+    let Ok(content) = fs::read_to_string(directory.join(".pinset-install.toml")) else {
+        return false;
+    };
+    let Ok(receipt) = toml::from_str::<InstallReceiptIdentity>(&content) else {
+        return false;
+    };
+    matches!(receipt.schema, 1 | 2)
+        && receipt.complete
+        && receipt.tool == tool
+        && receipt.version == version
+        && receipt.target == target
+}
+
+fn validate_tool_and_version(tool: &str, version: &str) -> Result<()> {
+    if runtime_provider(tool).is_none() {
+        return Err(Error::UnsupportedSourceProvider {
+            provider: tool.to_owned(),
+        });
+    }
+    if !valid_version_segment(version) {
+        return Err(Error::InvalidToolVersion {
+            tool: tool.to_owned(),
+            version: version.to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn valid_version_segment(value: &str) -> bool {
+    !value.is_empty()
+        && value != "."
+        && value != ".."
+        && !value.contains(['/', '\\', ':'])
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'.' || byte == b'-')
+}
+
+fn version_key(version: &str) -> (u64, u64, u64) {
+    let mut parts = version.split('.');
+    (
+        parts.next().and_then(|part| part.parse().ok()).unwrap_or(0),
+        parts.next().and_then(|part| part.parse().ok()).unwrap_or(0),
+        parts.next().and_then(|part| part.parse().ok()).unwrap_or(0),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lists_schema_two_bun_install_receipts() {
+        let home = tempfile::tempdir().expect("home");
+        let directory = home.path().join("installs/bun/1.3.14/windows-x86_64-avx2");
+        fs::create_dir_all(&directory).expect("directory");
+        fs::write(
+            directory.join(".pinset-install.toml"),
+            "schema = 2\ncomplete = true\ntool = \"bun\"\nversion = \"1.3.14\"\ntarget = \"windows-x86_64-avx2\"\n",
+        )
+        .expect("receipt");
+        let installed = list_installed_tool_versions(home.path(), "bun").expect("installed");
+        assert_eq!(installed.len(), 1);
+        assert_eq!(installed[0].version, "1.3.14");
+    }
+}

--- a/crates/pinset-core/src/runtime_provider.rs
+++ b/crates/pinset-core/src/runtime_provider.rs
@@ -2,14 +2,33 @@
 pub struct RuntimeProvider {
     pub tool: &'static str,
     pub commands: &'static [&'static str],
+    pub command_layout: RuntimeCommandLayout,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeCommandLayout {
+    NodeNative,
+    Root,
+    Bin,
 }
 
 const NODE_COMMANDS: &[&str] = &["node", "npm", "npx", "corepack"];
 const NODE_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "node",
     commands: NODE_COMMANDS,
+    command_layout: RuntimeCommandLayout::NodeNative,
 };
-const PROVIDERS: &[RuntimeProvider] = &[NODE_PROVIDER];
+const PNPM_PROVIDER: RuntimeProvider = RuntimeProvider {
+    tool: "pnpm",
+    commands: &["pnpm"],
+    command_layout: RuntimeCommandLayout::Root,
+};
+const BUN_PROVIDER: RuntimeProvider = RuntimeProvider {
+    tool: "bun",
+    commands: &["bun", "bunx"],
+    command_layout: RuntimeCommandLayout::Bin,
+};
+const PROVIDERS: &[RuntimeProvider] = &[NODE_PROVIDER, PNPM_PROVIDER, BUN_PROVIDER];
 
 pub fn runtime_providers() -> &'static [RuntimeProvider] {
     PROVIDERS
@@ -45,6 +64,11 @@ mod tests {
 
     #[test]
     fn unavailable_providers_and_commands_are_not_invented() {
+        assert_eq!(runtime_provider("pnpm").expect("pnpm").commands, ["pnpm"]);
+        assert_eq!(
+            runtime_provider("bun").expect("bun").commands,
+            ["bun", "bunx"]
+        );
         assert!(runtime_provider("python").is_none());
         assert!(runtime_provider_for_command("python").is_none());
         assert!(runtime_provider_for_command("flutter").is_none());

--- a/crates/pinset-core/src/target.rs
+++ b/crates/pinset-core/src/target.rs
@@ -2,6 +2,28 @@ pub fn current_target() -> String {
     format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH)
 }
 
+pub fn current_target_for_tool(tool: &str) -> String {
+    let target = current_target();
+    if tool != "bun" || std::env::consts::ARCH != "x86_64" {
+        return target;
+    }
+    if x86_64_supports_avx2() {
+        format!("{target}-avx2")
+    } else {
+        format!("{target}-baseline")
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+fn x86_64_supports_avx2() -> bool {
+    std::is_x86_feature_detected!("avx2")
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+fn x86_64_supports_avx2() -> bool {
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -14,5 +36,13 @@ mod tests {
             target.contains(std::env::consts::ARCH)
                 || (std::env::consts::ARCH == "aarch64" && target.contains("aarch64"))
         );
+    }
+
+    #[test]
+    fn bun_x64_target_records_cpu_variant() {
+        let target = current_target_for_tool("bun");
+        if std::env::consts::ARCH == "x86_64" {
+            assert!(target.ends_with("-avx2") || target.ends_with("-baseline"));
+        }
     }
 }

--- a/crates/pinset-shim/src/main.rs
+++ b/crates/pinset-shim/src/main.rs
@@ -9,7 +9,7 @@ use std::{
 use std::ffi::OsStr;
 
 use pinset_core::{
-    CommandResolution, path_with_selected_runtime, pinset_home_from_env, resolve_command_with_path,
+    CommandResolution, path_with_selected_tools, pinset_home_from_env, resolve_command_with_path,
 };
 
 const SHIM_DEPTH_ENV: &str = "PINSET_SHIM_DEPTH";
@@ -44,7 +44,7 @@ fn run() -> Result<i32, Box<dyn std::error::Error>> {
     )?;
     reject_shim_directory_target(&resolution, &home)?;
 
-    let runtime_path = path_with_selected_runtime(&resolution.executable)?;
+    let runtime_path = path_with_selected_tools(&resolution.executable, &invocation.cwd, &home)?;
     let mut child = command_for_runtime(&resolution.executable, &invocation.arguments);
     child
         .env("PATH", runtime_path)

--- a/crates/pinset/Cargo.toml
+++ b/crates/pinset/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap.workspace = true
-pinset-core = { path = "../pinset-core", features = ["installer", "node-metadata", "project-write", "sources", "state-write"] }
+pinset-core = { path = "../pinset-core", features = ["installer", "node-metadata", "npm-metadata", "project-write", "sources", "state-write"] }
 serde.workspace = true
 serde_json.workspace = true
 terminal_size.workspace = true

--- a/crates/pinset/src/i18n.rs
+++ b/crates/pinset/src/i18n.rs
@@ -210,31 +210,31 @@ impl Catalog {
         match command {
             Some("init") => "创建项目配置。\n\n用法：pinset init",
             Some("global") => {
-                "查看或设置项目之外使用的全局默认 Node.js。\n\n用法：pinset global [node@x.y.z|主版本|主次版本|lts|current] [--no-install]"
+                "查看或设置项目之外使用的全局默认运行时。\n\n用法：pinset global [node@lts|pnpm@11|bun@1.3] [--no-install]"
             }
             Some("use") => {
-                "选择并锁定 Node.js 版本。\n\n用法：pinset use <node@x.y.z|主版本|主次版本|lts|current> [--global] [--no-install]"
+                "选择并锁定 Node.js、pnpm 或 Bun 版本。\n\n用法：pinset use <node@24|pnpm@11|bun@1.3> [--global] [--no-install]"
             }
             Some("unset") => {
-                "清除项目或全局 Node.js 选择，不卸载运行时。\n\n用法：pinset unset node [--global] [--cwd <目录>]"
+                "清除项目或全局运行时选择，不卸载运行时。\n\n用法：pinset unset <node|pnpm|bun> [--global] [--cwd <目录>]"
             }
             Some("install") => {
-                "安装指定 Node.js 版本，或根据项目/全局锁文件安装。\n\n用法：\n  pinset install node@<版本选择器>\n  pinset install [--locked] [--global] [--cwd <目录>]"
+                "安装指定运行时版本，或根据项目/全局锁文件安装全部工具。\n\n用法：\n  pinset install <node|pnpm|bun>@<版本选择器>\n  pinset install [--locked] [--global] [--cwd <目录>]"
             }
             Some("which") => {
                 "显示实际执行的运行时命令路径。\n\n用法：pinset which <命令> [--cwd <目录>]"
             }
             Some("current") => {
-                "显示当前版本、来源和安装路径。\n\n用法：pinset current [node] [--cwd <目录>]"
+                "显示当前版本、来源和安装路径。\n\n用法：pinset current [node|pnpm|bun] [--cwd <目录>]"
             }
             Some("list") => {
-                "列出本机已安装或官方可用的 Node.js 版本。\n\n用法：pinset list node [--available]"
+                "列出本机已安装或官方可用的运行时版本。\n\n用法：pinset list <node|pnpm|bun> [--available]"
             }
             Some("uninstall") => {
-                "卸载 Pinset 管理的精确 Node.js 版本。\n\n用法：pinset uninstall node@x.y.z [--cwd <目录>] [--force]"
+                "卸载 Pinset 管理的精确运行时版本。\n\n用法：pinset uninstall <node|pnpm|bun>@x.y.z [--cwd <目录>] [--force]"
             }
             Some("cache") => {
-                "查看或清理已验证的运行时下载缓存。\n\n用法：pinset cache <list|clean>"
+                "查看、清理或离线导入已验证的运行时下载缓存。\n\n用法：pinset cache <list|clean|import>"
             }
             Some("exec") => {
                 "使用当前选择或一次性 Node.js 版本执行命令。\n\n用法：pinset exec [--cwd <目录>] [node@<版本选择器>] -- <命令> [参数...]"
@@ -420,13 +420,13 @@ impl Catalog {
         }
     }
 
-    pub fn cache_entry(self, sha256: &str, size: u64, path: &Path) -> String {
+    pub fn cache_entry(self, integrity: &str, size: u64, path: &Path) -> String {
         match self.language {
             Language::English => {
-                format!("{sha256} cached bytes={size} path={}", path.display())
+                format!("{integrity} cached bytes={size} path={}", path.display())
             }
             Language::SimplifiedChinese => {
-                format!("{sha256} 已缓存 字节数={size} 路径={}", path.display())
+                format!("{integrity} 已缓存 字节数={size} 路径={}", path.display())
             }
         }
     }
@@ -440,14 +440,14 @@ impl Catalog {
         }
     }
 
-    pub fn cache_imported(self, sha256: &str, size: u64, path: &Path) -> String {
+    pub fn cache_imported(self, integrity: &str, size: u64, path: &Path) -> String {
         match self.language {
             Language::English => format!(
-                "imported verified cache archive sha256={sha256} bytes={size} path={}",
+                "imported verified cache archive integrity={integrity} bytes={size} path={}",
                 path.display()
             ),
             Language::SimplifiedChinese => format!(
-                "已导入校验通过的缓存归档：SHA-256={sha256}；字节数={size}；路径={}",
+                "已导入校验通过的缓存归档：完整性={integrity}；字节数={size}；路径={}",
                 path.display()
             ),
         }
@@ -627,9 +627,11 @@ impl Catalog {
 
     pub fn download_finished(self, artifact: &str, downloaded: &str) -> String {
         match self.language {
-            Language::English => format!("downloaded {artifact} ({downloaded}); SHA-256 verified"),
+            Language::English => {
+                format!("downloaded {artifact} ({downloaded}); integrity verified")
+            }
             Language::SimplifiedChinese => {
-                format!("已下载 {artifact}（{downloaded}）；SHA-256 校验通过")
+                format!("已下载 {artifact}（{downloaded}）；完整性校验通过")
             }
         }
     }
@@ -643,6 +645,7 @@ impl Catalog {
 
     pub fn current_installed(
         self,
+        tool: &str,
         version: &str,
         source: &str,
         executable: &Path,
@@ -654,22 +657,24 @@ impl Catalog {
         if source == "system" {
             return match self.language {
                 Language::English => format!(
-                    "node system installed {} source=system config=-",
+                    "{tool} system installed {} source=system config=-",
                     executable.display()
                 ),
                 Language::SimplifiedChinese => format!(
-                    "系统 PATH 中的 Node.js：{}；来源=系统 PATH；配置=-",
+                    "系统 PATH 中的 {}：{}；来源=系统 PATH；配置=-",
+                    self.tool_name(tool),
                     executable.display()
                 ),
             };
         }
         match self.language {
             Language::English => format!(
-                "node {version} installed {} source={source} config={config}",
+                "{tool} {version} installed {} source={source} config={config}",
                 executable.display()
             ),
             Language::SimplifiedChinese => format!(
-                "Node.js {version} 已安装：{}；来源={}; 配置={config}",
+                "{} {version} 已安装：{}；来源={}; 配置={config}",
+                self.tool_name(tool),
                 executable.display(),
                 self.source_name(source)
             ),
@@ -678,6 +683,7 @@ impl Catalog {
 
     pub fn current_missing(
         self,
+        tool: &str,
         version: &str,
         source: &str,
         expected: &Path,
@@ -688,15 +694,20 @@ impl Catalog {
             .unwrap_or_else(|| "-".to_owned());
         match self.language {
             Language::English => format!(
-                "node {version} missing expected={} source={source} config={config}",
+                "{tool} {version} missing expected={} source={source} config={config}",
                 expected.display()
             ),
             Language::SimplifiedChinese => format!(
-                "Node.js {version} 尚未安装；预期路径={}；来源={}; 配置={config}",
+                "{} {version} 尚未安装；预期路径={}；来源={}; 配置={config}",
+                self.tool_name(tool),
                 expected.display(),
                 self.source_name(source)
             ),
         }
+    }
+
+    fn tool_name(self, tool: &str) -> &str {
+        if tool == "node" { "Node.js" } else { tool }
     }
 
     pub fn doctor_line(self, key: &str, value: impl fmt::Display, state: &str) -> String {
@@ -985,8 +996,8 @@ impl Catalog {
 
     pub fn node_only_error(self) -> &'static str {
         match self.language {
-            Language::English => "the Node-first release only accepts the node tool",
-            Language::SimplifiedChinese => "当前 Node-first 版本只接受 node 工具",
+            Language::English => "this operation only accepts the node tool",
+            Language::SimplifiedChinese => "此操作只接受 node 工具",
         }
     }
 

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -16,18 +16,21 @@ use std::ffi::OsStr;
 
 use clap::{Parser, Subcommand, ValueEnum, error::ErrorKind};
 use pinset_core::{
-    DownloadProgressEvent, Error, GlobalConfig, InstallLimits, Installer, Lockfile,
-    NodeMetadataClient, SUPPORTED_SOURCE_PROVIDERS, ShimInstallMethod, SourceView,
-    clean_download_cache, command_tool, create_project_config, current_target, ensure_shims,
-    find_optional_project_config, find_project_config, global_config_path, global_lockfile_path,
-    import_download_cache, install_locked_node, is_managed_command_shim, list_download_cache,
-    list_installed_node_versions, load_global_config, load_lockfile, load_optional_global_config,
-    load_project_config, load_source_config, load_user_settings, lockfile_path,
-    node_command_directory, path_with_selected_runtime, pinset_home, resolve_command,
-    resolve_tool_selection, runtime_provider, save_global_config, save_global_state, save_lockfile,
-    save_project_config, save_source_config, save_user_settings, source_config_path,
-    uninstall_node_version, user_settings_path, validate_exact_node_version,
-    validate_lock_matches_selection,
+    ArtifactIntegrity, DownloadProgressEvent, Error, GlobalConfig, InstallLimits, Installer,
+    LockedTool, Lockfile, NodeMetadataClient, NpmMetadataClient, SUPPORTED_SOURCE_PROVIDERS,
+    ShimInstallMethod, SourceView, clean_download_cache, command_tool, create_project_config,
+    current_target, current_target_for_tool, ensure_shims, find_optional_project_config,
+    find_project_config, global_config_path, global_lockfile_path, import_download_cache,
+    import_download_cache_with_integrity, install_locked_node, install_locked_npm_tool,
+    is_managed_command_shim, list_download_cache, list_installed_tool_versions, load_global_config,
+    load_lockfile, load_optional_global_config, load_optional_lockfile, load_project_config,
+    load_source_config, load_user_settings, lockfile_path, node_command_directory,
+    path_with_selected_tools, pinset_home, resolve_command, resolve_tool_selection,
+    runtime_command_directory, runtime_provider, save_global_config, save_global_state,
+    save_lockfile, save_project_config, save_source_config, save_user_settings, source_config_path,
+    uninstall_node_version, uninstall_tool_version, user_settings_path,
+    validate_exact_node_version, validate_lock_matches_selection, validate_lock_matches_tool,
+    validate_lock_matches_tools,
 };
 use serde::Serialize;
 use terminal_size::{Width, terminal_size_of};
@@ -53,17 +56,17 @@ struct Cli {
 enum Commands {
     /// Create a minimal pinset.toml in the current directory.
     Init,
-    /// Show or set the default Node.js version used outside projects.
+    /// Show or set a default runtime version used outside projects.
     Global {
-        /// Selection such as node@24.0.0, node@24, node@24.12, node@lts or node@current.
+        /// Selection such as node@lts, pnpm@11 or bun@1.3.
         selection: Option<String>,
         /// Update the global selection and lock without downloading the runtime.
         #[arg(long, requires = "selection")]
         no_install: bool,
     },
-    /// Select and lock a Node.js version for the current project or globally.
+    /// Select and lock a runtime version for the current project or globally.
     Use {
-        /// Selection such as node@24.0.0, node@24, node@24.12, node@lts or node@current.
+        /// Selection such as node@24, pnpm@11 or bun@1.3.
         selection: String,
         /// Update the selection and lock without downloading the runtime.
         #[arg(long)]
@@ -72,9 +75,9 @@ enum Commands {
         #[arg(long)]
         global: bool,
     },
-    /// Clear the project or global Node.js selection without uninstalling anything.
+    /// Clear a project or global runtime selection without uninstalling anything.
     Unset {
-        /// Tool to clear. The Node-first release accepts node.
+        /// Tool to clear: node, pnpm or bun.
         tool: String,
         /// Clear the global default instead of the nearest project selection.
         #[arg(long, conflicts_with = "cwd")]
@@ -83,9 +86,9 @@ enum Commands {
         #[arg(long, conflicts_with = "global")]
         cwd: Option<PathBuf>,
     },
-    /// Install an explicit Node.js version or the current project/global lockfile target.
+    /// Install an explicit runtime version or every project/global lockfile target.
     Install {
-        /// Install a Node.js version without changing project or global selection.
+        /// Install a runtime version without changing project or global selection.
         #[arg(conflicts_with_all = ["locked", "global", "cwd"])]
         selection: Option<String>,
         /// Require the selected config and lockfile to match. This is the default.
@@ -105,20 +108,20 @@ enum Commands {
     },
     /// Print the effective project, global or system selection and executable path.
     Current {
-        /// Tool to inspect. Defaults to node in the Node-first release.
+        /// Tool to inspect. Defaults to node.
         tool: Option<String>,
         #[arg(long)]
         cwd: Option<PathBuf>,
     },
-    /// List installed or officially available Node.js versions.
+    /// List installed or officially available runtime versions.
     List {
-        /// Tool to list. The Node-first release accepts node.
+        /// Tool to list: node, pnpm or bun.
         tool: String,
-        /// Query the official Node.js release index instead of local installations.
+        /// Query the official provider index instead of local installations.
         #[arg(long)]
         available: bool,
     },
-    /// Uninstall an exact Node.js version owned by Pinset.
+    /// Uninstall an exact runtime version owned by Pinset.
     Uninstall {
         /// Exact selection such as node@24.0.0.
         selection: String,
@@ -239,8 +242,11 @@ enum CacheCommands {
     Import {
         archive: PathBuf,
         /// Expected SHA-256 from a reviewed pinset.lock or upstream manifest.
-        #[arg(long)]
-        sha256: String,
+        #[arg(long, conflicts_with = "integrity")]
+        sha256: Option<String>,
+        /// Expected SRI or canonical integrity, for example sha512-<base64>.
+        #[arg(long, conflicts_with = "sha256")]
+        integrity: Option<String>,
     },
 }
 
@@ -372,7 +378,7 @@ fn run(cli: Cli, catalog: Catalog) -> Result<ExitCode, Box<dyn std::error::Error
         } => {
             if let Some(selection) = selection {
                 let cwd = env::current_dir()?;
-                select_node(&selection, true, no_install, false, &cwd, catalog)?;
+                select_tool(&selection, true, no_install, false, &cwd, catalog)?;
                 print_project_override(&cwd, &pinset_home()?, catalog)?;
             } else {
                 print_global_current(catalog)?;
@@ -385,13 +391,11 @@ fn run(cli: Cli, catalog: Catalog) -> Result<ExitCode, Box<dyn std::error::Error
             global,
         } => {
             let cwd = env::current_dir()?;
-            select_node(&selection, global, no_install, false, &cwd, catalog)?
+            select_tool(&selection, global, no_install, false, &cwd, catalog)?
         }
         Commands::Unset { tool, global, cwd } => {
-            if tool != "node" {
-                return Err(catalog.node_only_error().into());
-            }
-            unset_node(global, &effective_cwd(cwd)?, catalog)?;
+            require_provider(&tool)?;
+            unset_tool(&tool, global, &effective_cwd(cwd)?, catalog)?;
         }
         Commands::Install {
             selection,
@@ -400,7 +404,7 @@ fn run(cli: Cli, catalog: Catalog) -> Result<ExitCode, Box<dyn std::error::Error
             cwd,
         } => {
             if let Some(selection) = selection {
-                install_node_selection(&selection, catalog)?;
+                install_tool_selection(&selection, catalog)?;
             } else if global {
                 install_global(&pinset_home()?, catalog)?;
             } else {
@@ -417,32 +421,44 @@ fn run(cli: Cli, catalog: Catalog) -> Result<ExitCode, Box<dyn std::error::Error
             print_current(&cwd, tool.as_deref().unwrap_or("node"), catalog)?;
         }
         Commands::List { tool, available } => {
-            if tool != "node" {
-                return Err(catalog.node_only_error().into());
-            }
+            require_provider(&tool)?;
             if available {
-                let releases = node_metadata_client(&pinset_home()?)?.available_releases()?;
-                for release in releases {
-                    println!(
-                        "{}",
-                        catalog.available_node(
-                            &release.version,
-                            &release.date,
-                            release.lts.as_deref(),
-                            release.security,
-                        )
-                    );
-                }
-            } else {
-                let installed = list_installed_node_versions(&pinset_home()?)?;
-                if installed.is_empty() {
-                    println!("{}", catalog.no_installed_node());
-                } else {
-                    for entry in installed {
+                if tool == "node" {
+                    let releases = node_metadata_client(&pinset_home()?)?.available_releases()?;
+                    for release in releases {
                         println!(
                             "{}",
-                            catalog.installed_node(&entry.version, &entry.targets.join(","))
+                            catalog.available_node(
+                                &release.version,
+                                &release.date,
+                                release.lts.as_deref(),
+                                release.security,
+                            )
                         );
+                    }
+                } else {
+                    for release in NpmMetadataClient::official()?.available_releases(&tool)? {
+                        println!("{}@{}", tool, release.version);
+                    }
+                }
+            } else {
+                let installed = list_installed_tool_versions(&pinset_home()?, &tool)?;
+                if installed.is_empty() {
+                    if tool == "node" {
+                        println!("{}", catalog.no_installed_node());
+                    } else {
+                        println!("no Pinset-managed {tool} versions are installed");
+                    }
+                } else {
+                    for entry in installed {
+                        if tool == "node" {
+                            println!(
+                                "{}",
+                                catalog.installed_node(&entry.version, &entry.targets.join(","))
+                            );
+                        } else {
+                            println!("{}@{} [{}]", tool, entry.version, entry.targets.join(","));
+                        }
                     }
                 }
             }
@@ -452,14 +468,29 @@ fn run(cli: Cli, catalog: Catalog) -> Result<ExitCode, Box<dyn std::error::Error
             force,
             cwd,
         } => {
-            let version = parse_node_selection(&selection, catalog)?;
-            validate_exact_node_version(&version)?;
-            let outcome =
-                uninstall_node_version(&pinset_home()?, &effective_cwd(cwd)?, &version, force)?;
-            println!(
-                "{}",
-                catalog.uninstalled_node(&outcome.version, &outcome.targets.join(","))
-            );
+            let (tool, version) = parse_tool_selection(&selection, catalog)?;
+            validate_exact_tool_version(&tool, &version)?;
+            if tool == "node" {
+                let outcome =
+                    uninstall_node_version(&pinset_home()?, &effective_cwd(cwd)?, &version, force)?;
+                println!(
+                    "{}",
+                    catalog.uninstalled_node(&outcome.version, &outcome.targets.join(","))
+                );
+            } else {
+                let outcome = uninstall_tool_version(
+                    &pinset_home()?,
+                    &effective_cwd(cwd)?,
+                    &tool,
+                    &version,
+                    force,
+                )?;
+                println!(
+                    "uninstalled {tool}@{} [{}]",
+                    outcome.version,
+                    outcome.targets.join(",")
+                );
+            }
         }
         Commands::Cache { command } => match command {
             CacheCommands::List => {
@@ -470,7 +501,7 @@ fn run(cli: Cli, catalog: Catalog) -> Result<ExitCode, Box<dyn std::error::Error
                     for entry in entries {
                         println!(
                             "{}",
-                            catalog.cache_entry(&entry.sha256, entry.size, &entry.path)
+                            catalog.cache_entry(&entry.integrity, entry.size, &entry.path)
                         );
                     }
                 }
@@ -479,12 +510,23 @@ fn run(cli: Cli, catalog: Catalog) -> Result<ExitCode, Box<dyn std::error::Error
                 let outcome = clean_download_cache(&pinset_home()?)?;
                 println!("{}", catalog.cache_cleaned(outcome.entries, outcome.bytes));
             }
-            CacheCommands::Import { archive, sha256 } => {
+            CacheCommands::Import {
+                archive,
+                sha256,
+                integrity,
+            } => {
                 let archive = absolutize(&archive)?;
-                let entry = import_download_cache(&pinset_home()?, &archive, &sha256)?;
+                let entry = if let Some(sha256) = sha256 {
+                    import_download_cache(&pinset_home()?, &archive, &sha256)?
+                } else if let Some(integrity) = integrity {
+                    let integrity = ArtifactIntegrity::parse(&integrity)?;
+                    import_download_cache_with_integrity(&pinset_home()?, &archive, &integrity)?
+                } else {
+                    return Err("cache import requires --sha256 or --integrity".into());
+                };
                 println!(
                     "{}",
-                    catalog.cache_imported(&entry.sha256, entry.size, &entry.path)
+                    catalog.cache_imported(&entry.integrity, entry.size, &entry.path)
                 );
             }
         },
@@ -517,7 +559,7 @@ fn run(cli: Cli, catalog: Catalog) -> Result<ExitCode, Box<dyn std::error::Error
             } else {
                 let candidate = select_legacy_candidate(&candidates, source.as_deref(), catalog)?;
                 let selector = normalize_legacy_node_selector(&candidate.version)?;
-                select_node(
+                select_tool(
                     &format!("node@{selector}"),
                     global,
                     no_install,
@@ -593,20 +635,78 @@ fn run(cli: Cli, catalog: Catalog) -> Result<ExitCode, Box<dyn std::error::Error
     Ok(ExitCode::SUCCESS)
 }
 
+fn parse_tool_selection(
+    selection: &str,
+    catalog: Catalog,
+) -> Result<(String, String), Box<dyn std::error::Error>> {
+    let Some((tool, version)) = selection.split_once('@') else {
+        return Err(catalog.selection_error().into());
+    };
+    if version.is_empty() || version.contains('@') {
+        return Err(catalog.selection_error().into());
+    }
+    require_provider(tool)?;
+    Ok((tool.to_owned(), version.to_owned()))
+}
+
 fn parse_node_selection(
     selection: &str,
     catalog: Catalog,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let Some((tool, version)) = selection.split_once('@') else {
-        return Err(catalog.selection_error().into());
-    };
-    if tool != "node" || version.is_empty() || version.contains('@') {
+    let (tool, version) = parse_tool_selection(selection, catalog)?;
+    if tool != "node" {
         return Err(catalog.node_only_error().into());
     }
-    Ok(version.to_owned())
+    Ok(version)
 }
 
-fn select_node(
+fn require_provider(tool: &str) -> Result<(), Box<dyn std::error::Error>> {
+    runtime_provider(tool)
+        .map(|_| ())
+        .ok_or_else(|| format!("runtime provider {tool:?} is not available").into())
+}
+
+fn validate_exact_tool_version(
+    tool: &str,
+    version: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if tool == "node" {
+        validate_exact_node_version(version)?;
+    } else {
+        let resolved = NpmMetadataClient::official()?.resolve_version_selector(tool, version)?;
+        if resolved != version {
+            return Err(format!("{tool}@{version} is not an exact stable version").into());
+        }
+    }
+    Ok(())
+}
+
+fn resolve_locked_tool(
+    tool: &str,
+    selector: &str,
+) -> Result<LockedTool, Box<dyn std::error::Error>> {
+    if tool == "node" {
+        let lockfile = node_metadata_client(&pinset_home()?)?
+            .resolve_lock(selector, &format!("pinset {}", env!("CARGO_PKG_VERSION")))?;
+        return Ok(lockfile
+            .tool("node")
+            .expect("generated Node lock contains node")
+            .clone());
+    }
+    let client = NpmMetadataClient::official()?;
+    let version = client.resolve_version_selector(tool, selector)?;
+    Ok(client.resolve_tool(tool, &version)?)
+}
+
+fn new_lockfile() -> Lockfile {
+    Lockfile {
+        schema: pinset_core::LOCKFILE_SCHEMA,
+        generated_by: format!("pinset {}", env!("CARGO_PKG_VERSION")),
+        tools: Vec::new(),
+    }
+}
+
+fn select_tool(
     selection: &str,
     global: bool,
     no_install: bool,
@@ -614,21 +714,24 @@ fn select_node(
     cwd: &Path,
     catalog: Catalog,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let selector = parse_node_selection(selection, catalog)?;
-    let lockfile = node_metadata_client(&pinset_home()?)?
-        .resolve_lock(&selector, &format!("pinset {}", env!("CARGO_PKG_VERSION")))?;
-    let locked_node = lockfile.tool("node").expect("generated lock contains node");
-    let version = locked_node.version.clone();
+    let (tool, selector) = parse_tool_selection(selection, catalog)?;
+    let locked_tool = resolve_locked_tool(&tool, &selector)?;
+    let version = locked_tool.version.clone();
     if selector != version {
-        println!("{}", catalog.selector_resolved(&selector, &version));
+        println!("{tool}@{selector} resolved to {tool}@{version}");
     }
     let (scope, lock_path) = if global {
         let home = pinset_home()?;
         let config_path = global_config_path(&home);
         let mut config = load_optional_global_config(&config_path)?.unwrap_or_default();
-        config.set_tool("node", &version);
+        let lock_path = global_lockfile_path(&home);
+        let mut lockfile = load_optional_lockfile(&lock_path)?.unwrap_or_else(new_lockfile);
+        lockfile.generated_by = format!("pinset {}", env!("CARGO_PKG_VERSION"));
+        lockfile.upsert_tool(locked_tool.clone());
+        config.set_tool(&tool, &version);
+        validate_lock_matches_tools(&lockfile, &config.tools, &config_path)?;
         save_global_state(&home, &config, &lockfile)?;
-        ("global", global_lockfile_path(&home))
+        ("global", lock_path)
     } else {
         let config_path = match find_optional_project_config(cwd)? {
             Some(path) => path,
@@ -637,22 +740,34 @@ fn select_node(
         };
         let mut project = load_project_config(&config_path)?;
         let lock_path = lockfile_path(&config_path);
+        let mut lockfile = load_optional_lockfile(&lock_path)?.unwrap_or_else(new_lockfile);
+        lockfile.generated_by = format!("pinset {}", env!("CARGO_PKG_VERSION"));
+        lockfile.upsert_tool(locked_tool.clone());
+        project.set_tool(&tool, &version);
+        validate_lock_matches_tools(&lockfile, &project.tools, &config_path)?;
         save_lockfile(&lock_path, &lockfile)?;
-        project.set_tool("node", &version);
         save_project_config(&config_path, &project)?;
         ("project", lock_path)
     };
-    println!(
-        "{}",
-        catalog.selected(scope, &version, locked_node.artifacts.len(), &lock_path)
-    );
+    if tool == "node" {
+        println!(
+            "{}",
+            catalog.selected(scope, &version, locked_tool.artifacts.len(), &lock_path)
+        );
+    } else {
+        println!(
+            "selected {tool}@{version} for {scope} ({} targets, lock {})",
+            locked_tool.artifacts.len(),
+            lock_path.display()
+        );
+    }
     if !no_install {
         if global {
             install_global(&pinset_home()?, catalog)?;
         } else {
             install_project(cwd, catalog)?;
         }
-    } else if let Err(error) = register_provider_commands(&pinset_home()?, "node", catalog) {
+    } else if let Err(error) = register_provider_commands(&pinset_home()?, &tool, catalog) {
         eprintln!(
             "{}",
             catalog.shim_auto_registration_failed(&error.to_string())
@@ -661,24 +776,25 @@ fn select_node(
     Ok(())
 }
 
-fn install_node_selection(
+fn install_tool_selection(
     selection: &str,
     catalog: Catalog,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let selector = parse_node_selection(selection, catalog)?;
-    let lockfile = node_metadata_client(&pinset_home()?)?
-        .resolve_lock(&selector, &format!("pinset {}", env!("CARGO_PKG_VERSION")))?;
-    let locked_node = lockfile.tool("node").expect("generated lock contains node");
-    if selector != locked_node.version {
+    let (tool, selector) = parse_tool_selection(selection, catalog)?;
+    let locked_tool = resolve_locked_tool(&tool, &selector)?;
+    if selector != locked_tool.version {
         println!(
-            "{}",
-            catalog.selector_resolved(&selector, &locked_node.version)
+            "{tool}@{selector} resolved to {tool}@{}",
+            locked_tool.version
         );
     }
-    install_node_from_lock(&pinset_home()?, &lockfile, catalog)
+    let mut lockfile = new_lockfile();
+    lockfile.upsert_tool(locked_tool);
+    install_tool_from_lock(&pinset_home()?, &lockfile, &tool, catalog)
 }
 
-fn unset_node(
+fn unset_tool(
+    tool: &str,
     global: bool,
     cwd: &Path,
     catalog: Catalog,
@@ -690,7 +806,7 @@ fn unset_node(
             println!("{}", catalog.selection_unset("global", &config_path, false));
             return Ok(());
         };
-        if config.tools.remove("node").is_none() {
+        if config.tools.remove(tool).is_none() {
             println!("{}", catalog.selection_unset("global", &config_path, false));
             return Ok(());
         }
@@ -699,14 +815,14 @@ fn unset_node(
             load_lockfile(&lock_path)?;
         }
         save_global_config(&config_path, &config)?;
-        remove_tool_from_lock(&lock_path, "node")?;
+        remove_tool_from_lock(&lock_path, tool)?;
         println!("{}", catalog.selection_unset("global", &config_path, true));
         return Ok(());
     }
 
     let config_path = find_project_config(cwd)?;
     let mut config = load_project_config(&config_path)?;
-    if config.tools.remove("node").is_none() {
+    if config.tools.remove(tool).is_none() {
         println!(
             "{}",
             catalog.selection_unset("project", &config_path, false)
@@ -718,7 +834,7 @@ fn unset_node(
         load_lockfile(&lock_path)?;
     }
     save_project_config(&config_path, &config)?;
-    remove_tool_from_lock(&lock_path, "node")?;
+    remove_tool_from_lock(&lock_path, tool)?;
     println!("{}", catalog.selection_unset("project", &config_path, true));
     Ok(())
 }
@@ -728,7 +844,7 @@ fn remove_tool_from_lock(path: &Path, tool: &str) -> Result<(), Box<dyn std::err
         return Ok(());
     }
     let mut lockfile = load_lockfile(path)?;
-    lockfile.tools.retain(|locked| locked.name != tool);
+    lockfile.remove_tool(tool);
     if lockfile.tools.is_empty() {
         fs::remove_file(path)?;
     } else {
@@ -826,31 +942,17 @@ fn resolve_language(requested: Option<Language>) -> Result<Language, Box<dyn std
 fn install_project(cwd: &Path, catalog: Catalog) -> Result<(), Box<dyn std::error::Error>> {
     let config_path = find_project_config(cwd)?;
     let project = load_project_config(&config_path)?;
-    let configured = project
-        .tools
-        .get("node")
-        .ok_or_else(|| Error::ToolNotConfigured {
-            tool: "node".to_owned(),
-            config_path: config_path.clone(),
-        })?;
     let lock_path = lockfile_path(&config_path);
     let home = pinset_home()?;
-    install_locked_selection(&home, configured, &config_path, &lock_path, catalog)
+    install_locked_selection(&home, &project.tools, &config_path, &lock_path, catalog)
 }
 
 fn install_global(home: &Path, catalog: Catalog) -> Result<(), Box<dyn std::error::Error>> {
     let config_path = global_config_path(home);
     let config: GlobalConfig = load_global_config(&config_path)?;
-    let configured = config
-        .tools
-        .get("node")
-        .ok_or_else(|| Error::ToolNotConfigured {
-            tool: "node".to_owned(),
-            config_path: config_path.clone(),
-        })?;
     install_locked_selection(
         home,
-        configured,
+        &config.tools,
         &config_path,
         &global_lockfile_path(home),
         catalog,
@@ -859,49 +961,75 @@ fn install_global(home: &Path, catalog: Catalog) -> Result<(), Box<dyn std::erro
 
 fn install_locked_selection(
     home: &Path,
-    configured: &str,
+    configured: &std::collections::BTreeMap<String, String>,
     config_path: &Path,
     lock_path: &Path,
     catalog: Catalog,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let lockfile = load_lockfile(lock_path)?;
-    validate_lock_matches_selection(&lockfile, configured, config_path)?;
-    install_node_from_lock(home, &lockfile, catalog)
+    validate_lock_matches_tools(&lockfile, configured, config_path)?;
+    for provider in pinset_core::runtime_providers() {
+        if configured.contains_key(provider.tool) {
+            install_tool_from_lock(home, &lockfile, provider.tool, catalog)?;
+        }
+    }
+    Ok(())
 }
 
-fn install_node_from_lock(
+fn install_tool_from_lock(
     home: &Path,
     lockfile: &Lockfile,
+    tool: &str,
     catalog: Catalog,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let locked_node = lockfile
-        .tool("node")
-        .expect("validated or generated Node lock contains node");
-    let sources = load_source_config(&source_config_path(home))?;
+    let locked_tool = lockfile
+        .tool(tool)
+        .ok_or_else(|| Error::LockedToolMissing {
+            tool: tool.to_owned(),
+        })?;
     let installer = Installer::new(InstallLimits::default())?
         .with_progress_reporter(download_progress_reporter(catalog));
-    let outcome = install_locked_node(&installer, home, &sources, locked_node, &current_target())?;
-    if outcome.reused_existing {
-        println!(
-            "{}",
-            catalog.already_installed(
-                &locked_node.version,
-                &current_target(),
-                &outcome.install_dir,
-            )
-        );
+    let target = current_target_for_tool(tool);
+    let outcome = if tool == "node" {
+        let sources = load_source_config(&source_config_path(home))?;
+        install_locked_node(&installer, home, &sources, locked_tool, &target)?
     } else {
-        println!(
-            "{}",
-            catalog.installed(
-                &locked_node.version,
-                &current_target(),
-                &outcome.source_id,
-                &outcome.install_dir,
-            )
-        );
+        install_locked_npm_tool(&installer, home, locked_tool, &target)?
+    };
+    if outcome.reused_existing {
+        if tool == "node" {
+            println!(
+                "{}",
+                catalog.already_installed(&locked_tool.version, &target, &outcome.install_dir)
+            );
+        } else {
+            println!(
+                "{tool}@{} is already installed for {target} at {}",
+                locked_tool.version,
+                outcome.install_dir.display()
+            );
+        }
+    } else {
+        if tool == "node" {
+            println!(
+                "{}",
+                catalog.installed(
+                    &locked_tool.version,
+                    &target,
+                    &outcome.source_id,
+                    &outcome.install_dir,
+                )
+            );
+        } else {
+            println!(
+                "installed {tool}@{} for {target} from {} at {}",
+                locked_tool.version,
+                outcome.source_id,
+                outcome.install_dir.display()
+            );
+        }
     }
-    if let Err(error) = register_provider_commands(home, "node", catalog) {
+    if let Err(error) = register_provider_commands(home, tool, catalog) {
         eprintln!(
             "{}",
             catalog.shim_auto_registration_failed(&error.to_string())
@@ -1175,11 +1303,14 @@ fn print_global_current(catalog: Catalog) -> Result<(), Box<dyn std::error::Erro
         println!("{}", catalog.global_not_selected(&config_path));
         return Ok(());
     };
-    let Some(version) = config.tools.get("node") else {
+    if config.tools.is_empty() {
         println!("{}", catalog.global_not_selected(&config_path));
         return Ok(());
-    };
-    print_declared_node(&home, version, "global", &config_path, catalog)
+    }
+    for (tool, version) in &config.tools {
+        print_declared_tool(&home, tool, version, "global", &config_path, catalog)?;
+    }
+    Ok(())
 }
 
 fn print_project_override(
@@ -1208,8 +1339,9 @@ fn print_project_override(
     Ok(())
 }
 
-fn print_declared_node(
+fn print_declared_tool(
     home: &Path,
+    tool: &str,
     version: &str,
     source: &str,
     config_path: &Path,
@@ -1217,20 +1349,25 @@ fn print_declared_node(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let install_dir = home
         .join("installs")
-        .join("node")
+        .join(tool)
         .join(version)
-        .join(current_target());
-    let command_dir = node_command_directory(&install_dir, &current_target())?;
-    let executable = node_runtime_command_path(&command_dir, "node");
+        .join(current_target_for_tool(tool));
+    let command_dir = runtime_command_directory(tool, &install_dir);
+    let command = runtime_provider(tool)
+        .and_then(|provider| provider.commands.first())
+        .ok_or_else(|| Error::UnsupportedCommand {
+            command: tool.to_owned(),
+        })?;
+    let executable = runtime_command_path(&command_dir, command);
     if executable.is_file() {
         println!(
             "{}",
-            catalog.current_installed(version, source, &executable, Some(config_path))
+            catalog.current_installed(tool, version, source, &executable, Some(config_path))
         );
     } else {
         println!(
             "{}",
-            catalog.current_missing(version, source, &command_dir, Some(config_path))
+            catalog.current_missing(tool, version, source, &command_dir, Some(config_path))
         );
     }
     Ok(())
@@ -1249,6 +1386,7 @@ fn print_current(
         Ok(resolution) => println!(
             "{}",
             catalog.current_installed(
+                selected_tool,
                 &resolution.version,
                 resolution.source.as_str(),
                 &resolution.executable,
@@ -1257,8 +1395,9 @@ fn print_current(
         ),
         Err(Error::RuntimeCommandNotFound { .. }) => {
             let selection = resolve_tool_selection(selected_tool, cwd, &home)?;
-            print_declared_node(
+            print_declared_tool(
                 &home,
+                selected_tool,
                 &selection.version,
                 selection.source.as_str(),
                 &selection.config_path,
@@ -1309,7 +1448,7 @@ fn execute_selected(
                 .join(&version)
                 .join(current_target());
             let command_dir = node_command_directory(&install_dir, &current_target())?;
-            let executable = node_runtime_command_path(&command_dir, command_name);
+            let executable = runtime_command_path(&command_dir, command_name);
             if !executable.is_file() {
                 return Err(Error::RuntimeCommandNotFound {
                     tool: "node".to_owned(),
@@ -1330,7 +1469,7 @@ fn execute_selected(
                 resolution.selection_path,
             )
         };
-    let runtime_path = path_with_selected_runtime(&executable)?;
+    let runtime_path = path_with_selected_tools(&executable, cwd, &home)?;
     let mut child = command_for_runtime(&executable);
     child
         .args(&command[1..])
@@ -1353,17 +1492,15 @@ fn execute_selected(
     ))
 }
 
-fn node_runtime_command_path(command_dir: &Path, command: &str) -> PathBuf {
+fn runtime_command_path(command_dir: &Path, command: &str) -> PathBuf {
     if cfg!(windows) {
-        let native = command_dir.join(if command == "node" {
-            "node.exe".to_owned()
-        } else {
-            format!("{command}.cmd")
-        });
-        if native.is_file() || command != "node" {
-            return native;
+        for extension in ["exe", "cmd", "bat"] {
+            let candidate = command_dir.join(command).with_extension(extension);
+            if candidate.is_file() {
+                return candidate;
+            }
         }
-        return command_dir.join("node.cmd");
+        return command_dir.join(command).with_extension("exe");
     }
     command_dir.join(command)
 }
@@ -1522,19 +1659,22 @@ fn doctor_report(cwd: &Path) -> Result<DoctorReport, Box<dyn std::error::Error>>
     let shims = command_routing_directory(&home)?;
     let shim_on_path = directory_on_path(&shims);
     let shim_binary = default_shim_binary()?;
-    let commands = runtime_provider("node")
-        .expect("Node provider is built in")
-        .commands;
-    let path_candidates = inspect_path_candidates(commands, &home, &shim_binary);
+    let commands = pinset_core::runtime_providers()
+        .iter()
+        .flat_map(|provider| provider.commands.iter().copied())
+        .collect::<Vec<_>>();
+    let path_candidates = inspect_path_candidates(&commands, &home, &shim_binary);
     let legacy_shims = home.join("shims");
     let legacy_commands = if paths_equal(&legacy_shims, &shims) {
         Vec::new()
     } else {
-        existing_shim_commands(&legacy_shims, commands)
+        existing_shim_commands(&legacy_shims, &commands)
     };
     let routing_issues = collect_routing_issues(
-        selected.is_some(),
-        commands,
+        pinset_core::runtime_providers()
+            .iter()
+            .any(|provider| resolve_tool_selection(provider.tool, cwd, &home).is_ok()),
+        &commands,
         &path_candidates,
         &shims,
         &shim_binary,
@@ -1838,52 +1978,106 @@ fn run_doctor(cwd: &Path, catalog: Catalog) -> Result<(), Box<dyn std::error::Er
         }
     }
 
-    match resolve_tool_selection("node", cwd, &home) {
-        Ok(selection) => {
-            println!(
-                "{}",
-                catalog.doctor_selection(
+    for provider in pinset_core::runtime_providers() {
+        let mut has_declared_selection = false;
+        match resolve_tool_selection(provider.tool, cwd, &home) {
+            Ok(selection) => {
+                has_declared_selection = true;
+                if provider.tool == "node" {
+                    println!(
+                        "{}",
+                        catalog.doctor_selection(
+                            &selection.version,
+                            selection.source.as_str(),
+                            Some(&selection.config_path),
+                        )
+                    );
+                } else {
+                    println!(
+                        "{}",
+                        catalog.doctor_line(
+                            &format!("{}_selection", provider.tool),
+                            format!(
+                                "{}@{} source={} config={}",
+                                provider.tool,
+                                selection.version,
+                                selection.source.as_str(),
+                                selection.config_path.display()
+                            ),
+                            "ok",
+                        )
+                    );
+                }
+                let lock_path = match selection.source {
+                    pinset_core::SelectionSource::Project => lockfile_path(&selection.config_path),
+                    pinset_core::SelectionSource::Global => global_lockfile_path(&home),
+                    pinset_core::SelectionSource::System => unreachable!("declared selection"),
+                };
+                let lockfile = load_lockfile(&lock_path)?;
+                validate_lock_matches_tool(
+                    &lockfile,
+                    provider.tool,
                     &selection.version,
-                    selection.source.as_str(),
-                    Some(&selection.config_path),
-                )
-            );
-            let lock_path = match selection.source {
-                pinset_core::SelectionSource::Project => lockfile_path(&selection.config_path),
-                pinset_core::SelectionSource::Global => global_lockfile_path(&home),
-                pinset_core::SelectionSource::System => unreachable!("declared selection"),
-            };
-            let lockfile = load_lockfile(&lock_path)?;
-            validate_lock_matches_selection(&lockfile, &selection.version, &selection.config_path)?;
-            println!(
-                "{}",
-                catalog.doctor_lock_matches(&lock_path, &selection.version)
-            );
-        }
-        Err(Error::ToolSelectionNotFound { .. }) => {}
-        Err(error) => return Err(error.into()),
-    }
-
-    match resolve_command("node", cwd, &home) {
-        Ok(resolution) => {
-            if resolution.source == pinset_core::SelectionSource::System {
+                    &selection.config_path,
+                )?;
                 println!(
                     "{}",
-                    catalog
-                        .doctor_selection(&resolution.version, resolution.source.as_str(), None,)
+                    if provider.tool == "node" {
+                        catalog.doctor_lock_matches(&lock_path, &selection.version)
+                    } else {
+                        catalog.doctor_line(
+                            &format!("{}_lock", provider.tool),
+                            lock_path.display(),
+                            "ok",
+                        )
+                    }
                 );
             }
-            println!(
-                "{}",
-                catalog.doctor_line("runtime", resolution.executable.display(), "ok")
-            );
+            Err(Error::ToolSelectionNotFound { .. }) => {}
+            Err(error) => return Err(error.into()),
         }
-        Err(Error::RuntimeCommandNotFound { version, .. }) => println!(
-            "{}",
-            catalog.doctor_line("runtime", format!("node@{version}"), "missing")
-        ),
-        Err(Error::CommandSelectionNotFound { .. }) => println!("{}", catalog.no_selection()),
-        Err(error) => return Err(error.into()),
+
+        if provider.tool != "node" && !has_declared_selection {
+            continue;
+        }
+        let command = provider.commands[0];
+        match resolve_command(command, cwd, &home) {
+            Ok(resolution) => {
+                if provider.tool == "node"
+                    && resolution.source == pinset_core::SelectionSource::System
+                {
+                    println!(
+                        "{}",
+                        catalog.doctor_selection(
+                            &resolution.version,
+                            resolution.source.as_str(),
+                            None,
+                        )
+                    );
+                }
+                println!(
+                    "{}",
+                    catalog.doctor_line(
+                        &format!("{}_runtime", provider.tool),
+                        resolution.executable.display(),
+                        "ok",
+                    )
+                );
+            }
+            Err(Error::RuntimeCommandNotFound { version, .. }) => println!(
+                "{}",
+                catalog.doctor_line(
+                    &format!("{}_runtime", provider.tool),
+                    format!("{}@{version}", provider.tool),
+                    "missing",
+                )
+            ),
+            Err(Error::CommandSelectionNotFound { .. }) if provider.tool == "node" => {
+                println!("{}", catalog.no_selection())
+            }
+            Err(Error::CommandSelectionNotFound { .. }) => {}
+            Err(error) => return Err(error.into()),
+        }
     }
 
     let shims = command_routing_directory(&home)?;
@@ -1901,10 +2095,11 @@ fn run_doctor(cwd: &Path, catalog: Catalog) -> Result<(), Box<dyn std::error::Er
         )
     );
     let shim_binary = default_shim_binary()?;
-    let commands = runtime_provider("node")
-        .expect("Node provider is built in")
-        .commands;
-    let path_candidates = inspect_path_candidates(commands, &home, &shim_binary);
+    let commands = pinset_core::runtime_providers()
+        .iter()
+        .flat_map(|provider| provider.commands.iter().copied())
+        .collect::<Vec<_>>();
+    let path_candidates = inspect_path_candidates(&commands, &home, &shim_binary);
     for candidate in &path_candidates {
         println!(
             "{}",
@@ -1921,12 +2116,14 @@ fn run_doctor(cwd: &Path, catalog: Catalog) -> Result<(), Box<dyn std::error::Er
     let legacy_commands = if paths_equal(&legacy_shims, &shims) {
         Vec::new()
     } else {
-        existing_shim_commands(&legacy_shims, commands)
+        existing_shim_commands(&legacy_shims, &commands)
     };
-    let selected = resolve_tool_selection("node", cwd, &home).is_ok();
+    let selected = pinset_core::runtime_providers()
+        .iter()
+        .any(|provider| resolve_tool_selection(provider.tool, cwd, &home).is_ok());
     for issue in collect_routing_issues(
         selected,
-        commands,
+        &commands,
         &path_candidates,
         &shims,
         &shim_binary,

--- a/crates/pinset/tests/init_cli.rs
+++ b/crates/pinset/tests/init_cli.rs
@@ -19,7 +19,7 @@ fn init_creates_a_minimal_config_without_runtime_side_effects() {
     let config_path = project.join("pinset.toml");
     assert_eq!(
         fs::read_to_string(&config_path).expect("created config"),
-        "schema = 1\n\n[tools]\n"
+        "schema = 2\n\n[tools]\n"
     );
     assert!(String::from_utf8_lossy(&output.stdout).contains(&config_path.display().to_string()));
     assert!(!isolated_home.exists());

--- a/crates/pinset/tests/language_cli.rs
+++ b/crates/pinset/tests/language_cli.rs
@@ -49,8 +49,8 @@ fn saves_chinese_and_uses_it_for_following_commands() {
     assert!(stderr.contains("版本选择必须使用"), "stderr: {stderr}");
 
     let help = pinset(&first_project, &home, &["--lang", "zh-CN", "use", "--help"]);
-    assert_success_contains(&help, "选择并锁定 Node.js 版本");
-    assert_success_contains(&help, "主版本|主次版本|lts|current");
+    assert_success_contains(&help, "选择并锁定 Node.js、pnpm 或 Bun 版本");
+    assert_success_contains(&help, "node@24|pnpm@11|bun@1.3");
     assert!(
         !String::from_utf8_lossy(&help.stdout).contains("Usage:"),
         "help should be localized: {}",
@@ -62,7 +62,7 @@ fn saves_chinese_and_uses_it_for_following_commands() {
         &home,
         &["--lang", "zh-CN", "global", "--help"],
     );
-    assert_success_contains(&global_help, "查看或设置项目之外使用的全局默认 Node.js");
+    assert_success_contains(&global_help, "查看或设置项目之外使用的全局默认运行时");
     assert_success_contains(&global_help, "pinset global");
 
     let activate_help = pinset(
@@ -78,7 +78,7 @@ fn saves_chinese_and_uses_it_for_following_commands() {
         &home,
         &["--lang", "zh-CN", "install", "--help"],
     );
-    assert_success_contains(&install_help, "pinset install node@<版本选择器>");
+    assert_success_contains(&install_help, "pinset install <node|pnpm|bun>@<版本选择器>");
 
     let import_help = pinset(
         &first_project,
@@ -99,7 +99,7 @@ fn saves_chinese_and_uses_it_for_following_commands() {
         &home,
         &["--lang", "zh-CN", "unset", "--help"],
     );
-    assert_success_contains(&unset_help, "清除项目或全局 Node.js 选择");
+    assert_success_contains(&unset_help, "清除项目或全局运行时选择");
 
     let argument_error = pinset(&first_project, &home, &["--lang", "zh-CN", "use"]);
     assert!(!argument_error.status.success());

--- a/crates/pinset/tests/multi_provider_cli.rs
+++ b/crates/pinset/tests/multi_provider_cli.rs
@@ -1,0 +1,125 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+use tempfile::tempdir;
+
+#[test]
+fn resolves_lists_and_executes_pnpm_and_bun_with_a_composite_path() {
+    let root = tempdir().expect("root");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    fs::create_dir(&project).expect("project");
+    fs::write(
+        project.join("pinset.toml"),
+        "schema = 2\n\n[tools]\nbun = \"1.3.14\"\npnpm = \"11.21.0\"\n",
+    )
+    .expect("config");
+
+    let pnpm_dir = install_dir(&home, "pnpm", "11.21.0");
+    fs::create_dir_all(&pnpm_dir).expect("pnpm dir");
+    write_command(&pnpm_dir, "pnpm", nested_bun_command());
+    write_receipt(&pnpm_dir, "pnpm", "11.21.0");
+
+    let bun_dir = install_dir(&home, "bun", "1.3.14").join("bin");
+    fs::create_dir_all(&bun_dir).expect("bun dir");
+    write_command(&bun_dir, "bun", &echo_command("fake-bun-1.3.14"));
+    write_command(&bun_dir, "bunx", &echo_command("fake-bunx-1.3.14"));
+    write_receipt(bun_dir.parent().expect("bun install root"), "bun", "1.3.14");
+
+    let which_pnpm = pinset(&project, &home, &["which", "pnpm"]);
+    assert_success_contains(&which_pnpm, "pnpm");
+    let which_bunx = pinset(&project, &home, &["which", "bunx"]);
+    assert_success_contains(&which_bunx, "bunx");
+
+    let current_pnpm = pinset(&project, &home, &["current", "pnpm"]);
+    assert_success_contains(&current_pnpm, "pnpm 11.21.0");
+    let current_bun = pinset(&project, &home, &["current", "bun"]);
+    assert_success_contains(&current_bun, "bun 1.3.14");
+
+    let executed = pinset(&project, &home, &["exec", "--", "pnpm", "--version"]);
+    assert_success_contains(&executed, "fake-bun-1.3.14");
+
+    let pnpm_list = pinset(&project, &home, &["list", "pnpm"]);
+    assert_success_contains(&pnpm_list, "pnpm@11.21.0");
+    let bun_list = pinset(&project, &home, &["list", "bun"]);
+    assert_success_contains(&bun_list, "bun@1.3.14");
+}
+
+fn install_dir(home: &Path, tool: &str, version: &str) -> PathBuf {
+    home.join("installs")
+        .join(tool)
+        .join(version)
+        .join(pinset_core::current_target_for_tool(tool))
+}
+
+fn write_receipt(directory: &Path, tool: &str, version: &str) {
+    let target = pinset_core::current_target_for_tool(tool);
+    fs::write(
+        directory.join(".pinset-install.toml"),
+        format!(
+            "schema = 2\ncomplete = true\ntool = \"{tool}\"\nversion = \"{version}\"\ntarget = \"{target}\"\n"
+        ),
+    )
+    .expect("receipt");
+}
+
+#[cfg(windows)]
+fn write_command(directory: &Path, command: &str, body: &str) {
+    fs::write(directory.join(format!("{command}.cmd")), body).expect("command");
+}
+
+#[cfg(unix)]
+fn write_command(directory: &Path, command: &str, body: &str) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = directory.join(command);
+    fs::write(&path, body).expect("command");
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).expect("executable");
+}
+
+#[cfg(windows)]
+fn nested_bun_command() -> &'static str {
+    "@echo off\r\nbun --version\r\n"
+}
+
+#[cfg(unix)]
+fn nested_bun_command() -> &'static str {
+    "#!/bin/sh\nexec bun --version\n"
+}
+
+#[cfg(windows)]
+fn echo_command(value: &str) -> String {
+    format!("@echo off\r\necho {value}\r\n")
+}
+
+#[cfg(unix)]
+fn echo_command(value: &str) -> String {
+    format!("#!/bin/sh\nprintf '%s\\n' '{value}'\n")
+}
+
+fn pinset(project: &Path, home: &Path, arguments: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_pinset"))
+        .current_dir(project)
+        .env("PINSET_HOME", home)
+        .env("PINSET_LANG", "en")
+        .args(arguments)
+        .output()
+        .expect("run pinset")
+}
+
+fn assert_success_contains(output: &Output, expected: &str) {
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains(expected),
+        "expected {expected:?}, stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}

--- a/crates/pinset/tests/mvp_cli.rs
+++ b/crates/pinset/tests/mvp_cli.rs
@@ -290,7 +290,9 @@ fn doctor_reports_all_node_provider_commands_and_path_shadowing() {
         .collect::<std::collections::BTreeSet<_>>();
     assert_eq!(
         commands,
-        ["corepack", "node", "npm", "npx"].into_iter().collect()
+        ["bun", "bunx", "corepack", "node", "npm", "npx", "pnpm"]
+            .into_iter()
+            .collect()
     );
     assert!(
         report["routing_issues"]
@@ -588,7 +590,7 @@ fn doctor_json_and_import_preview_are_machine_readable_and_read_only() {
     );
     assert_eq!(
         fs::read_to_string(project.join("pinset.toml")).expect("project config"),
-        "schema = 1\n\n[tools]\nnode = \"24.0.0\"\n"
+        "schema = 2\n\n[tools]\nnode = \"24.0.0\"\n"
     );
 
     let conflict = pinset(&project, &home, &["import", "--apply", "--no-install"]);
@@ -600,7 +602,7 @@ fn doctor_json_and_import_preview_are_machine_readable_and_read_only() {
     );
     assert_eq!(
         fs::read_to_string(project.join("pinset.toml")).expect("project config"),
-        "schema = 1\n\n[tools]\nnode = \"24.0.0\"\n"
+        "schema = 2\n\n[tools]\nnode = \"24.0.0\"\n"
     );
 }
 
@@ -662,6 +664,7 @@ fn locked_artifact(version: &str, target: &str) -> LockedArtifact {
         canonical_url: plan.canonical_url,
         artifact_path: plan.artifact_path,
         sha256: "ab".repeat(32),
+        integrity: None,
         format: match plan.format {
             NodeArchiveFormat::Zip => LockedArtifactFormat::Zip,
             NodeArchiveFormat::TarXz => LockedArtifactFormat::TarXz,
@@ -751,6 +754,13 @@ fn create_fake_system_node(directory: &Path) -> PathBuf {
             "@echo off\r\nif \"%1\"==\"exit23\" exit /b 23\r\necho system:%*\r\necho source=%PINSET_SELECTION_SOURCE%\r\n",
         )
         .expect("fake system node");
+        for command in ["npm", "npx", "corepack", "pnpm", "bun", "bunx"] {
+            fs::write(
+                directory.join(format!("{command}.cmd")),
+                format!("@echo off\r\necho fake {command}\r\n"),
+            )
+            .expect("fake system command");
+        }
         executable
     }
 
@@ -769,6 +779,20 @@ fn create_fake_system_node(directory: &Path) -> PathBuf {
             .permissions();
         permissions.set_mode(0o755);
         fs::set_permissions(&executable, permissions).expect("fake system node permissions");
+        for command in ["npm", "npx", "corepack", "pnpm", "bun", "bunx"] {
+            let command_path = directory.join(command);
+            fs::write(
+                &command_path,
+                format!("#!/bin/sh\nprintf '%s\\n' 'fake {command}'\n"),
+            )
+            .expect("fake system command");
+            let mut command_permissions = fs::metadata(&command_path)
+                .expect("fake system command metadata")
+                .permissions();
+            command_permissions.set_mode(0o755);
+            fs::set_permissions(&command_path, command_permissions)
+                .expect("fake system command permissions");
+        }
         executable
     }
 }

--- a/crates/pinset/tests/node_discovery_cli.rs
+++ b/crates/pinset/tests/node_discovery_cli.rs
@@ -39,11 +39,11 @@ fn local_node_listing_and_help_are_localized() {
     assert_success_contains(&empty, "尚未安装任何 Node.js 版本");
 
     let help = pinset(&workspace, &home, &["--lang", "zh-CN", "list", "--help"]);
-    assert_success_contains(&help, "列出本机已安装或官方可用的 Node.js 版本");
+    assert_success_contains(&help, "列出本机已安装或官方可用的运行时版本");
 
     let unsupported = pinset(&workspace, &home, &["--lang", "zh-CN", "list", "python"]);
     assert!(!unsupported.status.success());
-    assert!(stderr(&unsupported).contains("只接受 node 工具"));
+    assert!(stderr(&unsupported).contains("python"));
 }
 
 fn create_install_receipt(home: &Path, version: &str, target: &str) {

--- a/crates/pinset/tests/node_lifecycle_cli.rs
+++ b/crates/pinset/tests/node_lifecycle_cli.rs
@@ -109,7 +109,36 @@ fn cache_import_requires_and_records_the_declared_sha256() {
         ],
     );
     assert!(!rejected.status.success());
-    assert!(stderr(&rejected).contains("SHA-256 mismatch"));
+    assert!(stderr(&rejected).contains("artifact integrity mismatch"));
+}
+
+#[test]
+fn cache_import_accepts_npm_sha512_integrity() {
+    let root = tempdir().expect("temporary root");
+    let home = root.path().join("home");
+    let project = root.path().join("project");
+    let archive = root.path().join("pnpm.tgz");
+    fs::create_dir_all(&project).expect("project");
+    fs::write(&archive, b"offline npm archive").expect("archive");
+    let sri = "sha512-fslFPQZh8o/BbjdWiKi5xaXVu9F+w4u351b6/BgD4pFONk1/lTPjNyL9bHzA5cWemHg+RgWJkXrarpWDZOYyzQ==";
+    let hash = "7ec9453d0661f28fc16e375688a8b9c5a5d5bbd17ec38bb7e756fafc1803e2914e364d7f9533e33722fd6c7cc0e5c59e98783e460589917adaae958364e632cd";
+
+    let imported = pinset(
+        &project,
+        &home,
+        &[
+            "cache",
+            "import",
+            archive.to_str().expect("UTF-8 archive"),
+            "--integrity",
+            sri,
+        ],
+    );
+    assert_success_contains(&imported, sri);
+    assert_eq!(
+        fs::read(home.join(format!("downloads/sha512/{hash}.archive"))).expect("cached archive"),
+        b"offline npm archive"
+    );
 }
 
 fn create_install_receipt(home: &Path, version: &str, target: &str) {

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -1,12 +1,12 @@
 # Pinset Plans
 
-当前版本：`v0.1.0-beta.1`
+当前发布候选：`v0.2.0`
 
-下一个版本：`v0.1.0`
+最新已发布版本：`v0.1.0-beta.1`
 
 更新时间：`2026-08-12`
 
-Beta 已发布。接下来继续完善 Node 支持，处理实际使用中的兼容问题，并准备稳定版。
+`v0.2.0` 在 Node Provider 基础上加入独立 pnpm 与 Bun Provider。功能和本地门禁已完成，发布由标签触发的三平台真实运行时验收作最终裁决。
 
 ## 版本路线
 
@@ -19,10 +19,23 @@ Beta 已发布。接下来继续完善 Node 支持，处理实际使用中的兼
 | `v0.1.0-alpha.5` | 已发布 | 自动注册 node/npm/npx/corepack、独立安装和旧 shim 迁移 |
 | `v0.1.0-alpha.6` | 已发布 | 完整卸载脚本和跨 Shell 修复 |
 | `v0.1.0-beta.1` | 已发布 | 简短安装命令、断点续传、可信镜像、离线导入和三平台 Node 测试 |
-| `v0.1.0` | 计划中 | 上游签名验证、兼容性确认和 Beta 问题修复 |
-| `v0.2.0+` | 未排期 | 评估 Python、Flutter 等 Provider |
+| `v0.2.0` | 待发布 | pnpm 10/11、Bun 1.x、多工具 schema 2、npm 签名与 SHA-512 |
+| `v0.3.0+` | 未排期 | 评估 Python、Flutter 等 Provider |
 
-版本号不对应固定日期。稳定版完成前不会加入新的 Provider。
+版本号不对应固定日期。`v0.2.0` 发布前不创建 Release 或 tag，三平台任一真实运行时验收失败都继续保留为开发版本。
+
+## v0.2.0 范围
+
+- `pinset list pnpm --available` 与 `pinset list bun --available`；
+- pnpm 10/11、Bun 1.x 的精确/主版本/主次版本/`latest`/`current` 选择器；
+- npm 官方平台包、SHA-512 SRI 与 registry ECDSA 签名；
+- schema 2 同时保存 Node、pnpm、Bun，并继续读取 schema 1；
+- `.tar.gz` 安全解压，SHA-256/SHA-512 分仓缓存和 `--integrity` 离线导入；
+- pnpm、bun、bunx 命令路由，以及排除 shim 的多 Provider 组合 PATH；
+- Bun x64 AVX2/baseline 自动选择；
+- 通用本地列表、卸载、current、which 和文本 doctor 检查。
+
+不在 `v0.2.0` 中加入 Corepack 驱动的 pnpm、Node 依赖、包依赖管理、Python、Flutter、新 Release 平台或自动修改 shell profile。
 
 ## Beta 已完成
 
@@ -85,12 +98,12 @@ git diff --check
 
 如果任一平台测试失败，本次 Release 不发布残缺资产，也不手动绕过工作流。
 
-## v0.1.0 计划
+## 稳定版计划
 
-稳定版仍然只做 Node，主要工作有：
+稳定版在 Node、pnpm、Bun 三个 Provider 基础上继续完成：
 
 1. 验证 Node 上游 `SHASUMS256.txt.sig`，整理发布密钥的更新和撤销方式；
-2. 确认 schema 1 的兼容规则和迁移方式；
+2. 冻结 schema 1 读取兼容与 schema 2 写入规则；
 3. 修复 Beta 用户在代理、镜像、断点续传、离线导入和旧管理器迁移中发现的问题；
 4. 增加更多三平台实际使用测试；
 5. 制定 Release 撤回和安全公告流程；
@@ -98,7 +111,7 @@ git diff --check
 
 ## 后续 Provider
 
-Python 和 Flutter 放在 Node 稳定版之后评估。
+Python 和 Flutter 放在当前三个 Provider 稳定后评估。
 
 Python 需要先确定解释器来源、校验方式、虚拟环境职责和系统 Python 回退规则。Flutter 需要确定 SDK 索引、channel、精确版本、Flutter/Dart 命令路由，以及 Android/iOS 工具链与 Pinset 的职责范围。
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,14 +1,14 @@
 # Pinset PRD
 
-文档版本：`v0.1.0-beta.1`
-产品阶段：`Node-first Beta`
+文档版本：`v0.2.0`
+产品阶段：`Multi-provider development`
 更新时间：`2026-08-12`
 
 ## 1. 产品简介
 
 Pinset 是一个本地优先、跨平台的运行时版本管理 CLI。它用一致的命令完成版本选择、锁定、安装、执行、镜像、缓存和诊断，减少在 nvm/fnm、uv、FVM 等工具之间切换的成本。
 
-后续可以增加其他 Provider。`v0.1.0-beta.1` 只支持 Node.js，Python 和 Flutter 暂不纳入。
+`v0.2.0` 支持 Node.js、pnpm 和 Bun。Python 和 Flutter 暂不纳入。
 
 ### 1.1 目标
 
@@ -28,8 +28,8 @@ Pinset 是一个本地优先、跨平台的运行时版本管理 CLI。它用一
 
 ### 1.3 本版本不做
 
-- 不在 Beta 接入 Python、Flutter、Java 等新 Provider；
-- 不替代 npm、pnpm、yarn 等包管理器；
+- 不接入 Python、Flutter、Java 等其他 Provider；
+- 不管理 npm、pnpm、Bun 中的项目依赖或全局包；
 - 不管理项目依赖包或全局 npm 包；
 - 不自动修改 shell profile、系统 PATH、IDE 配置或系统注册表；
 - 不维护第三方 Homebrew Tap、Scoop Bucket 或其他外部包仓库；
@@ -54,14 +54,14 @@ Pinset 是一个本地优先、跨平台的运行时版本管理 CLI。它用一
 
 - 默认只接受 HTTPS 下载源；
 - 自定义源默认只替换归档传输，不替换官方校验元数据；
-- SHA-256 不匹配立即停止，不继续 fallback；
+- 归档完整性不匹配立即停止，不继续 fallback；
 - 安装在临时目录完成校验和解压后再原子提交；
 - 不覆盖无法证明由 Pinset 所有的命令或目录；
 - 只删除经过路径和所有权检查的 Pinset 文件。
 
 ### 2.5 运行时中立
 
-curl 安装器只安装 `pinset` 与 `pinset-shim`。Node Provider 在用户选择或安装 Node 时注册 `node`、`npm`、`npx`、`corepack`；未来其他 Provider 使用同一注册模型。
+curl 安装器只安装 `pinset` 与 `pinset-shim`。Node Provider 注册 `node`、`npm`、`npx`、`corepack`，pnpm Provider 注册 `pnpm`，Bun Provider 注册 `bun`、`bunx`。
 
 ## 3. 支持矩阵
 
@@ -93,10 +93,12 @@ WSL 使用 Linux 归档，不能运行 Windows `.exe`，也不能复用 Windows 
 表达用户意图，可提交：
 
 ```toml
-schema = 1
+schema = 2
 
 [tools]
-node = "24"
+node = "24.0.0"
+pnpm = "11.21.0"
+bun = "1.3.14"
 ```
 
 ### 4.2 项目锁文件 `pinset.lock`
@@ -105,7 +107,7 @@ node = "24"
 
 - schema；
 - Provider 和精确版本；
-- 每个目标平台的归档 URL、格式和 SHA-256；
+- 每个目标平台的归档 URL、格式和完整性值；
 - 校验元数据来源；
 - 生成信息。
 
@@ -125,7 +127,7 @@ Provider 声明：
 - 运行时命令集合；
 - 安装、验证和命令路由规则。
 
-Node Provider 声明 `node`、`npm`、`npx`、`corepack`。
+Node Provider 声明 `node`、`npm`、`npx`、`corepack`；pnpm Provider 声明 `pnpm`；Bun Provider 声明 `bun`、`bunx`。
 
 ### 4.5 通用命令路由
 
@@ -142,9 +144,9 @@ Node Provider 声明 `node`、`npm`、`npx`、`corepack`。
 
 ### 4.7 下载缓存
 
-- 完整归档：`PINSET_HOME/downloads/sha256/<hash>.archive`；
-- 断点文件：`PINSET_HOME/downloads/partial/<hash>.part`；
-- 相同 SHA-256 跨来源、跨项目复用；
+- 完整归档：`PINSET_HOME/downloads/{sha256|sha512}/<hash>.archive`；
+- 断点文件：`PINSET_HOME/downloads/partial/{sha256|sha512}/<hash>.part`；
+- 相同完整性值跨来源、跨项目复用；
 - 未知文件和非普通文件不会被当作缓存处理。
 
 ## 5. Node 功能
@@ -329,14 +331,29 @@ Beta 支持：
 
 正常提示、帮助、诊断、常见错误和进度信息应接入统一目录；底层操作系统错误、路径、URL 和哈希保留原值。
 
+## 6.1 pnpm 与 Bun Provider
+
+pnpm Provider 支持稳定版 10 和 11，Bun Provider 支持稳定版 1.x。两者均可使用精确、主版本、主次版本、`latest` 和 `current` 选择器，并通过 `list <tool> --available` 查看满足全部发布目标的稳定版本。
+
+- pnpm 从 `@pnpm/exe` 的精确 `optionalDependencies` 解析 `@pnpm/win-x64`、`@pnpm/linux-x64`、`@pnpm/macos-arm64`；
+- Bun 从 `bun` 的精确 `optionalDependencies` 解析 `@oven` 平台包；
+- Bun x64 同时锁定 AVX2 与 baseline 包，当前机器安装目标通过 CPU 能力选择；
+- 平台包必须使用官方 npm HTTPS tarball、SHA-512 SRI 和可由 npm registry 当前公钥验证的 ECDSA 签名；
+- npm 包以 `.tar.gz` 安全解压，strip `package/` 后验证 `pnpm(.exe)` 或 `bin/bun(.exe)`；
+- Bun 安装后创建受安装目录约束的 `bunx` 硬链接，文件系统不支持时退回复制；
+- pnpm/Bun 不要求 Node 已选择或已安装，也不通过 Corepack 安装。
+
+多个 Provider 同时选择时，子进程 PATH 依次包含当前命令目录和其他已选择、已安装 Provider 的命令目录，再追加继承 PATH；Pinset shim 目录必须排除，以防脚本中的跨工具调用递归进入 shim。
+
 ## 7. 安全和供应链
 
-### 7.1 Node 归档
+### 7.1 Provider 归档
 
 - 从可信元数据源获得预期 SHA-256；
 - 下载源不得改变锁文件中的预期哈希；
 - 所有归档在解压前校验；
 - Beta 尚未验证 Node 上游 `SHASUMS256.txt.sig` 的 OpenPGP 签名，计划在稳定版加入。
+- pnpm/Bun 使用 npm 平台包的 SHA-512 SRI，并在锁定阶段验证 npm registry ECDSA 签名；安装阶段重新计算 SHA-512。
 
 ### 7.2 Pinset Release
 
@@ -385,7 +402,7 @@ Beta 支持：
 - shim 轻依赖检查；
 - `git diff --check`。
 
-这些检查只使用临时目录、假归档和本地服务，不在开发机安装真实 Node。
+这些检查只使用临时目录、假归档和本地服务，不在开发机安装真实运行时。
 
 ### 9.2 Release 检查
 
@@ -393,10 +410,11 @@ Beta 支持：
 
 - 构建 locked release 二进制；
 - 设置中文并验证持久化；
-- 安装一个全局 Node 和一个项目 Node；
+- 安装一个全局 Node、一个项目 Node、一个 pnpm 和一个 Bun；
 - 验证项目覆盖与离开项目后的全局恢复；
-- 验证 `pinset exec` 下的 node/npm/npx/corepack；
-- 验证 PATH 直接调用的 node/npm/npx/corepack；
+- 验证 `pinset exec` 下的 node/npm/npx/corepack/pnpm/bun/bunx；
+- 验证 PATH 直接调用的 node/npm/npx/corepack/pnpm/bun/bunx；
+- 验证项目 Node 覆盖与 pnpm 子进程组合 PATH；
 - 运行安装器/卸载器隔离测试；
 - 生成并发布归档、校验、SBOM 和来源证明。
 
@@ -404,13 +422,13 @@ Beta 支持：
 
 ## 10. 稳定版前待办
 
-`v0.1.0` 计划完成：
+稳定版前计划完成：
 
 - 验证 Node 上游 SHASUMS OpenPGP 签名，并定义密钥轮换策略；
-- 冻结 schema 1 兼容承诺和迁移策略；
+- 冻结 schema 1 读取兼容、schema 2 写入承诺和迁移策略；
 - 完成 Beta 用户在代理、镜像、离线和旧管理器迁移场景的反馈修复；
 - 决定 Linux arm64 与 macOS Intel 正式归档策略；
 - 完成发布回滚、撤回和安全公告流程；
-- Node 稳定版完成前不增加新 Provider。
+- 完成 Node、pnpm、Bun 的三平台真实运行时验收。
 
-Python 和 Flutter 排在 `v0.1.0` 之后。实现时复用现有 Provider、来源、缓存、路由和安全机制，不在 CLI 中增加语言专用的零散逻辑。
+Python 和 Flutter 排在当前三个 Provider 稳定之后。实现时复用现有 Provider、来源、缓存、路由和安全机制，不在 CLI 中增加语言专用的零散逻辑。

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,27 @@
 # Pinset Release Notes
 
+## v0.2.0（待发布）
+
+- 目标日期：`2026-08-12`
+- 阶段：多 Provider Beta / GitHub Release
+- 许可证：MIT
+- Pinset 归档：Linux x64、Windows x64、macOS Apple Silicon
+- 运行时：Node.js、pnpm 10/11、Bun 1.x
+- GitHub Release：[v0.2.0](https://github.com/Future-Element/pinset/releases/tag/v0.2.0)
+
+### 更新内容
+
+- 新增独立 pnpm Provider：稳定版 10/11，命令 `pnpm`；
+- 新增独立 Bun Provider：稳定版 1.x，命令 `bun`/`bunx`，x64 自动选择 AVX2 或 baseline；
+- 新增 `pinset list pnpm --available` 与 `pinset list bun --available`；
+- 项目/全局配置与锁文件升级为 schema 2，可同时保存 Node、pnpm、Bun，并继续读取 schema 1；
+- npm 平台包在锁定阶段验证 registry ECDSA 签名，安装阶段验证 SHA-512 SRI；
+- 安装器新增安全 `.tar.gz` 解压，缓存新增 SHA-512 分仓与 `cache import --integrity`；
+- 子进程使用多 Provider 组合 PATH，并排除 Pinset shim，支持工具之间安全调用；
+- 本地版本列表和卸载扩展到 pnpm/Bun。
+
+发布候选已通过 Windows 与 Ubuntu WSL 完整测试、`.tar.gz + SHA512`、多 Provider PATH、旧 Node 回归、官方 registry 版本列表和精确签名锁验证。本地访问运行时归档 CDN 时传输停滞，因此 Linux、Windows、macOS Release Runner 的真实 Node/pnpm/Bun 安装与执行仍是创建公开 Release 的阻断门禁。
+
 ## v0.1.0-beta.1
 
 - 发布日期：`2026-08-12`

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="0.1.0-beta.1"
+DEFAULT_VERSION="0.2.0"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -18,7 +18,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 0.1.0-beta.1.
+  --version VERSION       Install an exact release, for example 0.2.0.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.

--- a/scripts/tests/ubuntu_runtime_acceptance.sh
+++ b/scripts/tests/ubuntu_runtime_acceptance.sh
@@ -5,9 +5,12 @@ set -euo pipefail
 
 GLOBAL_VERSION="${PINSET_GLOBAL_VERSION:-24.0.0}"
 PROJECT_VERSION="${PINSET_PROJECT_VERSION:-22.0.0}"
+PNPM_VERSION="${PINSET_PNPM_VERSION:-11.21.0}"
+BUN_VERSION="${PINSET_BUN_VERSION:-1.3.14}"
 VERSION_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+$'
 
-if [[ ! "$GLOBAL_VERSION" =~ $VERSION_PATTERN ]] || [[ ! "$PROJECT_VERSION" =~ $VERSION_PATTERN ]]; then
+if [[ ! "$GLOBAL_VERSION" =~ $VERSION_PATTERN ]] || [[ ! "$PROJECT_VERSION" =~ $VERSION_PATTERN ]] ||
+   [[ ! "$PNPM_VERSION" =~ $VERSION_PATTERN ]] || [[ ! "$BUN_VERSION" =~ $VERSION_PATTERN ]]; then
   echo "acceptance versions must use x.y.z" >&2
   exit 2
 fi
@@ -29,6 +32,10 @@ grep -F '语言已切换为中文' language.txt
 grep -F 'language = "zh-CN"' "$PINSET_HOME/settings.toml"
 
 "$PINSET_BIN" use "node@$GLOBAL_VERSION" --global
+"$PINSET_BIN" list pnpm --available | grep -F "pnpm@$PNPM_VERSION"
+"$PINSET_BIN" list bun --available | grep -F "bun@$BUN_VERSION"
+"$PINSET_BIN" use "pnpm@$PNPM_VERSION" --global
+"$PINSET_BIN" use "bun@$BUN_VERSION" --global
 "$PINSET_BIN" current node | tee global-current.txt
 grep -F "Node.js $GLOBAL_VERSION" global-current.txt
 grep -F '来源=全局' global-current.txt
@@ -36,6 +43,9 @@ grep -F '来源=全局' global-current.txt
 "$PINSET_BIN" exec -- npm --version | grep -E '^[0-9]+\.[0-9]+\.[0-9]+'
 "$PINSET_BIN" exec -- npx --version | grep -E '^[0-9]+\.[0-9]+\.[0-9]+'
 "$PINSET_BIN" exec -- corepack --version | grep -E '^[0-9]+\.[0-9]+\.[0-9]+'
+"$PINSET_BIN" exec -- pnpm --version | grep -Fx "$PNPM_VERSION"
+"$PINSET_BIN" exec -- bun --version | grep -Fx "$BUN_VERSION"
+"$PINSET_BIN" exec -- bunx --version | grep -Fx "$BUN_VERSION"
 
 SHIM_DIR="$("$PINSET_BIN" shim path)"
 export PATH="$SHIM_DIR:$PATH"
@@ -43,6 +53,9 @@ node --version | grep -Fx "v$GLOBAL_VERSION"
 npm --version | grep -E '^[0-9]+\.[0-9]+\.[0-9]+'
 npx --version | grep -E '^[0-9]+\.[0-9]+\.[0-9]+'
 corepack --version | grep -E '^[0-9]+\.[0-9]+\.[0-9]+'
+pnpm --version | grep -Fx "$PNPM_VERSION"
+bun --version | grep -Fx "$BUN_VERSION"
+bunx --version | grep -Fx "$BUN_VERSION"
 
 mkdir project
 cd project
@@ -61,6 +74,10 @@ node --version | grep -Fx "v$PROJECT_VERSION"
 npm --version | grep -E '^[0-9]+\.[0-9]+\.[0-9]+'
 npx --version | grep -E '^[0-9]+\.[0-9]+\.[0-9]+'
 corepack --version | grep -E '^[0-9]+\.[0-9]+\.[0-9]+'
+pnpm --version | grep -Fx "$PNPM_VERSION"
+bun --version | grep -Fx "$BUN_VERSION"
+bunx --version | grep -Fx "$BUN_VERSION"
+pnpm exec node --version | grep -Fx "v$PROJECT_VERSION"
 
 cd "$TEST_ROOT"
 "$PINSET_BIN" current node | tee restored-global-current.txt
@@ -68,5 +85,7 @@ grep -F "Node.js $GLOBAL_VERSION" restored-global-current.txt
 grep -F '来源=全局' restored-global-current.txt
 "$PINSET_BIN" exec -- node --version | grep -Fx "v$GLOBAL_VERSION"
 node --version | grep -Fx "v$GLOBAL_VERSION"
+pnpm --version | grep -Fx "$PNPM_VERSION"
+bun --version | grep -Fx "$BUN_VERSION"
 
-echo "Unix real runtime acceptance passed"
+echo "Unix real Node, pnpm and Bun acceptance passed"

--- a/scripts/tests/windows_runtime_acceptance.ps1
+++ b/scripts/tests/windows_runtime_acceptance.ps1
@@ -8,9 +8,12 @@ if (-not $env:PINSET_BIN) {
 $Pinset = [System.IO.Path]::GetFullPath($env:PINSET_BIN)
 $GlobalVersion = if ($env:PINSET_GLOBAL_VERSION) { $env:PINSET_GLOBAL_VERSION } else { '24.0.0' }
 $ProjectVersion = if ($env:PINSET_PROJECT_VERSION) { $env:PINSET_PROJECT_VERSION } else { '22.0.0' }
+$PnpmVersion = if ($env:PINSET_PNPM_VERSION) { $env:PINSET_PNPM_VERSION } else { '11.21.0' }
+$BunVersion = if ($env:PINSET_BUN_VERSION) { $env:PINSET_BUN_VERSION } else { '1.3.14' }
 $VersionPattern = '^\d+\.\d+\.\d+$'
 
-if ($GlobalVersion -notmatch $VersionPattern -or $ProjectVersion -notmatch $VersionPattern) {
+if ($GlobalVersion -notmatch $VersionPattern -or $ProjectVersion -notmatch $VersionPattern -or
+    $PnpmVersion -notmatch $VersionPattern -or $BunVersion -notmatch $VersionPattern) {
     throw 'acceptance versions must use x.y.z'
 }
 if (-not (Test-Path -LiteralPath $Pinset -PathType Leaf)) {
@@ -55,10 +58,21 @@ try {
     }
 
     & $Pinset use "node@$GlobalVersion" --global
+    if (-not ((& $Pinset list pnpm --available) -contains "pnpm@$PnpmVersion")) {
+        throw "pnpm@$PnpmVersion was not listed as available"
+    }
+    if (-not ((& $Pinset list bun --available) -contains "bun@$BunVersion")) {
+        throw "bun@$BunVersion was not listed as available"
+    }
+    & $Pinset use "pnpm@$PnpmVersion" --global
+    & $Pinset use "bun@$BunVersion" --global
     Assert-ExactOutput "v$GlobalVersion" (& $Pinset exec -- node --version) 'global pinset exec node'
     Assert-VersionOutput (& $Pinset exec -- npm --version) 'global pinset exec npm'
     Assert-VersionOutput (& $Pinset exec -- npx --version) 'global pinset exec npx'
     Assert-VersionOutput (& $Pinset exec -- corepack --version) 'global pinset exec corepack'
+    Assert-ExactOutput $PnpmVersion (& $Pinset exec -- pnpm --version) 'global pinset exec pnpm'
+    Assert-ExactOutput $BunVersion (& $Pinset exec -- bun --version) 'global pinset exec bun'
+    Assert-ExactOutput $BunVersion (& $Pinset exec -- bunx --version) 'global pinset exec bunx'
 
     $ShimDirectory = ((& $Pinset shim path) | Out-String).Trim()
     if (-not $ShimDirectory) {
@@ -69,6 +83,9 @@ try {
     Assert-VersionOutput (& npm --version) 'global direct npm'
     Assert-VersionOutput (& npx --version) 'global direct npx'
     Assert-VersionOutput (& corepack --version) 'global direct corepack'
+    Assert-ExactOutput $PnpmVersion (& pnpm --version) 'global direct pnpm'
+    Assert-ExactOutput $BunVersion (& bun --version) 'global direct bun'
+    Assert-ExactOutput $BunVersion (& bunx --version) 'global direct bunx'
 
     $Project = Join-Path $TestRoot 'project'
     New-Item -ItemType Directory -Path $Project | Out-Null
@@ -79,10 +96,15 @@ try {
     Assert-VersionOutput (& npm --version) 'project direct npm'
     Assert-VersionOutput (& npx --version) 'project direct npx'
     Assert-VersionOutput (& corepack --version) 'project direct corepack'
+    Assert-ExactOutput $PnpmVersion (& pnpm --version) 'project direct pnpm'
+    Assert-ExactOutput $BunVersion (& bun --version) 'project direct bun'
+    Assert-ExactOutput "v$ProjectVersion" (& pnpm exec node --version) 'project pnpm child node'
 
     Set-Location $TestRoot
     Assert-ExactOutput "v$GlobalVersion" (& node --version) 'restored global direct node'
-    Write-Host 'Windows real runtime acceptance passed'
+    Assert-ExactOutput $PnpmVersion (& pnpm --version) 'restored global direct pnpm'
+    Assert-ExactOutput $BunVersion (& bun --version) 'restored global direct bun'
+    Write-Host 'Windows real Node, pnpm and Bun acceptance passed'
 }
 finally {
     $env:PATH = $OriginalPath


### PR DESCRIPTION
## Summary
- add independent pnpm 10/11 and Bun 1.x runtime providers
- add npm registry version discovery, ECDSA signature verification, SHA-512 SRI, tar.gz installation, and schema 2 multi-tool locks
- add multi-provider routing, lifecycle commands, release acceptance coverage, and v0.2.0 documentation

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features
- cargo build --release --locked -p pinset-cli -p pinset-shim
- Windows PowerShell acceptance syntax check
- WSL installer and uninstaller isolated tests
- online list pnpm/bun --available checks