### PR TITLE
test: correct pnpm exec runtime acceptance

### DIFF
--- a/scripts/tests/ubuntu_runtime_acceptance.sh
+++ b/scripts/tests/ubuntu_runtime_acceptance.sh
@@ -77,7 +77,14 @@ corepack --version | grep -E '^[0-9]+\.[0-9]+\.[0-9]+'
 pnpm --version | grep -Fx "$PNPM_VERSION"
 bun --version | grep -Fx "$BUN_VERSION"
 bunx --version | grep -Fx "$BUN_VERSION"
-pnpm exec node --version | grep -Fx "v$PROJECT_VERSION"
+set +e
+PNPM_CHILD_NODE_OUTPUT="$(pnpm exec node --version 2>&1)"
+PNPM_CHILD_NODE_STATUS=$?
+set -e
+printf 'pnpm exec node --version => status=%s output=%s\n' \
+  "$PNPM_CHILD_NODE_STATUS" "$PNPM_CHILD_NODE_OUTPUT"
+test "$PNPM_CHILD_NODE_STATUS" -eq 0
+printf '%s\n' "$PNPM_CHILD_NODE_OUTPUT" | grep -Fx "v$PROJECT_VERSION"
 
 cd "$TEST_ROOT"
 "$PINSET_BIN" current node | tee restored-global-current.txt

--- a/scripts/tests/ubuntu_runtime_acceptance.sh
+++ b/scripts/tests/ubuntu_runtime_acceptance.sh
@@ -59,6 +59,7 @@ bunx --version | grep -Fx "$BUN_VERSION"
 
 mkdir project
 cd project
+printf '{"private":true}\n' > package.json
 "$PINSET_BIN" init
 "$PINSET_BIN" use "node@$PROJECT_VERSION"
 test -f pinset.toml

--- a/scripts/tests/windows_runtime_acceptance.ps1
+++ b/scripts/tests/windows_runtime_acceptance.ps1
@@ -90,6 +90,7 @@ try {
     $Project = Join-Path $TestRoot 'project'
     New-Item -ItemType Directory -Path $Project | Out-Null
     Set-Location $Project
+    Set-Content -LiteralPath (Join-Path $Project 'package.json') -Value '{"private":true}' -NoNewline
     & $Pinset init
     & $Pinset use "node@$ProjectVersion"
     Assert-ExactOutput "v$ProjectVersion" (& node --version) 'project direct node'


### PR DESCRIPTION
## Summary
- print the actual pnpm child Node result when the Unix acceptance assertion fails
- create a minimal package manifest before running pnpm exec on Linux/macOS and Windows

## Root cause
The previous assertion ran pnpm exec in a directory without package.json, so pnpm 11.21 returned ERR_PNPM_RECURSIVE_EXEC_NO_PACKAGE. The installed pnpm runtime itself was already functioning correctly.

## Virtual-machine validation
GitHub Actions run 31613242231 passed on commit d0dcac2:
- Quality
- Ubuntu real Node, pnpm and Bun acceptance
- Linux x64 build/package
- Windows x64 build/package and isolated uninstaller
- macOS arm64 build/package