### PR TITLE
fix: complete pnpm runtime packaging on every platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,28 @@ jobs:
       - name: Build release binaries
         run: cargo build --release --locked -p pinset-cli -p pinset-shim
 
+      - name: Run real Node, pnpm and Bun acceptance on macOS
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          PINSET_BIN: ${{ github.workspace }}/target/release/pinset
+          PINSET_GLOBAL_VERSION: 24.0.0
+          PINSET_PROJECT_VERSION: 22.0.0
+          PINSET_PNPM_VERSION: 11.21.0
+          PINSET_BUN_VERSION: 1.3.14
+        run: bash scripts/tests/ubuntu_runtime_acceptance.sh
+
+      - name: Run real Node, pnpm and Bun acceptance on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          PINSET_BIN: ${{ github.workspace }}\target\release\pinset.exe
+          PINSET_GLOBAL_VERSION: 24.0.0
+          PINSET_PROJECT_VERSION: 22.0.0
+          PINSET_PNPM_VERSION: 11.21.0
+          PINSET_BUN_VERSION: 1.3.14
+        run: ./scripts/tests/windows_runtime_acceptance.ps1
+
       - name: Test Unix curl installer
         if: runner.os != 'Windows'
         shell: bash

--- a/crates/pinset-core/src/installer.rs
+++ b/crates/pinset-core/src/installer.rs
@@ -1690,6 +1690,11 @@ mod tests {
     fn merges_a_verified_npm_base_archive_before_the_platform_binary() {
         let base_archive = tar_gz_bytes(&[
             ("package/dist/pnpm.mjs", b"shared pnpm runtime", 0o644),
+            (
+                "package/package.json",
+                br#"{"name":"@pnpm/exe","type":"module"}"#,
+                0o644,
+            ),
             ("package/setup.js", b"must not be installed", 0o644),
         ]);
         let platform_archive = tar_gz_bytes(&[("package/pnpm", b"native pnpm", 0o644)]);
@@ -1725,8 +1730,14 @@ mod tests {
                 format: ArtifactFormat::TarGz,
             },
             strip_components: 1,
-            include_prefixes: vec![PathBuf::from("dist")],
-            required_paths: vec![PathBuf::from("dist/pnpm.mjs")],
+            include_prefixes: vec![
+                PathBuf::from("dist"),
+                PathBuf::from("package.json"),
+            ],
+            required_paths: vec![
+                PathBuf::from("dist/pnpm.mjs"),
+                PathBuf::from("package.json"),
+            ],
         }];
 
         let outcome = test_installer()
@@ -1742,6 +1753,10 @@ mod tests {
         assert_eq!(
             fs::read(outcome.install_dir.join("dist/pnpm.mjs")).expect("shared runtime"),
             b"shared pnpm runtime"
+        );
+        assert_eq!(
+            fs::read(outcome.install_dir.join("package.json")).expect("package metadata"),
+            br#"{"name":"@pnpm/exe","type":"module"}"#
         );
         assert!(!outcome.install_dir.join("setup.js").exists());
         #[cfg(unix)]

--- a/crates/pinset-core/src/installer.rs
+++ b/crates/pinset-core/src/installer.rs
@@ -87,6 +87,7 @@ pub struct InstallRequest {
     pub target: String,
     pub artifact: ArtifactSpec,
     pub strip_components: usize,
+    pub include_prefixes: Vec<PathBuf>,
     pub required_paths: Vec<PathBuf>,
     pub base_artifacts: Vec<ArtifactInstallSpec>,
     pub executable_paths: Vec<PathBuf>,
@@ -235,7 +236,7 @@ impl Installer {
             &staging_dir,
             request.artifact.format,
             request.strip_components,
-            &[],
+            &request.include_prefixes,
         )?;
         validate_required_paths(&staging_dir, &request.required_paths)?;
         ensure_executable_paths(&staging_dir, &request.executable_paths)?;
@@ -1095,6 +1096,11 @@ fn existing_install_outcome(final_dir: &Path, request: &InstallRequest) -> Optio
     if validate_required_paths(final_dir, &request.required_paths).is_err() {
         return None;
     }
+    for base in &request.base_artifacts {
+        if validate_required_paths(final_dir, &base.required_paths).is_err() {
+            return None;
+        }
+    }
     if ensure_executable_paths(final_dir, &request.executable_paths).is_err() {
         return None;
     }
@@ -1116,6 +1122,14 @@ fn validate_request(request: &InstallRequest) -> Result<()> {
     validate_segment("version", &request.version)?;
     validate_segment("target", &request.target)?;
     validate_artifact_request(&request.artifact, request.strip_components)?;
+    debug_assert!(
+        request.artifact.format != ArtifactFormat::Zip || request.include_prefixes.is_empty()
+    );
+    for path in &request.include_prefixes {
+        if !is_safe_relative(path) {
+            return Err(Error::InvalidRequiredPath { path: path.clone() });
+        }
+    }
     for base in &request.base_artifacts {
         validate_artifact_request(&base.artifact, base.strip_components)?;
         debug_assert!(
@@ -1697,7 +1711,14 @@ mod tests {
             ),
             ("package/setup.js", b"must not be installed", 0o644),
         ]);
-        let platform_archive = tar_gz_bytes(&[("package/pnpm", b"native pnpm", 0o644)]);
+        let platform_archive = tar_gz_bytes(&[
+            ("package/pnpm", b"native pnpm", 0o644),
+            (
+                "package/package.json",
+                br#"{"name":"@pnpm/linux-x64"}"#,
+                0o644,
+            ),
+        ]);
         let base_integrity = format!(
             "sha512-{}",
             base64::engine::general_purpose::STANDARD.encode(Sha512::digest(&base_archive))
@@ -1716,6 +1737,7 @@ mod tests {
         request.target = "linux-x86_64".to_owned();
         request.artifact.format = ArtifactFormat::TarGz;
         request.strip_components = 1;
+        request.include_prefixes = vec![PathBuf::from("pnpm")];
         request.required_paths = vec![PathBuf::from("pnpm")];
         request.executable_paths = vec![PathBuf::from("pnpm")];
         request.base_artifacts = vec![ArtifactInstallSpec {
@@ -2004,6 +2026,7 @@ mod tests {
                 format: ArtifactFormat::Zip,
             },
             strip_components: 0,
+            include_prefixes: Vec::new(),
             required_paths: vec![PathBuf::from("bin/node.exe")],
             base_artifacts: Vec::new(),
             executable_paths: Vec::new(),

--- a/crates/pinset-core/src/installer.rs
+++ b/crates/pinset-core/src/installer.rs
@@ -1690,7 +1690,11 @@ mod tests {
     fn merges_a_verified_npm_base_archive_before_the_platform_binary() {
         let base_archive = tar_gz_bytes(&[
             ("package/dist/pnpm.mjs", b"shared pnpm runtime", 0o644),
-            ("package/package.json", br#"{"name":"@pnpm/exe","type":"module"}"#, 0o644),
+            (
+                "package/package.json",
+                br#"{"name":"@pnpm/exe","type":"module"}"#,
+                0o644,
+            ),
             ("package/setup.js", b"must not be installed", 0o644),
         ]);
         let platform_archive = tar_gz_bytes(&[("package/pnpm", b"native pnpm", 0o644)]);
@@ -1727,7 +1731,10 @@ mod tests {
             },
             strip_components: 1,
             include_prefixes: vec![PathBuf::from("dist"), PathBuf::from("package.json")],
-            required_paths: vec![PathBuf::from("dist/pnpm.mjs"), PathBuf::from("package.json")],
+            required_paths: vec![
+                PathBuf::from("dist/pnpm.mjs"),
+                PathBuf::from("package.json"),
+            ],
         }];
 
         let outcome = test_installer()

--- a/crates/pinset-core/src/installer.rs
+++ b/crates/pinset-core/src/installer.rs
@@ -1690,11 +1690,7 @@ mod tests {
     fn merges_a_verified_npm_base_archive_before_the_platform_binary() {
         let base_archive = tar_gz_bytes(&[
             ("package/dist/pnpm.mjs", b"shared pnpm runtime", 0o644),
-            (
-                "package/package.json",
-                br#"{"name":"@pnpm/exe","type":"module"}"#,
-                0o644,
-            ),
+            ("package/package.json", br#"{"name":"@pnpm/exe","type":"module"}"#, 0o644),
             ("package/setup.js", b"must not be installed", 0o644),
         ]);
         let platform_archive = tar_gz_bytes(&[("package/pnpm", b"native pnpm", 0o644)]);
@@ -1730,14 +1726,8 @@ mod tests {
                 format: ArtifactFormat::TarGz,
             },
             strip_components: 1,
-            include_prefixes: vec![
-                PathBuf::from("dist"),
-                PathBuf::from("package.json"),
-            ],
-            required_paths: vec![
-                PathBuf::from("dist/pnpm.mjs"),
-                PathBuf::from("package.json"),
-            ],
+            include_prefixes: vec![PathBuf::from("dist"), PathBuf::from("package.json")],
+            required_paths: vec![PathBuf::from("dist/pnpm.mjs"), PathBuf::from("package.json")],
         }];
 
         let outcome = test_installer()

--- a/crates/pinset-core/src/node_runtime.rs
+++ b/crates/pinset-core/src/node_runtime.rs
@@ -46,6 +46,7 @@ pub fn install_locked_node(
             },
         },
         strip_components: 1,
+        include_prefixes: Vec::new(),
         required_paths: required_node_paths(target)?,
         base_artifacts: Vec::new(),
         executable_paths: Vec::new(),

--- a/crates/pinset-core/src/npm_runtime.rs
+++ b/crates/pinset-core/src/npm_runtime.rs
@@ -94,7 +94,10 @@ fn overlay_install_spec(overlay: &LockedArtifactOverlay) -> Result<ArtifactInsta
         },
         strip_components: 1,
         include_prefixes: vec![PathBuf::from("dist"), PathBuf::from("package.json")],
-        required_paths: vec![PathBuf::from("dist/pnpm.mjs"), PathBuf::from("package.json")],
+        required_paths: vec![
+            PathBuf::from("dist/pnpm.mjs"),
+            PathBuf::from("package.json"),
+        ],
     })
 }
 

--- a/crates/pinset-core/src/npm_runtime.rs
+++ b/crates/pinset-core/src/npm_runtime.rs
@@ -93,8 +93,14 @@ fn overlay_install_spec(overlay: &LockedArtifactOverlay) -> Result<ArtifactInsta
             format,
         },
         strip_components: 1,
-        include_prefixes: vec![PathBuf::from("dist")],
-        required_paths: vec![PathBuf::from("dist/pnpm.mjs")],
+        include_prefixes: vec![
+            PathBuf::from("dist"),
+            PathBuf::from("package.json"),
+        ],
+        required_paths: vec![
+            PathBuf::from("dist/pnpm.mjs"),
+            PathBuf::from("package.json"),
+        ],
     })
 }
 

--- a/crates/pinset-core/src/npm_runtime.rs
+++ b/crates/pinset-core/src/npm_runtime.rs
@@ -64,6 +64,11 @@ pub fn install_locked_npm_tool(
             format,
         },
         strip_components: 1,
+        include_prefixes: if locked_tool.name == "pnpm" {
+            vec![PathBuf::from(target_manifest.required_path)]
+        } else {
+            Vec::new()
+        },
         required_paths: vec![PathBuf::from(target_manifest.required_path)],
         base_artifacts,
         executable_paths,

--- a/crates/pinset-core/src/npm_runtime.rs
+++ b/crates/pinset-core/src/npm_runtime.rs
@@ -93,14 +93,8 @@ fn overlay_install_spec(overlay: &LockedArtifactOverlay) -> Result<ArtifactInsta
             format,
         },
         strip_components: 1,
-        include_prefixes: vec![
-            PathBuf::from("dist"),
-            PathBuf::from("package.json"),
-        ],
-        required_paths: vec![
-            PathBuf::from("dist/pnpm.mjs"),
-            PathBuf::from("package.json"),
-        ],
+        include_prefixes: vec![PathBuf::from("dist"), PathBuf::from("package.json")],
+        required_paths: vec![PathBuf::from("dist/pnpm.mjs"), PathBuf::from("package.json")],
     })
 }
 

--- a/scripts/tests/windows_runtime_acceptance.ps1
+++ b/scripts/tests/windows_runtime_acceptance.ps1
@@ -99,7 +99,16 @@ try {
     Assert-VersionOutput (& corepack --version) 'project direct corepack'
     Assert-ExactOutput $PnpmVersion (& pnpm --version) 'project direct pnpm'
     Assert-ExactOutput $BunVersion (& bun --version) 'project direct bun'
-    Assert-ExactOutput "v$ProjectVersion" (& pnpm exec node --version) 'project pnpm child node'
+    $PnpmChildNodeOutput = @(& pnpm exec node --version 2>&1 | ForEach-Object { $_.ToString() })
+    $PnpmChildNodeStatus = $LASTEXITCODE
+    Write-Host "pnpm exec node --version => status=$PnpmChildNodeStatus output=$($PnpmChildNodeOutput -join ' | ')"
+    if ($PnpmChildNodeStatus -ne 0) {
+        throw "project pnpm child node exited with $PnpmChildNodeStatus"
+    }
+    if ($PnpmChildNodeOutput.Count -eq 0) {
+        throw 'project pnpm child node returned no output'
+    }
+    Assert-ExactOutput "v$ProjectVersion" $PnpmChildNodeOutput 'project pnpm child node'
 
     Set-Location $TestRoot
     Assert-ExactOutput "v$GlobalVersion" (& node --version) 'restored global direct node'

--- a/scripts/tests/windows_runtime_acceptance.ps1
+++ b/scripts/tests/windows_runtime_acceptance.ps1
@@ -108,7 +108,9 @@ try {
     if ($PnpmChildNodeOutput.Count -eq 0) {
         throw 'project pnpm child node returned no output'
     }
-    Assert-ExactOutput "v$ProjectVersion" $PnpmChildNodeOutput 'project pnpm child node'
+    if ($PnpmChildNodeOutput -notcontains "v$ProjectVersion") {
+        throw "project pnpm child node did not report v$ProjectVersion"
+    }
 
     Set-Location $TestRoot
     Assert-ExactOutput "v$GlobalVersion" (& node --version) 'restored global direct node'


### PR DESCRIPTION
## Summary
- preserve signed @pnpm/exe package metadata together with its shared dist runtime
- extract only the verified native pnpm executable from platform packages, retaining archive collision protection
- validate overlay files when reusing an existing install
- run real Node, pnpm and Bun acceptance on Windows and macOS in manual CI
- make Windows pnpm child-runtime assertions tolerate normal pnpm lifecycle output while requiring the selected Node version

## Root cause
The pnpm native package is only one half of the npm-installed runtime. @pnpm/exe supplies shared JavaScript and ESM package metadata, while the platform package supplies the native executable. Installing only dist caused Windows ESM behavior to diverge; extracting both complete packages caused a protected package.json collision.

## Virtual-machine validation
GitHub Actions run 31618635539 passed on commit df31c4f:
- formatting, Clippy, full Rust tests and script gates
- Ubuntu real Node, pnpm and Bun acceptance
- macOS arm64 real Node, pnpm and Bun acceptance
- Windows x64 real Node, pnpm and Bun acceptance
- Linux, macOS and Windows release builds/packages

No local or WSL test was used.