### PR TITLE
feat: add Go runtime provider for v0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Build release binaries
         run: cargo build --release --locked -p pinset-cli -p pinset-shim
 
-      - name: Run real Node, pnpm and Bun acceptance on macOS
+      - name: Run real Node, pnpm, Bun and Go acceptance on macOS
         if: runner.os == 'macOS'
         shell: bash
         env:
@@ -106,7 +106,7 @@ jobs:
           PINSET_BUN_VERSION: 1.3.14
         run: bash scripts/tests/ubuntu_runtime_acceptance.sh
 
-      - name: Run real Node, pnpm and Bun acceptance on Windows
+      - name: Run real Node, pnpm, Bun and Go acceptance on Windows
         if: runner.os == 'Windows'
         shell: pwsh
         env:
@@ -181,7 +181,7 @@ jobs:
       - name: Build locked release binaries
         run: cargo build --release --locked -p pinset-cli -p pinset-shim
 
-      - name: Run real Node acceptance in an isolated home
+      - name: Run real Node, pnpm, Bun and Go acceptance in an isolated home
         env:
           PINSET_BIN: ${{ github.workspace }}/target/release/pinset
           PINSET_GLOBAL_VERSION: 24.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Build release binaries
         run: cargo build --release --locked -p pinset-cli -p pinset-shim
 
-      - name: Run real Node, pnpm and Bun acceptance on Linux and macOS
+      - name: Run real Node, pnpm, Bun and Go acceptance on Linux and macOS
         if: runner.os != 'Windows'
         shell: bash
         env:
@@ -139,7 +139,7 @@ jobs:
           PINSET_BUN_VERSION: 1.3.14
         run: bash scripts/tests/ubuntu_runtime_acceptance.sh
 
-      - name: Run real Node, pnpm and Bun acceptance on Windows
+      - name: Run real Node, pnpm, Bun and Go acceptance on Windows
         if: runner.os == 'Windows'
         shell: pwsh
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,7 +1181,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "clap",
  "pinset-core",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "atomic-write-file",
  "base64",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.85"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Future Element"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -3,22 +3,25 @@
 [![CI](https://github.com/Future-Element/pinset/actions/workflows/ci.yml/badge.svg)](https://github.com/Future-Element/pinset/actions/workflows/ci.yml)
 [![Release](https://github.com/Future-Element/pinset/actions/workflows/release.yml/badge.svg)](https://github.com/Future-Element/pinset/actions/workflows/release.yml)
 
-Pinset 是一个本地优先的多语言运行时版本管理 CLI。目标是用一致的命令管理 Node.js、Python、Flutter 等运行时，减少在 fnm、nvm、uv、FVM 之间切换的学习和维护成本。
+Pinset 是一个本地优先的多语言运行时版本管理 CLI。目标是用一致的命令管理 Node.js、Go、Python、Flutter 等运行时，减少在 fnm、nvm、Go 工具链、uv、FVM 之间切换的学习和维护成本。
 
 `v0.2.0` 在已验证的 Node.js 管理基础上新增独立的 pnpm 与 Bun Provider。Python 和 Flutter 尚未支持。当前功能包括：
 
 `v0.2.1` 修复 pnpm 10 独立可执行包被错误套用 pnpm 11 `dist/` 叠加层规则的问题，并覆盖项目 pnpm 10 与 Bun 1.2 的组合安装。
 
+`v0.3.0` 正在开发 Go Provider，并将 Provider 的元数据、安装器和受管环境策略收敛到统一清单。
+
 - 全局 Node 默认版本、项目级 Node 覆盖，以及离开项目后恢复全局版本；
 - `node@24.0.0`、`node@24`、`node@24.12`、`node@lts`、`node@current`；
 - pnpm 10/11 与 Bun 1.x 的精确、主版本、主次版本、`latest`/`current` 选择器；
+- Go 的精确、主版本、主次版本、`latest`/`current` 选择器；
 - Windows x64、Linux x64、macOS Apple Silicon 的 Pinset Release；
-- `node`、`npm`、`npx`、`corepack`、`pnpm`、`bun`、`bunx` 统一路由；
+- `node`、`npm`、`npx`、`corepack`、`pnpm`、`bun`、`bunx`、`go`、`gofmt` 统一路由；
 - 可提交的 `pinset.toml` 和 `pinset.lock`；
 - Node SHA-256、npm SHA-512 SRI 与 registry ECDSA 签名校验、安全解压、事务安装、并发安装锁、断点续传和内容寻址缓存；
 - 国内或企业镜像、有序回退、可选的可信元数据镜像和离线缓存导入；
 - 中英文提示、旧 Node 管理器配置导入、诊断、安全卸载；
-- 三平台自动构建、真实 Node/pnpm/Bun 验收、CycloneDX SBOM 和 GitHub 构建来源证明。
+- 三平台自动构建、真实 Node/pnpm/Bun/Go 验收、CycloneDX SBOM 和 GitHub 构建来源证明。
 
 ## 快速安装
 
@@ -39,10 +42,10 @@ pinset --version
 
 长期使用可自行把 `export PATH=...` 写入 `~/.bashrc` 或 `~/.zshrc`。Pinset 不会擅自修改这些文件。
 
-固定安装 `v0.2.0`：
+固定安装最新已发布的 `v0.2.1`：
 
 ```bash
-curl -fsSL https://github.com/Future-Element/pinset/releases/download/v0.2.0/install.sh | sh
+curl -fsSL https://github.com/Future-Element/pinset/releases/download/v0.2.1/install.sh | sh
 ```
 
 自定义安装目录：
@@ -132,9 +135,10 @@ schema = 2
 node = "22.0.0"
 pnpm = "11.21.0"
 bun = "1.3.14"
+go = "1.25.1"
 ```
 
-`pinset.lock` 保存解析后的精确版本、平台归档、完整性值和来源信息。Node 使用官方 SHA-256；pnpm/Bun 使用 npm 包的 SHA-512 SRI，并在生成锁文件前验证 registry ECDSA 签名。建议把 `pinset.toml` 与 `pinset.lock` 一起提交。
+`pinset.lock` 保存解析后的精确版本、平台归档、完整性值和来源信息。Node 和 Go 使用官方 SHA-256；pnpm/Bun 使用 npm 包的 SHA-512 SRI，并在生成锁文件前验证 registry ECDSA 签名。建议把 `pinset.toml` 与 `pinset.lock` 一起提交。
 
 在项目目录中，项目版本优先于全局版本；离开项目目录后自动恢复全局版本。如果项目或全局声明了版本但安装缺失，Pinset 会明确报错，不会静默换成系统 Node。
 
@@ -203,6 +207,25 @@ pnpm 与 Bun 是独立运行时，不依赖已选择的 Node，也不通过 Core
 
 精确版本可离线解析选择器，但生成可安装锁仍需读取官方 npm 单版本元数据并验证包签名。`list --available` 使用 npm abbreviated metadata，过滤预发布版本以及缺少任一受支持平台包的版本。
 
+## Go
+
+Go 与其他 Provider 使用相同的项目、全局、available、安装、卸载和命令路由流程：
+
+```shell
+pinset list go --available
+pinset global go@latest
+pinset use go@1.25
+pinset current go
+go version
+gofmt -w main.go
+```
+
+Pinset 从 Go 官方下载 JSON 索引读取稳定版本和 Windows x64、Linux x64、macOS x64/arm64 工件，锁定官方 SHA-256 后再安装。历史上省略补丁零的版本会规范化为 `x.y.0`，但仍使用对应的官方归档名。
+
+受管 Go 命令会获得与所选安装一致的 `GOROOT`。如果调用 Pinset 时没有显式设置 `GOTOOLCHAIN`，Pinset 为受管进程设置 `GOTOOLCHAIN=local`，避免 `go.mod` 或 `go.work` 绕过 Pinset 锁定并静默下载另一套工具链；显式用户设置会被保留。
+
+Pinset 不修改 `go.mod`/`go.work`，也不管理 Go module 依赖、`GOPATH`、`GOMODCACHE` 或 `GOCACHE`。
+
 ### 解析优先级
 
 ```text
@@ -229,6 +252,8 @@ pinset which npm
 ```shell
 pinset exec -- node --version
 pinset exec -- npm ci
+pinset exec -- go version
+pinset exec go@1.25 -- go version
 pinset exec -- npx vite
 ```
 
@@ -460,9 +485,9 @@ gh attestation verify pinset-linux-x86_64.tar.gz \
 
 来源证明关联 Release 归档与构建它的仓库、提交和工作流，但不等于安全审计；仍应结合 SHA-256、SBOM 和自己的信任策略判断。
 
-## 从源码构建和测试
+## 开发验证
 
-要求 Rust 1.85 或更高版本：
+项目要求 Rust 1.85 或更高版本。Pull Request 的 Quality 工作流在 GitHub Actions Ubuntu 虚拟机执行：
 
 ```shell
 cargo fmt --all -- --check
@@ -471,7 +496,7 @@ cargo test --workspace --all-features
 cargo build --release --locked -p pinset-cli -p pinset-shim
 ```
 
-本地 Rust 测试只使用临时目录、假归档、本地 HTTP 服务和假运行时，不会安装真实运行时。Release 工作流会在 Linux、Windows、macOS 的隔离 GitHub Runner 中安装两个真实 Node 版本、一个 pnpm 版本和一个 Bun 版本，验证全局/项目组合、项目覆盖、跨 Provider 子进程 PATH，以及七个受管命令的 `pinset exec`/shim 调用方式。
+真实运行时验收只在 GitHub Actions 隔离 Runner 中执行。工作流会在 Linux、Windows、macOS 安装 Node、pnpm、Bun 和 Go，验证 available、全局/项目组合、项目覆盖、跨 Provider 子进程 PATH、`GOROOT`、默认 `GOTOOLCHAIN=local`，以及受管命令的 `pinset exec`/shim 调用方式。
 
 Linux/WSL 构建产物：
 
@@ -484,10 +509,10 @@ Windows 构建产物是 `.exe`，不能直接作为 WSL/Linux 程序使用；需
 
 ## Beta 限制
 
-- 当前支持 Node.js、pnpm 和 Bun；Python、Flutter 和其他 Provider 尚未开放。
+- 当前开发版本支持 Node.js、pnpm、Bun 和 Go；Python、Flutter 和其他 Provider 尚未开放。
 - Pinset Release 暂无 Linux arm64、macOS Intel 安装包。
 - 项目不维护第三方 Homebrew Tap 或 Scoop Bucket；使用 curl、Release 归档或源码构建。
-- Pinset 会校验 Node 官方 HTTPS `SHASUMS256.txt` 中的 SHA-256，但 Beta 尚未验证该清单的上游 OpenPGP 签名；pnpm/Bun 则校验 npm SHA-512 SRI 和 registry ECDSA 签名。
+- Pinset 会校验 Node 官方 HTTPS `SHASUMS256.txt` 和 Go 官方下载索引中的 SHA-256，但 Beta 尚未验证 Node 清单的上游 OpenPGP 签名；pnpm/Bun 则校验 npm SHA-512 SRI 和 registry ECDSA 签名。
 - Pinset 不自动修改 shell profile、系统 PATH 或 IDE 配置。
 - 这是预发布版本，配置 schema 仍可能在稳定版前调整；任何迁移都会在 Release Notes 中说明。
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Pinset 是一个本地优先的多语言运行时版本管理 CLI。目标是用
 
 `v0.2.1` 修复 pnpm 10 独立可执行包被错误套用 pnpm 11 `dist/` 叠加层规则的问题，并覆盖项目 pnpm 10 与 Bun 1.2 的组合安装。
 
-`v0.3.0` 正在开发 Go Provider，并将 Provider 的元数据、安装器和受管环境策略收敛到统一清单。
+`v0.3.0` 新增 Go Provider，并将 Provider 的元数据、安装器和受管环境策略收敛到统一清单。
 
 - 全局 Node 默认版本、项目级 Node 覆盖，以及离开项目后恢复全局版本；
 - `node@24.0.0`、`node@24`、`node@24.12`、`node@lts`、`node@current`；
@@ -42,10 +42,10 @@ pinset --version
 
 长期使用可自行把 `export PATH=...` 写入 `~/.bashrc` 或 `~/.zshrc`。Pinset 不会擅自修改这些文件。
 
-固定安装最新已发布的 `v0.2.1`：
+固定安装最新已发布的 `v0.3.0`：
 
 ```bash
-curl -fsSL https://github.com/Future-Element/pinset/releases/download/v0.2.1/install.sh | sh
+curl -fsSL https://github.com/Future-Element/pinset/releases/download/v0.3.0/install.sh | sh
 ```
 
 自定义安装目录：

--- a/crates/pinset-core/Cargo.toml
+++ b/crates/pinset-core/Cargo.toml
@@ -20,7 +20,9 @@ installer = [
     "dep:xz2",
     "dep:zip",
 ]
-lockfile = ["node-provider", "dep:atomic-write-file", "dep:base64", "dep:hex"]
+go-metadata = ["lockfile", "sources", "dep:reqwest", "dep:serde_json"]
+go-provider = ["sources"]
+lockfile = ["node-provider", "go-provider", "dep:atomic-write-file", "dep:base64", "dep:hex"]
 node-metadata = ["lockfile", "dep:reqwest", "dep:serde_json"]
 node-provider = ["sources"]
 npm-metadata = [

--- a/crates/pinset-core/src/error.rs
+++ b/crates/pinset-core/src/error.rs
@@ -225,7 +225,9 @@ pub enum Error {
     PinsetHomeUnavailable,
 
     #[cfg(feature = "sources")]
-    #[error("unsupported source provider \"{provider}\"; expected one of: node, python, flutter")]
+    #[error(
+        "unsupported source provider \"{provider}\"; expected one of: node, go, python, flutter"
+    )]
     UnsupportedSourceProvider { provider: String },
 
     #[cfg(feature = "sources")]
@@ -323,6 +325,48 @@ pub enum Error {
     #[cfg(feature = "node-provider")]
     #[error("invalid exact Node.js version \"{version}\"; expected x.y.z without a leading 'v'")]
     InvalidNodeVersion { version: String },
+
+    #[cfg(feature = "go-provider")]
+    #[error("invalid exact Go version \"{version}\"; expected x.y.z without a leading 'go' or 'v'")]
+    InvalidGoVersion { version: String },
+
+    #[cfg(feature = "go-provider")]
+    #[error("unsupported Go target \"{target}\"")]
+    UnsupportedGoTarget { target: String },
+
+    #[cfg(feature = "go-metadata")]
+    #[error(
+        "invalid Go selector \"{selector}\"; expected x.y.z, a major/minor prefix, latest or current"
+    )]
+    InvalidGoSelector { selector: String },
+
+    #[cfg(feature = "go-metadata")]
+    #[error("official Go index contains no supported release matching \"{selector}\"")]
+    GoSelectorNotFound { selector: String },
+
+    #[cfg(feature = "go-metadata")]
+    #[error("failed to request Go download metadata {url}: {source}")]
+    GoMetadataRequest {
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+
+    #[cfg(feature = "go-metadata")]
+    #[error("failed while reading Go download metadata {url}: {source}")]
+    GoMetadataRead {
+        url: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[cfg(feature = "go-metadata")]
+    #[error("Go download index exceeds {limit} bytes")]
+    GoMetadataTooLarge { limit: u64 },
+
+    #[cfg(feature = "go-metadata")]
+    #[error("invalid Go download index: {reason}")]
+    InvalidGoIndex { reason: String },
 
     #[cfg(feature = "node-metadata")]
     #[error(
@@ -552,6 +596,7 @@ pub enum Error {
 
     #[cfg(any(
         feature = "installer",
+        feature = "go-metadata",
         feature = "node-metadata",
         feature = "npm-metadata"
     ))]

--- a/crates/pinset-core/src/go_metadata.rs
+++ b/crates/pinset-core/src/go_metadata.rs
@@ -1,0 +1,388 @@
+use std::{cmp::Reverse, io::Read, time::Duration};
+
+use reqwest::{Url, blocking::Client};
+use serde::Deserialize;
+
+use crate::{
+    Error, GO_TARGETS, GoArchiveFormat, LockedArtifact, LockedArtifactFormat, LockedTool, Result,
+    SourceConfig, plan_go_artifact, validate_exact_go_version,
+};
+
+const OFFICIAL_GO_DOWNLOAD_URL: &str = "https://go.dev/dl/";
+const MAX_GO_INDEX_BYTES: u64 = 32 * 1024 * 1024;
+const GO_VERIFICATION: &str = "go-download-json-sha256";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GoRelease {
+    pub version: String,
+}
+
+#[derive(Debug)]
+pub struct GoMetadataClient {
+    client: Client,
+    metadata_base_url: Url,
+    verification: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoIndexRelease {
+    version: String,
+    stable: bool,
+    #[serde(default)]
+    files: Vec<GoIndexFile>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GoIndexFile {
+    filename: String,
+    os: String,
+    arch: String,
+    version: String,
+    sha256: String,
+    size: u64,
+    kind: String,
+}
+
+#[derive(Debug)]
+struct SupportedGoRelease {
+    version: String,
+    files: Vec<(String, GoIndexFile)>,
+}
+
+impl GoMetadataClient {
+    pub fn official() -> Result<Self> {
+        Self::for_source(OFFICIAL_GO_DOWNLOAD_URL, "official")
+    }
+
+    pub fn for_base_url(base_url: &str) -> Result<Self> {
+        Self::for_source(base_url, "custom")
+    }
+
+    pub fn for_source(base_url: &str, alias: &str) -> Result<Self> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|source| Error::HttpClient { source })?;
+        let metadata_base_url =
+            Url::parse(base_url).map_err(|source| Error::InvalidSourceBaseUrl {
+                url: base_url.to_owned(),
+                reason: source.to_string(),
+            })?;
+        let verification = if alias == "official" {
+            GO_VERIFICATION.to_owned()
+        } else {
+            format!("{GO_VERIFICATION}-source:{alias}")
+        };
+        Ok(Self {
+            client,
+            metadata_base_url,
+            verification,
+        })
+    }
+
+    pub fn available_releases(&self) -> Result<Vec<GoRelease>> {
+        Ok(self
+            .supported_releases()?
+            .into_iter()
+            .map(|release| GoRelease {
+                version: release.version,
+            })
+            .collect())
+    }
+
+    pub fn resolve_version_selector(&self, selector: &str) -> Result<String> {
+        Ok(self.resolve_release(selector)?.version)
+    }
+
+    pub fn resolve_tool(&self, selector: &str) -> Result<LockedTool> {
+        let release = self.resolve_release(selector)?;
+        let artifacts = release
+            .files
+            .into_iter()
+            .map(|(target, file)| {
+                let plan = plan_go_artifact(&SourceConfig::default(), &release.version, &target)?;
+                Ok(LockedArtifact {
+                    target,
+                    canonical_url: plan.canonical_url,
+                    artifact_path: plan.artifact_path,
+                    sha256: file.sha256,
+                    integrity: None,
+                    format: match plan.format {
+                        GoArchiveFormat::Zip => LockedArtifactFormat::Zip,
+                        GoArchiveFormat::TarGz => LockedArtifactFormat::TarGz,
+                    },
+                    archive_root: plan.archive_root,
+                    verification: self.verification.clone(),
+                    overlays: Vec::new(),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(LockedTool {
+            name: "go".to_owned(),
+            requested: release.version.clone(),
+            version: release.version,
+            provider: "go-official".to_owned(),
+            artifacts,
+        })
+    }
+
+    fn resolve_release(&self, selector: &str) -> Result<SupportedGoRelease> {
+        let normalized = selector.trim().to_ascii_lowercase();
+        let exact = validate_exact_go_version(&normalized).is_ok();
+        let numeric_parts = normalized.split('.').collect::<Vec<_>>();
+        let numeric_selector = (numeric_parts.len() == 1 || numeric_parts.len() == 2)
+            && numeric_parts
+                .iter()
+                .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()));
+        if normalized != "latest" && normalized != "current" && !exact && !numeric_selector {
+            return Err(Error::InvalidGoSelector {
+                selector: selector.to_owned(),
+            });
+        }
+        let requested = numeric_selector
+            .then(|| {
+                numeric_parts
+                    .iter()
+                    .map(|part| part.parse::<u64>())
+                    .collect::<std::result::Result<Vec<_>, _>>()
+            })
+            .transpose()
+            .map_err(|_| Error::InvalidGoSelector {
+                selector: selector.to_owned(),
+            })?;
+
+        self.supported_releases()?
+            .into_iter()
+            .find(|release| {
+                if normalized == "latest" || normalized == "current" {
+                    return true;
+                }
+                if exact {
+                    return release.version == normalized;
+                }
+                let tuple = version_tuple(&release.version).expect("validated Go release");
+                let requested = requested.as_ref().expect("numeric selector");
+                tuple.0 == requested[0] && (requested.len() == 1 || tuple.1 == requested[1])
+            })
+            .ok_or_else(|| Error::GoSelectorNotFound {
+                selector: selector.to_owned(),
+            })
+    }
+
+    fn supported_releases(&self) -> Result<Vec<SupportedGoRelease>> {
+        let body = self.download_index()?;
+        parse_index(&body)
+    }
+
+    fn download_index(&self) -> Result<String> {
+        let mut url = self.metadata_base_url.clone();
+        url.set_query(Some("mode=json&include=all"));
+        let display_url = url.to_string();
+        let mut response = self
+            .client
+            .get(url)
+            .send()
+            .and_then(reqwest::blocking::Response::error_for_status)
+            .map_err(|source| Error::GoMetadataRequest {
+                url: display_url.clone(),
+                source,
+            })?;
+        if response
+            .content_length()
+            .is_some_and(|length| length > MAX_GO_INDEX_BYTES)
+        {
+            return Err(Error::GoMetadataTooLarge {
+                limit: MAX_GO_INDEX_BYTES,
+            });
+        }
+        let mut bytes = Vec::new();
+        (&mut response)
+            .take(MAX_GO_INDEX_BYTES + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|source| Error::GoMetadataRead {
+                url: display_url,
+                source,
+            })?;
+        if bytes.len() as u64 > MAX_GO_INDEX_BYTES {
+            return Err(Error::GoMetadataTooLarge {
+                limit: MAX_GO_INDEX_BYTES,
+            });
+        }
+        String::from_utf8(bytes).map_err(|_| Error::InvalidGoIndex {
+            reason: "index is not UTF-8".to_owned(),
+        })
+    }
+}
+
+fn parse_index(body: &str) -> Result<Vec<SupportedGoRelease>> {
+    let entries: Vec<GoIndexRelease> =
+        serde_json::from_str(body).map_err(|source| Error::InvalidGoIndex {
+            reason: source.to_string(),
+        })?;
+    let mut releases = Vec::new();
+    for entry in entries.into_iter().filter(|entry| entry.stable) {
+        let Some(version) = normalized_release_version(&entry.version) else {
+            continue;
+        };
+        let mut files = Vec::with_capacity(GO_TARGETS.len());
+        let mut supported = true;
+        for target in GO_TARGETS {
+            let plan = plan_go_artifact(&SourceConfig::default(), &version, target)?;
+            let matching = entry.files.iter().find(|file| {
+                file.kind == "archive"
+                    && file.os == plan.os
+                    && file.arch == plan.arch
+                    && file.version == entry.version
+                    && file.filename == plan.artifact_path
+                    && file.size > 0
+                    && valid_sha256(&file.sha256)
+            });
+            let Some(file) = matching else {
+                supported = false;
+                break;
+            };
+            files.push((target.to_owned(), file.clone()));
+        }
+        if supported {
+            releases.push(SupportedGoRelease { version, files });
+        }
+    }
+    releases.sort_by_key(|release| Reverse(version_tuple(&release.version).unwrap_or_default()));
+    releases.dedup_by(|left, right| left.version == right.version);
+    Ok(releases)
+}
+
+fn normalized_release_version(value: &str) -> Option<String> {
+    let value = value.strip_prefix("go")?;
+    let parts = value.split('.').collect::<Vec<_>>();
+    if !(parts.len() == 2 || parts.len() == 3)
+        || parts
+            .iter()
+            .any(|part| part.is_empty() || !part.bytes().all(|byte| byte.is_ascii_digit()))
+    {
+        return None;
+    }
+    let normalized = if parts.len() == 2 {
+        format!("{value}.0")
+    } else {
+        value.to_owned()
+    };
+    validate_exact_go_version(&normalized).ok()?;
+    Some(normalized)
+}
+
+fn version_tuple(version: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = version.split('.');
+    Some((
+        parts.next()?.parse().ok()?,
+        parts.next()?.parse().ok()?,
+        parts.next()?.parse().ok()?,
+    ))
+}
+
+fn valid_sha256(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+        thread,
+    };
+
+    use super::*;
+
+    #[test]
+    fn parses_only_stable_releases_with_every_pinset_target() {
+        let body = go_index_fixture("go1.25.1", true, true);
+        let releases = parse_index(&body).expect("index");
+        assert_eq!(releases.len(), 1);
+        assert_eq!(releases[0].version, "1.25.1");
+        assert_eq!(releases[0].files.len(), GO_TARGETS.len());
+
+        let incomplete = go_index_fixture("go1.25.1", true, false);
+        assert!(
+            parse_index(&incomplete)
+                .expect("incomplete index")
+                .is_empty()
+        );
+        let unstable = go_index_fixture("go1.26rc1", false, true);
+        assert!(parse_index(&unstable).expect("unstable index").is_empty());
+    }
+
+    #[test]
+    fn normalizes_historical_patch_zero_versions() {
+        assert_eq!(
+            normalized_release_version("go1.20").as_deref(),
+            Some("1.20.0")
+        );
+        assert_eq!(
+            normalized_release_version("go1.21.0").as_deref(),
+            Some("1.21.0")
+        );
+        assert!(normalized_release_version("go1.26rc1").is_none());
+    }
+
+    #[test]
+    fn resolves_a_numeric_selector_to_a_sha256_locked_tool() {
+        let body = go_index_fixture("go1.25.1", true, true).into_bytes();
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+        let address = listener.local_addr().expect("address");
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("request");
+            let mut request = [0_u8; 2048];
+            let count = stream.read(&mut request).expect("read request");
+            assert!(
+                String::from_utf8_lossy(&request[..count]).contains("GET /?mode=json&include=all")
+            );
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            )
+            .expect("headers");
+            stream.write_all(&body).expect("body");
+        });
+        let client =
+            GoMetadataClient::for_base_url(&format!("http://{address}/")).expect("metadata client");
+        let locked = client.resolve_tool("1.25").expect("locked Go");
+        server.join().expect("server");
+
+        assert_eq!(locked.name, "go");
+        assert_eq!(locked.version, "1.25.1");
+        assert_eq!(locked.provider, "go-official");
+        assert_eq!(locked.artifacts.len(), GO_TARGETS.len());
+        assert!(locked.artifacts.iter().all(|artifact| {
+            artifact.sha256 == "ab".repeat(32)
+                && artifact.verification == "go-download-json-sha256-source:custom"
+        }));
+    }
+
+    fn go_index_fixture(version: &str, stable: bool, complete: bool) -> String {
+        let normalized = normalized_release_version(version).unwrap_or_else(|| "1.25.1".to_owned());
+        let targets: &[&str] = if complete {
+            &GO_TARGETS
+        } else {
+            &GO_TARGETS[..GO_TARGETS.len() - 1]
+        };
+        let files = targets
+            .iter()
+            .map(|target| {
+                let plan = plan_go_artifact(&SourceConfig::default(), &normalized, target)
+                    .expect("artifact plan");
+                serde_json::json!({
+                    "filename": plan.artifact_path,
+                    "os": plan.os,
+                    "arch": plan.arch,
+                    "version": version,
+                    "sha256": "ab".repeat(32),
+                    "size": 123,
+                    "kind": "archive"
+                })
+            })
+            .collect::<Vec<_>>();
+        serde_json::json!([{"version": version, "stable": stable, "files": files}]).to_string()
+    }
+}

--- a/crates/pinset-core/src/go_provider.rs
+++ b/crates/pinset-core/src/go_provider.rs
@@ -1,0 +1,148 @@
+use crate::{Error, ResolvedArtifactSource, Result, SourceConfig};
+
+pub const GO_TARGETS: [&str; 4] = [
+    "windows-x86_64",
+    "macos-aarch64",
+    "macos-x86_64",
+    "linux-x86_64",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GoArchiveFormat {
+    Zip,
+    TarGz,
+}
+
+impl GoArchiveFormat {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Zip => "zip",
+            Self::TarGz => "tar.gz",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GoArtifactPlan {
+    pub version: String,
+    pub upstream_version: String,
+    pub target: String,
+    pub os: &'static str,
+    pub arch: &'static str,
+    pub artifact_path: String,
+    pub archive_root: String,
+    pub format: GoArchiveFormat,
+    pub canonical_url: String,
+    pub sources: Vec<ResolvedArtifactSource>,
+}
+
+pub fn plan_go_artifact(
+    config: &SourceConfig,
+    version: &str,
+    target: &str,
+) -> Result<GoArtifactPlan> {
+    validate_exact_go_version(version)?;
+    let (os, arch, format) = go_platform(target)?;
+    let upstream_version = upstream_go_version(version);
+    let artifact_path = format!("go{upstream_version}.{os}-{arch}.{}", format.as_str());
+    let canonical_url = config.official_artifact_url("go", &artifact_path)?;
+    let sources = config.resolve_artifact_sources("go", &artifact_path)?;
+
+    Ok(GoArtifactPlan {
+        version: version.to_owned(),
+        upstream_version,
+        target: target.to_owned(),
+        os,
+        arch,
+        artifact_path,
+        archive_root: "go".to_owned(),
+        format,
+        canonical_url,
+        sources,
+    })
+}
+
+pub fn validate_exact_go_version(version: &str) -> Result<()> {
+    let parts = version.split('.').collect::<Vec<_>>();
+    if parts.len() != 3
+        || parts.iter().any(|part| {
+            part.is_empty()
+                || !part.bytes().all(|byte| byte.is_ascii_digit())
+                || part.parse::<u64>().is_err()
+        })
+    {
+        return Err(Error::InvalidGoVersion {
+            version: version.to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn upstream_go_version(version: &str) -> String {
+    let parts = version
+        .split('.')
+        .map(|part| part.parse::<u64>().expect("validated Go version"))
+        .collect::<Vec<_>>();
+    if parts[0] == 1 && parts[1] < 21 && parts[2] == 0 {
+        format!("{}.{}", parts[0], parts[1])
+    } else {
+        version.to_owned()
+    }
+}
+
+fn go_platform(target: &str) -> Result<(&'static str, &'static str, GoArchiveFormat)> {
+    match target {
+        "windows-x86_64" => Ok(("windows", "amd64", GoArchiveFormat::Zip)),
+        "windows-aarch64" => Ok(("windows", "arm64", GoArchiveFormat::Zip)),
+        "linux-x86_64" => Ok(("linux", "amd64", GoArchiveFormat::TarGz)),
+        "linux-aarch64" => Ok(("linux", "arm64", GoArchiveFormat::TarGz)),
+        "macos-x86_64" => Ok(("darwin", "amd64", GoArchiveFormat::TarGz)),
+        "macos-aarch64" => Ok(("darwin", "arm64", GoArchiveFormat::TarGz)),
+        _ => Err(Error::UnsupportedGoTarget {
+            target: target.to_owned(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plans_go_archives_for_pinset_targets() {
+        let config = SourceConfig::default();
+        let windows = plan_go_artifact(&config, "1.25.1", "windows-x86_64").expect("windows plan");
+        assert_eq!(windows.format, GoArchiveFormat::Zip);
+        assert_eq!(windows.artifact_path, "go1.25.1.windows-amd64.zip");
+        assert_eq!(
+            windows.canonical_url,
+            "https://go.dev/dl/go1.25.1.windows-amd64.zip"
+        );
+
+        let macos = plan_go_artifact(&config, "1.25.1", "macos-aarch64").expect("macOS plan");
+        assert_eq!(macos.format, GoArchiveFormat::TarGz);
+        assert_eq!(macos.artifact_path, "go1.25.1.darwin-arm64.tar.gz");
+    }
+
+    #[test]
+    fn preserves_historical_go_patch_zero_archive_names() {
+        let plan = plan_go_artifact(&SourceConfig::default(), "1.20.0", "linux-x86_64")
+            .expect("historical plan");
+        assert_eq!(plan.upstream_version, "1.20");
+        assert_eq!(plan.artifact_path, "go1.20.linux-amd64.tar.gz");
+    }
+
+    #[test]
+    fn rejects_floating_versions_and_unknown_targets() {
+        for version in ["1", "1.25", "go1.25.0", "v1.25.0", "1.25.0-rc1"] {
+            assert!(matches!(
+                plan_go_artifact(&SourceConfig::default(), version, "linux-x86_64"),
+                Err(Error::InvalidGoVersion { .. })
+            ));
+        }
+        assert!(matches!(
+            plan_go_artifact(&SourceConfig::default(), "1.25.0", "linux-riscv64"),
+            Err(Error::UnsupportedGoTarget { .. })
+        ));
+    }
+}

--- a/crates/pinset-core/src/go_runtime.rs
+++ b/crates/pinset-core/src/go_runtime.rs
@@ -1,0 +1,106 @@
+use std::path::{Path, PathBuf};
+
+use crate::{
+    ArtifactFormat, ArtifactSource, ArtifactSourceKind, ArtifactSpec, Error, GoArchiveFormat,
+    InstallOutcome, InstallRequest, Installer, LockedArtifactFormat, LockedTool, Result,
+    SourceConfig, SourceKind, plan_go_artifact,
+};
+
+pub fn install_locked_go(
+    installer: &Installer,
+    pinset_home: &Path,
+    source_config: &SourceConfig,
+    locked_go: &LockedTool,
+    target: &str,
+) -> Result<InstallOutcome> {
+    if locked_go.name != "go" || locked_go.provider != "go-official" {
+        return Err(Error::InvalidLockfile {
+            reason: format!(
+                "{}/{} is not the built-in Go provider",
+                locked_go.name, locked_go.provider
+            ),
+        });
+    }
+    let artifact = locked_go
+        .artifact(target)
+        .ok_or_else(|| Error::LockedArtifactMissing {
+            tool: "go".to_owned(),
+            target: target.to_owned(),
+        })?;
+    let plan = plan_go_artifact(source_config, &locked_go.version, target)?;
+    let sources = plan
+        .sources
+        .into_iter()
+        .map(|source| ArtifactSource {
+            id: source.alias,
+            url: source.url,
+            kind: match source.kind {
+                SourceKind::Official => ArtifactSourceKind::Official,
+                SourceKind::Custom => ArtifactSourceKind::Mirror,
+            },
+        })
+        .collect();
+    let required_paths = required_go_paths(target)?;
+    let request = InstallRequest {
+        pinset_home: pinset_home.to_path_buf(),
+        tool: "go".to_owned(),
+        version: locked_go.version.clone(),
+        target: target.to_owned(),
+        artifact: ArtifactSpec {
+            canonical_url: artifact.canonical_url.clone(),
+            sources,
+            integrity: artifact.artifact_integrity()?.canonical(),
+            format: match artifact.format {
+                LockedArtifactFormat::Zip => ArtifactFormat::Zip,
+                LockedArtifactFormat::TarGz => ArtifactFormat::TarGz,
+                LockedArtifactFormat::TarXz => {
+                    return Err(Error::InvalidLockfile {
+                        reason: format!("Go artifact {target} cannot use tar.xz"),
+                    });
+                }
+            },
+        },
+        strip_components: 1,
+        include_prefixes: Vec::new(),
+        required_paths: required_paths.clone(),
+        base_artifacts: Vec::new(),
+        executable_paths: if plan.format == GoArchiveFormat::TarGz {
+            required_paths
+        } else {
+            Vec::new()
+        },
+    };
+    installer.install(&request)
+}
+
+fn required_go_paths(target: &str) -> Result<Vec<PathBuf>> {
+    if target.starts_with("windows-") {
+        Ok(vec![
+            PathBuf::from("bin/go.exe"),
+            PathBuf::from("bin/gofmt.exe"),
+        ])
+    } else if target.starts_with("linux-") || target.starts_with("macos-") {
+        Ok(vec![PathBuf::from("bin/go"), PathBuf::from("bin/gofmt")])
+    } else {
+        Err(Error::UnsupportedGoTarget {
+            target: target.to_owned(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn requires_go_and_gofmt_from_the_sdk_bin_directory() {
+        assert_eq!(
+            required_go_paths("linux-x86_64").expect("linux paths"),
+            [PathBuf::from("bin/go"), PathBuf::from("bin/gofmt")]
+        );
+        assert_eq!(
+            required_go_paths("windows-x86_64").expect("windows paths"),
+            [PathBuf::from("bin/go.exe"), PathBuf::from("bin/gofmt.exe")]
+        );
+    }
+}

--- a/crates/pinset-core/src/lib.rs
+++ b/crates/pinset-core/src/lib.rs
@@ -3,6 +3,12 @@ mod config;
 mod download_cache;
 mod error;
 mod global_state;
+#[cfg(feature = "go-metadata")]
+mod go_metadata;
+#[cfg(feature = "go-provider")]
+mod go_provider;
+#[cfg(all(feature = "installer", feature = "go-provider", feature = "lockfile"))]
+mod go_runtime;
 #[cfg(feature = "installer")]
 mod installer;
 #[cfg(any(feature = "installer", feature = "lockfile", feature = "npm-metadata"))]
@@ -51,6 +57,14 @@ pub use global_state::{
     global_config_path, global_lockfile_path, global_state_dir, load_global_config,
     load_optional_global_config,
 };
+#[cfg(feature = "go-metadata")]
+pub use go_metadata::{GoMetadataClient, GoRelease};
+#[cfg(feature = "go-provider")]
+pub use go_provider::{
+    GO_TARGETS, GoArchiveFormat, GoArtifactPlan, plan_go_artifact, validate_exact_go_version,
+};
+#[cfg(all(feature = "installer", feature = "go-provider", feature = "lockfile"))]
+pub use go_runtime::install_locked_go;
 #[cfg(feature = "installer")]
 pub use installer::{
     ArtifactFormat, ArtifactInstallSpec, ArtifactSource, ArtifactSourceKind, ArtifactSpec,
@@ -85,18 +99,19 @@ pub use npm_metadata::{
 #[cfg(all(feature = "installer", feature = "npm-metadata"))]
 pub use npm_runtime::install_locked_npm_tool;
 pub use resolver::{
-    CommandResolution, SelectionSource, ToolSelection, command_tool, find_system_commands,
-    path_with_selected_runtime, path_with_selected_tools, pinset_home, pinset_home_from_env,
-    resolve_command, resolve_command_with_path, resolve_from_env, resolve_tool_selection,
-    runtime_command_directory,
+    CommandResolution, RuntimeEnvironmentVariable, SelectionSource, ToolSelection, command_tool,
+    find_system_commands, path_with_selected_runtime, path_with_selected_tools, pinset_home,
+    pinset_home_from_env, resolve_command, resolve_command_with_path, resolve_from_env,
+    resolve_tool_selection, runtime_command_directory, runtime_environment_for_install,
+    selected_runtime_environment,
 };
 pub use runtime_lifecycle::{
     InstalledToolVersion, ToolVersionReference, UninstallToolOutcome, find_tool_version_references,
     list_installed_tool_versions, uninstall_tool_version,
 };
 pub use runtime_provider::{
-    RuntimeCommandLayout, RuntimeProvider, runtime_provider, runtime_provider_for_command,
-    runtime_providers,
+    RuntimeCommandLayout, RuntimeEnvironmentKind, RuntimeInstallKind, RuntimeMetadataKind,
+    RuntimeProvider, runtime_provider, runtime_provider_for_command, runtime_providers,
 };
 pub use shim_install::{
     ShimInstallMethod, ShimInstallResult, ensure_shims, install_shims, is_managed_command_shim,

--- a/crates/pinset-core/src/lockfile.rs
+++ b/crates/pinset-core/src/lockfile.rs
@@ -9,7 +9,8 @@ use atomic_write_file::AtomicWriteFile;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ArtifactIntegrity, Error, NodeArchiveFormat, Result, SourceConfig, plan_node_artifact,
+    ArtifactIntegrity, Error, GO_TARGETS, GoArchiveFormat, NodeArchiveFormat, Result, SourceConfig,
+    plan_go_artifact, plan_node_artifact,
 };
 
 pub const LOCKFILE_FILENAME: &str = "pinset.lock";
@@ -294,7 +295,10 @@ fn validate_lockfile(lockfile: &Lockfile) -> Result<()> {
 fn validate_locked_tool(tool: &LockedTool) -> Result<()> {
     let provider_supported = matches!(
         (tool.name.as_str(), tool.provider.as_str()),
-        ("node", "nodejs-official") | ("pnpm", "pnpm-npm") | ("bun", "bun-npm")
+        ("node", "nodejs-official")
+            | ("pnpm", "pnpm-npm")
+            | ("bun", "bun-npm")
+            | ("go", "go-official")
     );
     if !provider_supported {
         return Err(Error::InvalidLockfile {
@@ -321,6 +325,7 @@ fn validate_locked_tool(tool: &LockedTool) -> Result<()> {
         }
         match tool.name.as_str() {
             "node" => validate_locked_node_artifact(&tool.version, artifact)?,
+            "go" => validate_locked_go_artifact(&tool.version, artifact)?,
             "pnpm" | "bun" => validate_locked_npm_artifact(tool, artifact)?,
             _ => unreachable!("provider pair checked above"),
         }
@@ -332,6 +337,19 @@ fn validate_locked_tool(tool: &LockedTool) -> Result<()> {
                     reason: format!("missing Node MVP artifact for {target}"),
                 });
             }
+        }
+    } else if tool.name == "go" {
+        for target in GO_TARGETS {
+            if !targets.contains(target) {
+                return Err(Error::InvalidLockfile {
+                    reason: format!("missing Go artifact for {target}"),
+                });
+            }
+        }
+        if targets.len() != GO_TARGETS.len() {
+            return Err(Error::InvalidLockfile {
+                reason: "Go lock contains an unsupported artifact target".to_owned(),
+            });
         }
     } else {
         for (target, _) in npm_tool_targets(&tool.name) {
@@ -350,6 +368,46 @@ fn validate_locked_tool(tool: &LockedTool) -> Result<()> {
     if tool.artifacts.is_empty() {
         return Err(Error::InvalidLockfile {
             reason: format!("{} has no artifacts", tool.name),
+        });
+    }
+    Ok(())
+}
+
+fn validate_locked_go_artifact(version: &str, artifact: &LockedArtifact) -> Result<()> {
+    let plan = plan_go_artifact(&SourceConfig::default(), version, &artifact.target)?;
+    let expected_format = match plan.format {
+        GoArchiveFormat::Zip => LockedArtifactFormat::Zip,
+        GoArchiveFormat::TarGz => LockedArtifactFormat::TarGz,
+    };
+    if artifact.canonical_url != plan.canonical_url
+        || artifact.artifact_path != plan.artifact_path
+        || artifact.archive_root != plan.archive_root
+        || artifact.format != expected_format
+    {
+        return Err(Error::InvalidLockfile {
+            reason: format!(
+                "artifact identity for {} does not match the built-in Go provider",
+                artifact.target
+            ),
+        });
+    }
+    if artifact.artifact_integrity()?.algorithm() != crate::IntegrityAlgorithm::Sha256 {
+        return Err(Error::InvalidLockfile {
+            reason: format!("invalid Go SHA-256 for {}", artifact.target),
+        });
+    }
+    if artifact.verification != "go-download-json-sha256"
+        && !artifact
+            .verification
+            .starts_with("go-download-json-sha256-source:")
+    {
+        return Err(Error::InvalidLockfile {
+            reason: format!("unsupported Go verification for {}", artifact.target),
+        });
+    }
+    if !artifact.overlays.is_empty() {
+        return Err(Error::InvalidLockfile {
+            reason: format!("Go artifact {} cannot contain overlays", artifact.target),
         });
     }
     Ok(())
@@ -378,7 +436,11 @@ fn validate_locked_node_artifact(version: &str, artifact: &LockedArtifact) -> Re
             reason: format!("invalid SHA-256 for {}", artifact.target),
         });
     }
-    if artifact.verification != "nodejs-shasums-https" {
+    if artifact.verification != "nodejs-shasums-https"
+        && !artifact
+            .verification
+            .starts_with("nodejs-shasums-https-source:")
+    {
         return Err(Error::InvalidLockfile {
             reason: format!("unsupported verification for {}", artifact.target),
         });
@@ -605,6 +667,41 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn validates_go_provider_identity_and_required_targets() {
+        let artifacts = GO_TARGETS
+            .into_iter()
+            .map(|target| locked_go_artifact("1.25.1", target))
+            .collect::<Vec<_>>();
+        let tool = LockedTool {
+            name: "go".to_owned(),
+            requested: "1.25.1".to_owned(),
+            version: "1.25.1".to_owned(),
+            provider: "go-official".to_owned(),
+            artifacts: artifacts.clone(),
+        };
+        validate_locked_tool(&tool).expect("Go lock");
+
+        let mut invalid = tool;
+        invalid.artifacts[0].canonical_url = "https://example.invalid/go.zip".to_owned();
+        assert!(matches!(
+            validate_locked_tool(&invalid),
+            Err(Error::InvalidLockfile { .. })
+        ));
+
+        let incomplete = LockedTool {
+            name: "go".to_owned(),
+            requested: "1.25.1".to_owned(),
+            version: "1.25.1".to_owned(),
+            provider: "go-official".to_owned(),
+            artifacts: artifacts.into_iter().skip(1).collect(),
+        };
+        assert!(matches!(
+            validate_locked_tool(&incomplete),
+            Err(Error::InvalidLockfile { .. })
+        ));
+    }
+
     fn locked_artifact(target: &str) -> LockedArtifact {
         let plan = plan_node_artifact(&SourceConfig::default(), "24.0.0", target).expect("plan");
         LockedArtifact {
@@ -630,6 +727,24 @@ mod tests {
             version: version.to_owned(),
             provider: "pnpm-npm".to_owned(),
             artifacts: vec![artifact],
+        }
+    }
+
+    fn locked_go_artifact(version: &str, target: &str) -> LockedArtifact {
+        let plan = plan_go_artifact(&SourceConfig::default(), version, target).expect("Go plan");
+        LockedArtifact {
+            target: target.to_owned(),
+            canonical_url: plan.canonical_url,
+            artifact_path: plan.artifact_path,
+            sha256: "ab".repeat(32),
+            integrity: None,
+            format: match plan.format {
+                GoArchiveFormat::Zip => LockedArtifactFormat::Zip,
+                GoArchiveFormat::TarGz => LockedArtifactFormat::TarGz,
+            },
+            archive_root: plan.archive_root,
+            verification: "go-download-json-sha256".to_owned(),
+            overlays: Vec::new(),
         }
     }
 

--- a/crates/pinset-core/src/resolver.rs
+++ b/crates/pinset-core/src/resolver.rs
@@ -8,9 +8,10 @@ use std::{
 #[cfg(test)]
 use crate::current_target;
 use crate::{
-    Error, Result, RuntimeCommandLayout, current_target_for_tool, find_optional_project_config,
-    global_config_path, is_managed_command_shim, load_optional_global_config, load_project_config,
-    runtime_provider, runtime_provider_for_command, runtime_providers,
+    Error, Result, RuntimeCommandLayout, RuntimeEnvironmentKind, current_target_for_tool,
+    find_optional_project_config, global_config_path, is_managed_command_shim,
+    load_optional_global_config, load_project_config, runtime_provider,
+    runtime_provider_for_command, runtime_providers,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -46,6 +47,12 @@ pub struct CommandResolution {
     pub source: SelectionSource,
     pub selection_path: Option<PathBuf>,
     pub executable: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeEnvironmentVariable {
+    pub name: &'static str,
+    pub value: OsString,
 }
 
 pub fn command_tool(command: &str) -> Option<&'static str> {
@@ -340,6 +347,53 @@ pub fn path_with_selected_tools(
         }
     }
     env::join_paths(entries).map_err(|source| Error::RuntimePathJoin { source })
+}
+
+pub fn selected_runtime_environment(
+    cwd: &Path,
+    pinset_home: &Path,
+) -> Vec<RuntimeEnvironmentVariable> {
+    let mut variables = Vec::new();
+    for provider in runtime_providers() {
+        if provider.environment == RuntimeEnvironmentKind::None {
+            continue;
+        }
+        let Ok(selection) = resolve_tool_selection(provider.tool, cwd, pinset_home) else {
+            continue;
+        };
+        let install_dir = pinset_home
+            .join("installs")
+            .join(provider.tool)
+            .join(selection.version)
+            .join(current_target_for_tool(provider.tool));
+        if !install_dir.is_dir() {
+            continue;
+        }
+        variables.extend(runtime_environment_for_install(provider.tool, &install_dir));
+    }
+    variables
+}
+
+pub fn runtime_environment_for_install(
+    tool: &str,
+    install_dir: &Path,
+) -> Vec<RuntimeEnvironmentVariable> {
+    match runtime_provider(tool).map(|provider| provider.environment) {
+        Some(RuntimeEnvironmentKind::Go) => {
+            let mut variables = vec![RuntimeEnvironmentVariable {
+                name: "GOROOT",
+                value: install_dir.as_os_str().to_owned(),
+            }];
+            if env::var_os("GOTOOLCHAIN").is_none() {
+                variables.push(RuntimeEnvironmentVariable {
+                    name: "GOTOOLCHAIN",
+                    value: OsString::from("local"),
+                });
+            }
+            variables
+        }
+        Some(RuntimeEnvironmentKind::None) | None => Vec::new(),
+    }
 }
 
 pub fn runtime_command_directory(tool: &str, install_dir: &Path) -> PathBuf {

--- a/crates/pinset-core/src/runtime_provider.rs
+++ b/crates/pinset-core/src/runtime_provider.rs
@@ -3,6 +3,9 @@ pub struct RuntimeProvider {
     pub tool: &'static str,
     pub commands: &'static [&'static str],
     pub command_layout: RuntimeCommandLayout,
+    pub metadata: RuntimeMetadataKind,
+    pub installer: RuntimeInstallKind,
+    pub environment: RuntimeEnvironmentKind,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -12,23 +15,60 @@ pub enum RuntimeCommandLayout {
     Bin,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeMetadataKind {
+    Node,
+    Npm,
+    Go,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeInstallKind {
+    Node,
+    Npm,
+    Go,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeEnvironmentKind {
+    None,
+    Go,
+}
+
 const NODE_COMMANDS: &[&str] = &["node", "npm", "npx", "corepack"];
 const NODE_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "node",
     commands: NODE_COMMANDS,
     command_layout: RuntimeCommandLayout::NodeNative,
+    metadata: RuntimeMetadataKind::Node,
+    installer: RuntimeInstallKind::Node,
+    environment: RuntimeEnvironmentKind::None,
 };
 const PNPM_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "pnpm",
     commands: &["pnpm"],
     command_layout: RuntimeCommandLayout::Root,
+    metadata: RuntimeMetadataKind::Npm,
+    installer: RuntimeInstallKind::Npm,
+    environment: RuntimeEnvironmentKind::None,
 };
 const BUN_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "bun",
     commands: &["bun", "bunx"],
     command_layout: RuntimeCommandLayout::Bin,
+    metadata: RuntimeMetadataKind::Npm,
+    installer: RuntimeInstallKind::Npm,
+    environment: RuntimeEnvironmentKind::None,
 };
-const PROVIDERS: &[RuntimeProvider] = &[NODE_PROVIDER, PNPM_PROVIDER, BUN_PROVIDER];
+const GO_PROVIDER: RuntimeProvider = RuntimeProvider {
+    tool: "go",
+    commands: &["go", "gofmt"],
+    command_layout: RuntimeCommandLayout::Bin,
+    metadata: RuntimeMetadataKind::Go,
+    installer: RuntimeInstallKind::Go,
+    environment: RuntimeEnvironmentKind::Go,
+};
+const PROVIDERS: &[RuntimeProvider] = &[NODE_PROVIDER, PNPM_PROVIDER, BUN_PROVIDER, GO_PROVIDER];
 
 pub fn runtime_providers() -> &'static [RuntimeProvider] {
     PROVIDERS
@@ -68,6 +108,14 @@ mod tests {
         assert_eq!(
             runtime_provider("bun").expect("bun").commands,
             ["bun", "bunx"]
+        );
+        assert_eq!(
+            runtime_provider("go").expect("go").commands,
+            ["go", "gofmt"]
+        );
+        assert_eq!(
+            runtime_provider_for_command("gofmt").map(|provider| provider.tool),
+            Some("go")
         );
         assert!(runtime_provider("python").is_none());
         assert!(runtime_provider_for_command("python").is_none());

--- a/crates/pinset-core/src/source_config.rs
+++ b/crates/pinset-core/src/source_config.rs
@@ -11,7 +11,7 @@ use url::Url;
 
 use crate::{Error, Result};
 
-pub const SUPPORTED_SOURCE_PROVIDERS: [&str; 3] = ["node", "python", "flutter"];
+pub const SUPPORTED_SOURCE_PROVIDERS: [&str; 4] = ["node", "go", "python", "flutter"];
 const SOURCE_CONFIG_SCHEMA: u32 = 1;
 const OFFICIAL_ALIAS: &str = "official";
 
@@ -538,6 +538,7 @@ fn join_artifact_url(alias: &str, base_url: &str, artifact_path: &str) -> Result
 fn official_base_url(provider: &str) -> &'static str {
     match provider {
         "node" => "https://nodejs.org/dist/",
+        "go" => "https://go.dev/dl/",
         "python" => "https://github.com/astral-sh/python-build-standalone/releases/download/",
         "flutter" => "https://storage.googleapis.com/",
         _ => unreachable!(),

--- a/crates/pinset-shim/src/main.rs
+++ b/crates/pinset-shim/src/main.rs
@@ -10,6 +10,7 @@ use std::ffi::OsStr;
 
 use pinset_core::{
     CommandResolution, path_with_selected_tools, pinset_home_from_env, resolve_command_with_path,
+    selected_runtime_environment,
 };
 
 const SHIM_DEPTH_ENV: &str = "PINSET_SHIM_DEPTH";
@@ -52,6 +53,9 @@ fn run() -> Result<i32, Box<dyn std::error::Error>> {
         .env(SELECTED_TOOL_ENV, &resolution.tool)
         .env(SELECTED_VERSION_ENV, &resolution.version)
         .env(SELECTION_SOURCE_ENV, resolution.source.as_str());
+    for variable in selected_runtime_environment(&invocation.cwd, &home) {
+        child.env(variable.name, variable.value);
+    }
     if let Some(path) = &resolution.selection_path {
         child.env(CONFIG_PATH_ENV, path);
     } else {

--- a/crates/pinset/Cargo.toml
+++ b/crates/pinset/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap.workspace = true
-pinset-core = { path = "../pinset-core", features = ["installer", "node-metadata", "npm-metadata", "project-write", "sources", "state-write"] }
+pinset-core = { path = "../pinset-core", features = ["go-metadata", "installer", "node-metadata", "npm-metadata", "project-write", "sources", "state-write"] }
 serde.workspace = true
 serde_json.workspace = true
 terminal_size.workspace = true

--- a/crates/pinset/src/i18n.rs
+++ b/crates/pinset/src/i18n.rs
@@ -210,34 +210,34 @@ impl Catalog {
         match command {
             Some("init") => "创建项目配置。\n\n用法：pinset init",
             Some("global") => {
-                "查看或设置项目之外使用的全局默认运行时。\n\n用法：pinset global [node@lts|pnpm@11|bun@1.3] [--no-install]"
+                "查看或设置项目之外使用的全局默认运行时。\n\n用法：pinset global [node@lts|pnpm@11|bun@1.3|go@1.25] [--no-install]"
             }
             Some("use") => {
-                "选择并锁定 Node.js、pnpm 或 Bun 版本。\n\n用法：pinset use <node@24|pnpm@11|bun@1.3> [--global] [--no-install]"
+                "选择并锁定 Node.js、pnpm、Bun 或 Go 版本。\n\n用法：pinset use <node@24|pnpm@11|bun@1.3|go@1.25> [--global] [--no-install]"
             }
             Some("unset") => {
-                "清除项目或全局运行时选择，不卸载运行时。\n\n用法：pinset unset <node|pnpm|bun> [--global] [--cwd <目录>]"
+                "清除项目或全局运行时选择，不卸载运行时。\n\n用法：pinset unset <node|pnpm|bun|go> [--global] [--cwd <目录>]"
             }
             Some("install") => {
-                "安装指定运行时版本，或根据项目/全局锁文件安装全部工具。\n\n用法：\n  pinset install <node|pnpm|bun>@<版本选择器>\n  pinset install [--locked] [--global] [--cwd <目录>]"
+                "安装指定运行时版本，或根据项目/全局锁文件安装全部工具。\n\n用法：\n  pinset install <node|pnpm|bun|go>@<版本选择器>\n  pinset install [--locked] [--global] [--cwd <目录>]"
             }
             Some("which") => {
                 "显示实际执行的运行时命令路径。\n\n用法：pinset which <命令> [--cwd <目录>]"
             }
             Some("current") => {
-                "显示当前版本、来源和安装路径。\n\n用法：pinset current [node|pnpm|bun] [--cwd <目录>]"
+                "显示当前版本、来源和安装路径。\n\n用法：pinset current [node|pnpm|bun|go] [--cwd <目录>]"
             }
             Some("list") => {
-                "列出本机已安装或官方可用的运行时版本。\n\n用法：pinset list <node|pnpm|bun> [--available]"
+                "列出本机已安装或官方可用的运行时版本。\n\n用法：pinset list <node|pnpm|bun|go> [--available]"
             }
             Some("uninstall") => {
-                "卸载 Pinset 管理的精确运行时版本。\n\n用法：pinset uninstall <node|pnpm|bun>@x.y.z [--cwd <目录>] [--force]"
+                "卸载 Pinset 管理的精确运行时版本。\n\n用法：pinset uninstall <node|pnpm|bun|go>@x.y.z [--cwd <目录>] [--force]"
             }
             Some("cache") => {
                 "查看、清理或离线导入已验证的运行时下载缓存。\n\n用法：pinset cache <list|clean|import>"
             }
             Some("exec") => {
-                "使用当前选择或一次性 Node.js 版本执行命令。\n\n用法：pinset exec [--cwd <目录>] [node@<版本选择器>] -- <命令> [参数...]"
+                "使用当前选择或一次性运行时版本执行命令。\n\n用法：pinset exec [--cwd <目录>] [<工具>@<版本选择器>] -- <命令> [参数...]"
             }
             Some("doctor") => {
                 "只读检查配置、锁文件、运行时、shim 和 PATH。\n\n用法：pinset doctor [--cwd <目录>] [--json]"
@@ -840,6 +840,7 @@ impl Catalog {
                     "provider-route-shadowed" => "Pinset 命令路由被更早的 PATH 项遮蔽",
                     "provider-route-conflict" => "目标目录存在外部同名命令",
                     "provider-route-missing" => "Provider 命令路由缺失",
+                    "go-toolchain-override" => "显式 GOTOOLCHAIN 可能绕过 Pinset 锁定",
                     _ => code,
                 };
                 format!(
@@ -989,15 +990,8 @@ impl Catalog {
 
     pub fn selection_error(self) -> &'static str {
         match self.language {
-            Language::English => "selection must use node@<selector>",
-            Language::SimplifiedChinese => "版本选择必须使用 node@<选择器> 格式",
-        }
-    }
-
-    pub fn node_only_error(self) -> &'static str {
-        match self.language {
-            Language::English => "this operation only accepts the node tool",
-            Language::SimplifiedChinese => "此操作只接受 node 工具",
+            Language::English => "selection must use <tool>@<selector>",
+            Language::SimplifiedChinese => "版本选择必须使用 <工具>@<选择器> 格式",
         }
     }
 

--- a/crates/pinset/src/i18n.rs
+++ b/crates/pinset/src/i18n.rs
@@ -362,15 +362,6 @@ impl Catalog {
         }
     }
 
-    pub fn selector_resolved(self, selector: &str, version: &str) -> String {
-        match self.language {
-            Language::English => format!("resolved node@{selector} to node@{version}"),
-            Language::SimplifiedChinese => {
-                format!("已将 node@{selector} 解析为精确版本 node@{version}")
-            }
-        }
-    }
-
     pub fn no_installed_node(self) -> &'static str {
         match self.language {
             Language::English => "no Node.js versions are installed by Pinset",

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -16,19 +16,20 @@ use std::ffi::OsStr;
 
 use clap::{Parser, Subcommand, ValueEnum, error::ErrorKind};
 use pinset_core::{
-    ArtifactIntegrity, DownloadProgressEvent, Error, GlobalConfig, InstallLimits, Installer,
-    LockedTool, Lockfile, NodeMetadataClient, NpmMetadataClient, SUPPORTED_SOURCE_PROVIDERS,
-    ShimInstallMethod, SourceView, clean_download_cache, command_tool, create_project_config,
-    current_target, current_target_for_tool, ensure_shims, find_optional_project_config,
-    find_project_config, global_config_path, global_lockfile_path, import_download_cache,
-    import_download_cache_with_integrity, install_locked_node, install_locked_npm_tool,
-    is_managed_command_shim, list_download_cache, list_installed_tool_versions, load_global_config,
-    load_lockfile, load_optional_global_config, load_optional_lockfile, load_project_config,
-    load_source_config, load_user_settings, lockfile_path, node_command_directory,
-    path_with_selected_tools, pinset_home, resolve_command, resolve_tool_selection,
-    runtime_command_directory, runtime_provider, save_global_config, save_global_state,
-    save_lockfile, save_project_config, save_source_config, save_user_settings, source_config_path,
-    uninstall_node_version, uninstall_tool_version, user_settings_path,
+    ArtifactIntegrity, DownloadProgressEvent, Error, GlobalConfig, GoMetadataClient, InstallLimits,
+    Installer, LockedTool, Lockfile, NodeMetadataClient, NpmMetadataClient, RuntimeInstallKind,
+    RuntimeMetadataKind, SUPPORTED_SOURCE_PROVIDERS, ShimInstallMethod, SourceView,
+    clean_download_cache, command_tool, create_project_config, current_target_for_tool,
+    ensure_shims, find_optional_project_config, find_project_config, global_config_path,
+    global_lockfile_path, import_download_cache, import_download_cache_with_integrity,
+    install_locked_go, install_locked_node, install_locked_npm_tool, is_managed_command_shim,
+    list_download_cache, list_installed_tool_versions, load_global_config, load_lockfile,
+    load_optional_global_config, load_optional_lockfile, load_project_config, load_source_config,
+    load_user_settings, lockfile_path, path_with_selected_tools, pinset_home, resolve_command,
+    resolve_tool_selection, runtime_command_directory, runtime_environment_for_install,
+    runtime_provider, save_global_config, save_global_state, save_lockfile, save_project_config,
+    save_source_config, save_user_settings, selected_runtime_environment, source_config_path,
+    uninstall_node_version, uninstall_tool_version, user_settings_path, validate_exact_go_version,
     validate_exact_node_version, validate_lock_matches_selection, validate_lock_matches_tool,
     validate_lock_matches_tools,
 };
@@ -58,7 +59,7 @@ enum Commands {
     Init,
     /// Show or set a default runtime version used outside projects.
     Global {
-        /// Selection such as node@lts, pnpm@11 or bun@1.3.
+        /// Selection such as node@lts, pnpm@11, bun@1.3 or go@1.25.
         selection: Option<String>,
         /// Update the global selection and lock without downloading the runtime.
         #[arg(long, requires = "selection")]
@@ -66,7 +67,7 @@ enum Commands {
     },
     /// Select and lock a runtime version for the current project or globally.
     Use {
-        /// Selection such as node@24, pnpm@11 or bun@1.3.
+        /// Selection such as node@24, pnpm@11, bun@1.3 or go@1.25.
         selection: String,
         /// Update the selection and lock without downloading the runtime.
         #[arg(long)]
@@ -77,7 +78,7 @@ enum Commands {
     },
     /// Clear a project or global runtime selection without uninstalling anything.
     Unset {
-        /// Tool to clear: node, pnpm or bun.
+        /// Tool to clear: node, pnpm, bun or go.
         tool: String,
         /// Clear the global default instead of the nearest project selection.
         #[arg(long, conflicts_with = "cwd")]
@@ -115,7 +116,7 @@ enum Commands {
     },
     /// List installed or officially available runtime versions.
     List {
-        /// Tool to list: node, pnpm or bun.
+        /// Tool to list: node, pnpm, bun or go.
         tool: String,
         /// Query the official provider index instead of local installations.
         #[arg(long)]
@@ -254,7 +255,7 @@ enum CacheCommands {
 enum SourceCommands {
     /// List built-in and custom sources.
     List {
-        /// Limit output to node, python or flutter.
+        /// Limit output to node, go, python or flutter.
         provider: Option<String>,
     },
     /// Add a custom source. HTTPS is required by default.
@@ -423,22 +424,32 @@ fn run(cli: Cli, catalog: Catalog) -> Result<ExitCode, Box<dyn std::error::Error
         Commands::List { tool, available } => {
             require_provider(&tool)?;
             if available {
-                if tool == "node" {
-                    let releases = node_metadata_client(&pinset_home()?)?.available_releases()?;
-                    for release in releases {
-                        println!(
-                            "{}",
-                            catalog.available_node(
-                                &release.version,
-                                &release.date,
-                                release.lts.as_deref(),
-                                release.security,
-                            )
-                        );
+                let provider = runtime_provider(&tool).expect("required provider exists");
+                match provider.metadata {
+                    RuntimeMetadataKind::Node => {
+                        let releases =
+                            node_metadata_client(&pinset_home()?)?.available_releases()?;
+                        for release in releases {
+                            println!(
+                                "{}",
+                                catalog.available_node(
+                                    &release.version,
+                                    &release.date,
+                                    release.lts.as_deref(),
+                                    release.security,
+                                )
+                            );
+                        }
                     }
-                } else {
-                    for release in NpmMetadataClient::official()?.available_releases(&tool)? {
-                        println!("{}@{}", tool, release.version);
+                    RuntimeMetadataKind::Npm => {
+                        for release in NpmMetadataClient::official()?.available_releases(&tool)? {
+                            println!("{}@{}", tool, release.version);
+                        }
+                    }
+                    RuntimeMetadataKind::Go => {
+                        for release in go_metadata_client(&pinset_home()?)?.available_releases()? {
+                            println!("go@{}", release.version);
+                        }
                     }
                 }
             } else {
@@ -649,17 +660,6 @@ fn parse_tool_selection(
     Ok((tool.to_owned(), version.to_owned()))
 }
 
-fn parse_node_selection(
-    selection: &str,
-    catalog: Catalog,
-) -> Result<String, Box<dyn std::error::Error>> {
-    let (tool, version) = parse_tool_selection(selection, catalog)?;
-    if tool != "node" {
-        return Err(catalog.node_only_error().into());
-    }
-    Ok(version)
-}
-
 fn require_provider(tool: &str) -> Result<(), Box<dyn std::error::Error>> {
     runtime_provider(tool)
         .map(|_| ())
@@ -670,12 +670,18 @@ fn validate_exact_tool_version(
     tool: &str,
     version: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    if tool == "node" {
-        validate_exact_node_version(version)?;
-    } else {
-        let resolved = NpmMetadataClient::official()?.resolve_version_selector(tool, version)?;
-        if resolved != version {
-            return Err(format!("{tool}@{version} is not an exact stable version").into());
+    let provider = runtime_provider(tool).expect("validated provider");
+    match provider.metadata {
+        RuntimeMetadataKind::Node => validate_exact_node_version(version)?,
+        RuntimeMetadataKind::Npm => {
+            let resolved =
+                NpmMetadataClient::official()?.resolve_version_selector(tool, version)?;
+            if resolved != version {
+                return Err(format!("{tool}@{version} is not an exact stable version").into());
+            }
+        }
+        RuntimeMetadataKind::Go => {
+            validate_exact_go_version(version)?;
         }
     }
     Ok(())
@@ -685,17 +691,23 @@ fn resolve_locked_tool(
     tool: &str,
     selector: &str,
 ) -> Result<LockedTool, Box<dyn std::error::Error>> {
-    if tool == "node" {
-        let lockfile = node_metadata_client(&pinset_home()?)?
-            .resolve_lock(selector, &format!("pinset {}", env!("CARGO_PKG_VERSION")))?;
-        return Ok(lockfile
-            .tool("node")
-            .expect("generated Node lock contains node")
-            .clone());
+    let provider = runtime_provider(tool).expect("validated provider");
+    match provider.metadata {
+        RuntimeMetadataKind::Node => {
+            let lockfile = node_metadata_client(&pinset_home()?)?
+                .resolve_lock(selector, &format!("pinset {}", env!("CARGO_PKG_VERSION")))?;
+            Ok(lockfile
+                .tool("node")
+                .expect("generated Node lock contains node")
+                .clone())
+        }
+        RuntimeMetadataKind::Npm => {
+            let client = NpmMetadataClient::official()?;
+            let version = client.resolve_version_selector(tool, selector)?;
+            Ok(client.resolve_tool(tool, &version)?)
+        }
+        RuntimeMetadataKind::Go => Ok(go_metadata_client(&pinset_home()?)?.resolve_tool(selector)?),
     }
-    let client = NpmMetadataClient::official()?;
-    let version = client.resolve_version_selector(tool, selector)?;
-    Ok(client.resolve_tool(tool, &version)?)
 }
 
 fn new_lockfile() -> Lockfile {
@@ -990,11 +1002,17 @@ fn install_tool_from_lock(
     let installer = Installer::new(InstallLimits::default())?
         .with_progress_reporter(download_progress_reporter(catalog));
     let target = current_target_for_tool(tool);
-    let outcome = if tool == "node" {
-        let sources = load_source_config(&source_config_path(home))?;
-        install_locked_node(&installer, home, &sources, locked_tool, &target)?
-    } else {
-        install_locked_npm_tool(&installer, home, locked_tool, &target)?
+    let provider = runtime_provider(tool).expect("locked tool provider exists");
+    let outcome = match provider.installer {
+        RuntimeInstallKind::Node => {
+            let sources = load_source_config(&source_config_path(home))?;
+            install_locked_node(&installer, home, &sources, locked_tool, &target)?
+        }
+        RuntimeInstallKind::Npm => install_locked_npm_tool(&installer, home, locked_tool, &target)?,
+        RuntimeInstallKind::Go => {
+            let sources = load_source_config(&source_config_path(home))?;
+            install_locked_go(&installer, home, &sources, locked_tool, &target)?
+        }
     };
     if outcome.reused_existing {
         if tool == "node" {
@@ -1414,14 +1432,18 @@ fn execute_selected(
     command: &[OsString],
     catalog: Catalog,
 ) -> Result<ExitCode, Box<dyn std::error::Error>> {
-    let (ephemeral_selector, mut command) = command
+    let (ephemeral_selection, mut command) = command
         .first()
         .and_then(|value| value.to_str())
-        .filter(|value| value.starts_with("node@"))
+        .filter(|value| {
+            value.split_once('@').is_some_and(|(tool, selector)| {
+                !selector.is_empty() && runtime_provider(tool).is_some()
+            })
+        })
         .map_or((None, command), |selection| {
             (Some(selection), &command[1..])
         });
-    if ephemeral_selector.is_some() && command.first().is_some_and(|value| value == "--") {
+    if ephemeral_selection.is_some() && command.first().is_some_and(|value| value == "--") {
         command = &command[1..];
     }
     let command_name = command
@@ -1429,14 +1451,15 @@ fn execute_selected(
         .and_then(|value| value.to_str())
         .ok_or_else(|| catalog.utf8_command_error())?;
     let home = pinset_home()?;
-    let (executable, tool, version, source, config_path) =
-        if let Some(selection) = ephemeral_selector {
-            let selector = parse_node_selection(selection, catalog)?;
-            let version = node_metadata_client(&home)?.resolve_version_selector(&selector)?;
+    let (executable, tool, version, source, config_path, ephemeral_environment) =
+        if let Some(selection) = ephemeral_selection {
+            let (tool, selector) = parse_tool_selection(selection, catalog)?;
+            let locked_tool = resolve_locked_tool(&tool, &selector)?;
+            let version = locked_tool.version;
             if selector != version {
-                println!("{}", catalog.selector_resolved(&selector, &version));
+                println!("{tool}@{selector} resolved to {tool}@{version}");
             }
-            if command_tool(command_name) != Some("node") {
+            if command_tool(command_name) != Some(tool.as_str()) {
                 return Err(Error::UnsupportedCommand {
                     command: command_name.to_owned(),
                 }
@@ -1444,21 +1467,22 @@ fn execute_selected(
             }
             let install_dir = home
                 .join("installs")
-                .join("node")
+                .join(&tool)
                 .join(&version)
-                .join(current_target());
-            let command_dir = node_command_directory(&install_dir, &current_target())?;
+                .join(current_target_for_tool(&tool));
+            let command_dir = runtime_command_directory(&tool, &install_dir);
             let executable = runtime_command_path(&command_dir, command_name);
             if !executable.is_file() {
                 return Err(Error::RuntimeCommandNotFound {
-                    tool: "node".to_owned(),
-                    version,
+                    tool: tool.clone(),
+                    version: version.clone(),
                     command: command_name.to_owned(),
                     searched: executable.display().to_string(),
                 }
                 .into());
             }
-            (executable, "node".to_owned(), version, "ephemeral", None)
+            let environment = runtime_environment_for_install(&tool, &install_dir);
+            (executable, tool, version, "ephemeral", None, environment)
         } else {
             let resolution = resolve_command(command_name, cwd, &home)?;
             (
@@ -1467,6 +1491,7 @@ fn execute_selected(
                 resolution.version,
                 resolution.source.as_str(),
                 resolution.selection_path,
+                Vec::new(),
             )
         };
     let runtime_path = path_with_selected_tools(&executable, cwd, &home)?;
@@ -1478,6 +1503,12 @@ fn execute_selected(
         .env("PINSET_SELECTED_TOOL", &tool)
         .env("PINSET_SELECTED_VERSION", &version)
         .env("PINSET_SELECTION_SOURCE", source);
+    for variable in selected_runtime_environment(cwd, &home) {
+        child.env(variable.name, variable.value);
+    }
+    for variable in ephemeral_environment {
+        child.env(variable.name, variable.value);
+    }
     if let Some(path) = &config_path {
         child.env("PINSET_CONFIG_PATH", path);
     } else {
@@ -1670,7 +1701,7 @@ fn doctor_report(cwd: &Path) -> Result<DoctorReport, Box<dyn std::error::Error>>
     } else {
         existing_shim_commands(&legacy_shims, &commands)
     };
-    let routing_issues = collect_routing_issues(
+    let mut routing_issues = collect_routing_issues(
         pinset_core::runtime_providers()
             .iter()
             .any(|provider| resolve_tool_selection(provider.tool, cwd, &home).is_ok()),
@@ -1681,6 +1712,9 @@ fn doctor_report(cwd: &Path) -> Result<DoctorReport, Box<dyn std::error::Error>>
         &legacy_shims,
         &legacy_commands,
     );
+    if let Some(issue) = go_toolchain_routing_issue(cwd, &home) {
+        routing_issues.push(issue);
+    }
     Ok(DoctorReport {
         schema: 1,
         cwd: cwd.display().to_string(),
@@ -1790,6 +1824,20 @@ fn collect_routing_issues(
         }
     }
     issues
+}
+
+fn go_toolchain_routing_issue(cwd: &Path, home: &Path) -> Option<DoctorRoutingIssue> {
+    resolve_tool_selection("go", cwd, home).ok()?;
+    let value = env::var_os("GOTOOLCHAIN")?;
+    if value.to_string_lossy().eq_ignore_ascii_case("local") {
+        return None;
+    }
+    Some(DoctorRoutingIssue {
+        code: "go-toolchain-override",
+        command: Some("go".to_owned()),
+        path: None,
+        action: "unset GOTOOLCHAIN or set it to local to enforce the Pinset lock",
+    })
 }
 
 fn detect_legacy_node_configs(
@@ -2121,7 +2169,7 @@ fn run_doctor(cwd: &Path, catalog: Catalog) -> Result<(), Box<dyn std::error::Er
     let selected = pinset_core::runtime_providers()
         .iter()
         .any(|provider| resolve_tool_selection(provider.tool, cwd, &home).is_ok());
-    for issue in collect_routing_issues(
+    let mut routing_issues = collect_routing_issues(
         selected,
         &commands,
         &path_candidates,
@@ -2129,7 +2177,11 @@ fn run_doctor(cwd: &Path, catalog: Catalog) -> Result<(), Box<dyn std::error::Er
         &shim_binary,
         &legacy_shims,
         &legacy_commands,
-    ) {
+    );
+    if let Some(issue) = go_toolchain_routing_issue(cwd, &home) {
+        routing_issues.push(issue);
+    }
+    for issue in routing_issues {
         println!(
             "{}",
             catalog.doctor_routing_issue(
@@ -2302,23 +2354,42 @@ fn run_source_command(
             println!("{}", catalog.source_changed("removed", &provider, &alias));
         }
         SourceCommands::Test { provider, alias } => {
-            if provider != "node" {
-                return Err(catalog.node_only_error().into());
-            }
             let source = config.source(&provider, alias.as_deref())?;
-            let client = NodeMetadataClient::for_base_url(&source.base_url)?;
-            let releases = client.available_releases()?;
-            let newest = releases.first().ok_or_else(|| Error::InvalidNodeIndex {
-                reason: "source index contains no supported stable releases".to_owned(),
-            })?;
-            client.resolve_exact_lock(&newest.version, "pinset source test")?;
+            let releases = match runtime_provider(&provider).map(|provider| provider.metadata) {
+                Some(RuntimeMetadataKind::Node) => {
+                    let client = NodeMetadataClient::for_base_url(&source.base_url)?;
+                    let releases = client.available_releases()?;
+                    let newest = releases.first().ok_or_else(|| Error::InvalidNodeIndex {
+                        reason: "source index contains no supported stable releases".to_owned(),
+                    })?;
+                    client.resolve_exact_lock(&newest.version, "pinset source test")?;
+                    releases.len()
+                }
+                Some(RuntimeMetadataKind::Go) => {
+                    let client = GoMetadataClient::for_base_url(&source.base_url)?;
+                    let releases = client.available_releases()?;
+                    if releases.is_empty() {
+                        return Err(Error::InvalidGoIndex {
+                            reason: "source index contains no supported stable releases".to_owned(),
+                        }
+                        .into());
+                    }
+                    releases.len()
+                }
+                Some(RuntimeMetadataKind::Npm) | None => {
+                    return Err(format!(
+                        "source testing is not available for provider {provider:?}"
+                    )
+                    .into());
+                }
+            };
             println!(
                 "{}",
                 catalog.source_test_ok(
                     &provider,
                     &source.alias,
                     &source.base_url,
-                    releases.len(),
+                    releases,
                     source.base_url.starts_with("https://"),
                 )
             );
@@ -2396,6 +2467,19 @@ fn node_metadata_client(home: &Path) -> Result<NodeMetadataClient, Box<dyn std::
         Ok(NodeMetadataClient::official()?)
     } else {
         Ok(NodeMetadataClient::for_source(
+            &source.base_url,
+            &source.alias,
+        )?)
+    }
+}
+
+fn go_metadata_client(home: &Path) -> Result<GoMetadataClient, Box<dyn std::error::Error>> {
+    let config = load_source_config(&source_config_path(home))?;
+    let source = config.metadata_source("go")?;
+    if source.kind == pinset_core::SourceKind::Official {
+        Ok(GoMetadataClient::official()?)
+    } else {
+        Ok(GoMetadataClient::for_source(
             &source.base_url,
             &source.alias,
         )?)

--- a/crates/pinset/tests/go_cli.rs
+++ b/crates/pinset/tests/go_cli.rs
@@ -1,0 +1,134 @@
+use std::{
+    fs,
+    path::Path,
+    process::{Command, Output},
+};
+
+use tempfile::tempdir;
+
+#[test]
+fn resolves_lists_and_executes_a_managed_go_sdk() {
+    let root = tempdir().expect("root");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    fs::create_dir(&project).expect("project");
+    fs::write(
+        project.join("pinset.toml"),
+        "schema = 2\n\n[tools]\ngo = \"1.25.1\"\n",
+    )
+    .expect("config");
+
+    let install_dir = home
+        .join("installs/go/1.25.1")
+        .join(pinset_core::current_target_for_tool("go"));
+    let bin_dir = install_dir.join("bin");
+    fs::create_dir_all(&bin_dir).expect("Go bin");
+    write_go_command(&bin_dir, &install_dir);
+    write_gofmt_command(&bin_dir);
+    fs::write(
+        install_dir.join(".pinset-install.toml"),
+        format!(
+            "schema = 2\ncomplete = true\ntool = \"go\"\nversion = \"1.25.1\"\ntarget = \"{}\"\n",
+            pinset_core::current_target_for_tool("go")
+        ),
+    )
+    .expect("receipt");
+
+    assert_success_contains(&pinset(&project, &home, &["list", "go"]), "go@1.25.1");
+    assert_success_contains(
+        &pinset(&project, &home, &["current", "go"]),
+        "go 1.25.1 installed",
+    );
+    let which = pinset(&project, &home, &["which", "go"]);
+    assert!(
+        which.status.success()
+            && String::from_utf8_lossy(&which.stdout).contains(&bin_dir.display().to_string()),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&which.stdout),
+        String::from_utf8_lossy(&which.stderr)
+    );
+
+    let executed = pinset(&project, &home, &["exec", "--", "go", "version"]);
+    assert_success_contains(&executed, "go version go1.25.1");
+    assert_success_contains(&executed, &format!("GOROOT={}", install_dir.display()));
+    assert_success_contains(&executed, "GOTOOLCHAIN=local");
+
+    let explicit_policy = Command::new(env!("CARGO_BIN_EXE_pinset"))
+        .current_dir(&project)
+        .env("PINSET_HOME", &home)
+        .env("PINSET_LANG", "en")
+        .env("GOTOOLCHAIN", "path")
+        .args(["exec", "--", "go", "version"])
+        .output()
+        .expect("run with explicit Go toolchain policy");
+    assert_success_contains(&explicit_policy, "GOTOOLCHAIN=path");
+
+    let gofmt = pinset(&project, &home, &["exec", "--", "gofmt", "fixture.go"]);
+    assert_success_contains(&gofmt, "fake-gofmt fixture.go");
+}
+
+#[cfg(windows)]
+fn write_go_command(directory: &Path, install_dir: &Path) {
+    fs::write(
+        directory.join("go.cmd"),
+        format!(
+            "@echo off\r\necho go version go1.25.1\r\necho GOROOT=%GOROOT%\r\necho GOTOOLCHAIN=%GOTOOLCHAIN%\r\nrem {}\r\n",
+            install_dir.display()
+        ),
+    )
+    .expect("go command");
+}
+
+#[cfg(unix)]
+fn write_go_command(directory: &Path, _install_dir: &Path) {
+    write_unix_command(
+        &directory.join("go"),
+        "#!/bin/sh\nprintf 'go version go1.25.1\\nGOROOT=%s\\nGOTOOLCHAIN=%s\\n' \"$GOROOT\" \"$GOTOOLCHAIN\"\n",
+    );
+}
+
+#[cfg(windows)]
+fn write_gofmt_command(directory: &Path) {
+    fs::write(
+        directory.join("gofmt.cmd"),
+        "@echo off\r\necho fake-gofmt %1\r\n",
+    )
+    .expect("gofmt command");
+}
+
+#[cfg(unix)]
+fn write_gofmt_command(directory: &Path) {
+    write_unix_command(
+        &directory.join("gofmt"),
+        "#!/bin/sh\nprintf 'fake-gofmt %s\\n' \"$1\"\n",
+    );
+}
+
+#[cfg(unix)]
+fn write_unix_command(path: &Path, body: &str) {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::write(path, body).expect("command");
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("executable");
+}
+
+fn pinset(project: &Path, home: &Path, arguments: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_pinset"))
+        .current_dir(project)
+        .env("PINSET_HOME", home)
+        .env("PINSET_LANG", "en")
+        .env_remove("GOROOT")
+        .env_remove("GOTOOLCHAIN")
+        .args(arguments)
+        .output()
+        .expect("run pinset")
+}
+
+fn assert_success_contains(output: &Output, expected: &str) {
+    assert!(
+        output.status.success() && String::from_utf8_lossy(&output.stdout).contains(expected),
+        "expected {expected:?}\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/pinset/tests/language_cli.rs
+++ b/crates/pinset/tests/language_cli.rs
@@ -49,8 +49,8 @@ fn saves_chinese_and_uses_it_for_following_commands() {
     assert!(stderr.contains("版本选择必须使用"), "stderr: {stderr}");
 
     let help = pinset(&first_project, &home, &["--lang", "zh-CN", "use", "--help"]);
-    assert_success_contains(&help, "选择并锁定 Node.js、pnpm 或 Bun 版本");
-    assert_success_contains(&help, "node@24|pnpm@11|bun@1.3");
+    assert_success_contains(&help, "选择并锁定 Node.js、pnpm、Bun 或 Go 版本");
+    assert_success_contains(&help, "node@24|pnpm@11|bun@1.3|go@1.25");
     assert!(
         !String::from_utf8_lossy(&help.stdout).contains("Usage:"),
         "help should be localized: {}",
@@ -78,7 +78,10 @@ fn saves_chinese_and_uses_it_for_following_commands() {
         &home,
         &["--lang", "zh-CN", "install", "--help"],
     );
-    assert_success_contains(&install_help, "pinset install <node|pnpm|bun>@<版本选择器>");
+    assert_success_contains(
+        &install_help,
+        "pinset install <node|pnpm|bun|go>@<版本选择器>",
+    );
 
     let import_help = pinset(
         &first_project,

--- a/crates/pinset/tests/mvp_cli.rs
+++ b/crates/pinset/tests/mvp_cli.rs
@@ -293,8 +293,8 @@ fn doctor_reports_all_provider_commands_and_path_shadowing() {
         [
             "bun", "bunx", "corepack", "go", "gofmt", "node", "npm", "npx", "pnpm",
         ]
-            .into_iter()
-            .collect()
+        .into_iter()
+        .collect()
     );
     assert!(
         report["routing_issues"]

--- a/crates/pinset/tests/mvp_cli.rs
+++ b/crates/pinset/tests/mvp_cli.rs
@@ -234,7 +234,7 @@ fn shim_migration_registers_new_routes_and_preserves_legacy_entries() {
 }
 
 #[test]
-fn doctor_reports_all_node_provider_commands_and_path_shadowing() {
+fn doctor_reports_all_provider_commands_and_path_shadowing() {
     let root = tempdir().expect("temporary root");
     let project = root.path().join("project");
     let home = root.path().join("home");
@@ -290,7 +290,9 @@ fn doctor_reports_all_node_provider_commands_and_path_shadowing() {
         .collect::<std::collections::BTreeSet<_>>();
     assert_eq!(
         commands,
-        ["bun", "bunx", "corepack", "node", "npm", "npx", "pnpm"]
+        [
+            "bun", "bunx", "corepack", "go", "gofmt", "node", "npm", "npx", "pnpm",
+        ]
             .into_iter()
             .collect()
     );

--- a/crates/pinset/tests/source_cli.rs
+++ b/crates/pinset/tests/source_cli.rs
@@ -172,6 +172,45 @@ fn tests_a_node_source_read_only_against_its_version_index() {
     assert!(!home.join("installs").exists());
 }
 
+#[test]
+fn tests_a_go_source_read_only_against_its_download_index() {
+    let root = tempdir().expect("temporary PINSET_HOME");
+    let home = root.path().join("isolated-home");
+    let hash = "ab".repeat(32);
+    let index = serde_json::json!([{
+        "version": "go1.25.1",
+        "stable": true,
+        "files": [
+            {"filename":"go1.25.1.windows-amd64.zip","os":"windows","arch":"amd64","version":"go1.25.1","sha256":hash.clone(),"size":1,"kind":"archive"},
+            {"filename":"go1.25.1.darwin-arm64.tar.gz","os":"darwin","arch":"arm64","version":"go1.25.1","sha256":hash.clone(),"size":1,"kind":"archive"},
+            {"filename":"go1.25.1.darwin-amd64.tar.gz","os":"darwin","arch":"amd64","version":"go1.25.1","sha256":hash.clone(),"size":1,"kind":"archive"},
+            {"filename":"go1.25.1.linux-amd64.tar.gz","os":"linux","arch":"amd64","version":"go1.25.1","sha256":hash,"size":1,"kind":"archive"}
+        ]
+    }])
+    .to_string()
+    .into_bytes();
+    let (base_url, server) = serve_sequence(vec![("GET /?mode=json&include=all", index)]);
+
+    pinset(
+        &home,
+        &[
+            "source",
+            "add",
+            "go",
+            "local",
+            "--base-url",
+            &base_url,
+            "--allow-insecure",
+        ],
+    )
+    .assert_success("added go local");
+    let tested = pinset(&home, &["--lang", "zh-CN", "source", "test", "go", "local"]);
+    server.join().expect("server");
+    tested.assert_success_contains("安装源测试通过");
+    tested.assert_success_contains("稳定版本数=1");
+    assert!(!home.join("installs").exists());
+}
+
 fn serve_sequence(responses: Vec<(&'static str, Vec<u8>)>) -> (String, thread::JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind server");
     let address = listener.local_addr().expect("server address");

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -1,10 +1,10 @@
 # Pinset Plans
 
-当前规划版本：`v0.3.0`
+当前规划版本：`v0.4.0`
 
 当前发布候选：无
 
-最新已发布版本：`v0.2.1`
+最新已发布版本：`v0.3.0`
 
 更新时间：`2026-08-13`
 
@@ -35,7 +35,7 @@ Pinset 将继续保持“一个工具统一选择、安装、锁定和路由开�
 | `v0.1.0-beta.1` | 已发布 | 简短安装命令、断点续传、可信镜像、离线导入和三平台 Node 测试 |
 | `v0.2.0` | 已发布 | pnpm、Bun Provider，通用 Provider/锁文件/命令路由基础 |
 | `v0.2.1` | 已发布 | pnpm、Bun 项目版本切换和安装路径修复 |
-| `v0.3.0` | 开发中 | Go Provider、Native Provider 通用化 |
+| `v0.3.0` | 已发布 | Go Provider、Native Provider 通用化 |
 | `v0.4.0` | 规划中 | Flutter SDK Provider、内置 Dart 路由 |
 | `v0.5.0` | 规划中 | CPython Provider |
 | `v0.6.0` | 规划中 | Eclipse Temurin JDK Provider |

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -1,131 +1,241 @@
 # Pinset Plans
 
+当前规划版本：`v0.3.0`
+
 当前发布候选：无
 
 最新已发布版本：`v0.2.1`
 
 更新时间：`2026-08-13`
 
-`v0.2.1` 修复 pnpm 10 独立可执行包与 pnpm 11 归档结构不同导致的项目安装失败，并将项目 pnpm 10 与 Bun 1.2 组合安装纳入三平台虚拟机验收。
+## 路线原则
+
+Pinset 将继续保持“一个工具统一选择、安装、锁定和路由开发运行时”的产品边界。后续版本每次只引入一个主要运行时，并在该版本中同步补齐可复用的 Provider 能力，避免多个生态同时开发导致配置、锁文件和命令路由失去一致性。
+
+规划顺序为：
+
+1. `v0.3.0`：Go，并完成 Native Provider 通用化。
+2. `v0.4.0`：Flutter SDK，同时管理其内置 Dart。
+3. `v0.5.0`：CPython。
+4. `v0.6.0`：Java，首期仅支持 Eclipse Temurin JDK。
+5. `v0.7.0`：Rust，通过 rustup 委托管理工具链。
+
+各版本暂不承诺日期。只有对应 Provider 在 Ubuntu、Windows、macOS 三平台 GitHub Actions 虚拟机完成真实安装和命令验证后，才能进入发布流程。
 
 ## 版本路线
 
-| 版本 | 状态 | 主要内容 |
+| 版本 | 状态 | 主要范围 |
 | --- | --- | --- |
 | `v0.1.0-alpha.1` | 已发布 | 项目配置、锁文件、精确版本安装、镜像、shim 和三平台构建 |
 | `v0.1.0-alpha.2` | 已发布 | 全局版本、项目覆盖、系统 PATH 回退和中文界面 |
 | `v0.1.0-alpha.3` | 已发布 | 浮动版本、本地版本列表、卸载、缓存、诊断和旧配置检测 |
 | `v0.1.0-alpha.4` | 已发布 | `global` 命令、下载进度和使用文档 |
-| `v0.1.0-alpha.5` | 已发布 | 自动注册 node/npm/npx/corepack、独立安装和旧 shim 迁移 |
+| `v0.1.0-alpha.5` | 已发布 | 自动注册 Node/npm/npx/corepack、独立安装和旧 shim 迁移 |
 | `v0.1.0-alpha.6` | 已发布 | 完整卸载脚本和跨 Shell 修复 |
 | `v0.1.0-beta.1` | 已发布 | 简短安装命令、断点续传、可信镜像、离线导入和三平台 Node 测试 |
-| `v0.2.0` | 已发布 | pnpm 10/11、Bun 1.x、多工具 schema 2、npm 签名与 SHA-512 |
-| `v0.2.1` | 已发布 | 修复 pnpm 10 包结构兼容性与 Bun 项目组合安装 |
-| `v0.3.0+` | 未排期 | 评估 Python、Flutter 等 Provider |
+| `v0.2.0` | 已发布 | pnpm、Bun Provider，通用 Provider/锁文件/命令路由基础 |
+| `v0.2.1` | 已发布 | pnpm、Bun 项目版本切换和安装路径修复 |
+| `v0.3.0` | 开发中 | Go Provider、Native Provider 通用化 |
+| `v0.4.0` | 规划中 | Flutter SDK Provider、内置 Dart 路由 |
+| `v0.5.0` | 规划中 | CPython Provider |
+| `v0.6.0` | 规划中 | Eclipse Temurin JDK Provider |
+| `v0.7.0` | 规划中 | rustup 委托式 Rust Provider |
 
-版本号不对应固定日期。`v0.2.1` 已通过 Linux、Windows 与 macOS GitHub Actions 真实运行时验收。
+## v0.3.0 — Go Provider 与 Native Provider 通用化
 
-## v0.2.0 范围
+### 目标
 
-- `pinset list pnpm --available` 与 `pinset list bun --available`；
-- pnpm 10/11、Bun 1.x 的精确/主版本/主次版本/`latest`/`current` 选择器；
-- npm 官方平台包、SHA-512 SRI 与 registry ECDSA 签名；
-- schema 2 同时保存 Node、pnpm、Bun，并继续读取 schema 1；
-- `.tar.gz` 安全解压，SHA-256/SHA-512 分仓缓存和 `--integrity` 离线导入；
-- pnpm、bun、bunx 命令路由，以及排除 shim 的多 Provider 组合 PATH；
-- Bun x64 AVX2/baseline 自动选择；
-- 通用本地列表、卸载、current、which 和文本 doctor 检查。
+- 支持 `pinset list go --available` 查看可安装版本。
+- 支持 `pinset use go@<selector>`、`pinset global go@<selector>` 和现有项目锁定流程。
+- 支持精确版本、`latest`、主版本和主次版本选择器，并将最终解析结果写入锁文件。
+- 路由 `go`、`gofmt` 等 Go 安装包提供的命令。
+- 将 Node.js、pnpm、Bun 中仍然分散的安装、激活和命令路由逻辑收敛到 Native Provider 公共能力。
 
-不在 `v0.2.0` 中加入 Corepack 驱动的 pnpm、Node 依赖、包依赖管理、Python、Flutter、新 Release 平台或自动修改 shell profile。
+### 技术范围
 
-## Beta 已完成
+- 使用 Go 官方版本元数据、归档和 SHA-256 校验信息。
+- 按平台、架构和归档类型选择工件，复用安全解压、缓存、并发锁和原子安装流程。
+- 由 Pinset 为受管子进程设置正确的 `GOROOT` 和命令路径。
+- 保留用户已有的 `GOPATH`、`GOMODCACHE`、`GOCACHE` 等工作区与缓存配置。
+- 默认只在 Pinset 管理的子进程中使用 `GOTOOLCHAIN=local`，防止 Go 根据项目声明静默下载另一套工具链；如果用户显式设置该变量，则尊重用户设置并由 `doctor` 给出可诊断提示。
+- Provider 元数据统一描述版本选择器、平台目标、下载工件、校验方式、命令入口、环境变量和安装后验证。
 
-### Node 使用
+### 不包含
 
-- 设置和查看全局 Node 版本；
-- 使用项目配置覆盖全局版本；
-- 离开项目目录后恢复全局版本；
-- 支持精确版本、主版本、主次版本、LTS 和 Current；
-- 直接运行 `node`、`npm`、`npx` 和 `corepack`；
-- 独立安装版本，不改变项目或全局选择；
-- 导入 `.nvmrc`、`.node-version`、Volta、asdf 和 mise 配置；
-- 卸载单个 Node 版本或完整删除 Pinset。
+- Go module 依赖管理、代理服务或私有模块凭据管理。
+- 自动修改 `go.mod`、`go.work`。
+- 交叉编译工具链、TinyGo、GCC 或系统 C 工具链管理。
 
-### 下载和安装
+### 验收条件
 
-- 下载进度在同一行刷新，并适配窄终端和中文；
-- 同一版本的并发安装使用文件锁；
-- 支持 HTTP Range 断点续传；
-- 归档按 SHA-256 缓存，可手动导入离线归档；
-- 支持下载镜像、备用源和可信 HTTPS 元数据镜像；
-- 校验失败、归档格式错误或解压安全检查失败时立即停止；
-- 安装在临时目录完成，校验通过后再写入最终目录。
+- Ubuntu、Windows、macOS 虚拟机均能执行 available、global、use 和项目锁文件场景。
+- 精确版本和模糊选择器解析结果一致、可复现。
+- `go version` 与锁文件版本一致，项目版本能够覆盖全局版本。
+- 已安装版本可离线复用，损坏缓存和不匹配校验值会明确失败。
+- Node.js、pnpm、Bun 既有行为没有回归。
 
-### 平台和发布
+## v0.4.0 — Flutter SDK Provider
 
-- Pinset 安装包：Linux x64、Windows x64、macOS Apple Silicon；
-- Node 归档：Windows x64、Linux x64、macOS x64 和 macOS arm64；
-- Release 包含 `SHA256SUMS`、CycloneDX SBOM 和 GitHub 构建来源证明；
-- Linux、Windows、macOS 的 Release 任务都测试了全局版本、项目版本和四个 Node 命令；
-- curl 安装器只安装 `pinset` 与 `pinset-shim`，不会自动安装 Node 或修改 shell profile。
+### 目标
 
-Beta 暂不支持 Python、Flutter、Linux arm64 Pinset 安装包和 macOS Intel Pinset 安装包，也不维护 Homebrew Tap 或 Scoop Bucket。
+- 管理 Flutter SDK，并将其捆绑的 Dart 视为同一个不可拆分的运行时单元。
+- 支持 `pinset list flutter --available`、`use`、`global`、项目锁定和导入现有项目版本声明。
+- 路由 `flutter`、`dart`，并确保两者始终来自同一套 Flutter SDK。
+- 首期支持 stable 渠道、精确版本、主版本和主次版本选择器。
 
-## 本地检查
+### 技术范围
 
-日常开发使用以下命令，不下载真实 Node，也不会触发 GitHub Actions：
+- 锁文件记录 Flutter 版本、渠道、Dart 版本、平台工件和校验信息。
+- 处理 Flutter SDK 的 `bin/cache` 初始化与复用，避免只复制命令入口而遗漏实际运行依赖。
+- 识别并导入 `.fvmrc`，但不接管 FVM 的缓存和目录。
+- 阻止受管 SDK 通过 `flutter upgrade`、`flutter channel`、`flutter downgrade` 原地改变版本；版本变化必须通过 Pinset 重新解析和安装。
 
-```shell
-cargo fmt --all -- --check
-cargo clippy --workspace --all-targets --all-features -- -D warnings
-cargo test --workspace --all-features
-cargo build --release --locked -p pinset-cli -p pinset-shim
-git diff --check
-```
+### 不包含
 
-测试使用临时 `PINSET_HOME`、本地 HTTP 服务、测试归档和假运行时。WSL 中也应设置独立的临时目录，避免碰到已有的 Pinset 或 Node 安装。
+- Android SDK、Android NDK、JDK、Xcode、CocoaPods、模拟器或设备管理。
+- Flutter/Dart 项目依赖和 pub 缓存管理。
+- beta、dev、master 等非 stable 渠道的首期支持。
 
-真实 Node 测试只在目标系统或 Release 工作流的隔离 Runner 中运行。普通提交不运行这类测试，避免不必要的 GitHub Actions 消耗。
+### 验收条件
+
+- 三平台虚拟机可安装并运行匹配版本的 `flutter --version` 和 `dart --version`。
+- 项目版本正确覆盖全局版本，Flutter 与 Dart 不会交叉引用不同安装目录。
+- 首次 cache 初始化、已有 cache 复用和离线重用都有自动化场景。
+- 尝试原地改变受管 SDK 时给出明确、可操作的提示。
+
+## v0.5.0 — CPython Provider
+
+### 目标
+
+- 首期只管理 CPython 解释器，不扩展到 PyPy、GraalPy 等实现。
+- 支持 `pinset list python --available`、`use`、`global`、项目锁定和 `.python-version` 导入。
+- 路由 `python`、`python3` 以及安装包明确提供的基础命令。
+
+### 技术范围
+
+- 以 Astral `python-build-standalone` 作为跨平台预构建分发来源。
+- 锁文件除 Python 版本外，还记录构建 ID、发行变体、来源和校验值，避免同一 CPython 版本对应不同构建却无法复现。
+- 明确区分解释器安装与项目虚拟环境；用户仍可使用 Python 自身能力创建虚拟环境，但 Pinset 不负责创建、激活或同步虚拟环境。
+
+### 不包含
+
+- pip、uv、Poetry、PDM、Conda 等依赖或环境管理器。
+- Python 包依赖解析、虚拟环境生命周期和项目依赖锁定。
+- 从源码编译 CPython 或管理系统级 C/C++ 构建依赖。
+
+### 验收条件
+
+- 三平台虚拟机可安装并运行锁定版本的解释器。
+- `.python-version` 可以安全导入，无法映射的声明会明确报错而不是猜测。
+- 全局版本、项目版本、离线缓存和损坏工件场景均被覆盖。
+- 锁文件能精确区分 Python 版本相同但构建不同的工件。
+
+## v0.6.0 — Java Provider
+
+### 目标
+
+- 首期只支持 Eclipse Temurin JDK、HotSpot、GA 正式版本。
+- 支持 `pinset list java --available`、`use`、`global` 和项目锁定。
+- 路由 `java`、`javac`、`jar`、`javadoc`、`jshell`、`keytool` 等 JDK 命令，并设置正确的 `JAVA_HOME`。
+
+### 技术范围
+
+- 通过 Adoptium API 获取版本、操作系统、架构、包类型和工件信息。
+- 校验 SHA-256，并评估将上游 GPG 签名纳入强校验链。
+- 将锁文件升级到能够明确表达 distribution、package type、JVM implementation 和 release kind 的 schema；旧锁文件必须保持可读并提供清晰迁移路径。
+
+### 不包含
+
+- 多厂商 JDK、JRE、OpenJ9、早期访问版和自定义 JVM 构建。
+- Maven、Gradle、Ant 或 Java 项目依赖管理。
+- 自动修改项目的 Gradle/Maven toolchain 配置。
+
+### 验收条件
+
+- 三平台虚拟机可安装并运行 `java -version` 与 `javac -version`。
+- `JAVA_HOME`、`PATH` 和锁文件都指向同一安装。
+- LTS、最新 GA、精确版本和主版本选择器行为稳定。
+- 旧 schema 项目继续可用，新 schema 的厂商和包类型没有歧义。
+
+## v0.7.0 — rustup 委托式 Rust Provider
+
+### 目标
+
+- 不重复实现 rustup 已成熟的工具链、组件、target 和代理命令管理。
+- Pinset 负责项目声明、选择器解析、锁定意图、环境接入和诊断；rustup 负责实际工具链下载、安装和组件维护。
+- 支持识别和导入 `rust-toolchain.toml`，并为未安装工具链提供明确操作提示。
+
+### Provider 模型
+
+- `NativeProvider`：Pinset 直接解析、下载、校验、安装并路由运行时；Node.js、pnpm、Bun、Go、Flutter、Python、Java 属于此类。
+- `DelegatedProvider`：Pinset 管理声明和诊断，将安装与组件生命周期委托给官方管理器；Rust/rustup 首先采用此类。
+
+### 不包含
+
+- 自行下载和解压 Rust toolchain。
+- 重做 rustup 的 component、target、profile 和 update 机制。
+- Cargo 包依赖、crate 发布或项目构建管理。
+
+### 验收条件
+
+- 在已安装 rustup 的三平台虚拟机中，Pinset 能正确识别、锁定并激活项目工具链。
+- 缺少 rustup、缺少工具链、组件不完整和声明冲突均有可诊断错误。
+- `rust-toolchain.toml` 与 Pinset 配置冲突时，不静默选择其中一方。
+- Rust 接入不会改变 Native Provider 的下载和安装语义。
+
+## Provider 架构约束
+
+从 `v0.3.0` 开始，新 Provider 必须复用同一套核心生命周期：
+
+1. 解析 Provider 和版本选择器。
+2. 获取、缓存并规范化 available 版本元数据。
+3. 解析平台目标与具体工件。
+4. 将最终版本和工件身份写入锁文件。
+5. 下载、校验、安全解压和原子安装。
+6. 构建仅作用于受管命令的环境变量和命令路径。
+7. 验证安装结果，并通过 `doctor` 输出可操作诊断。
+
+Provider 特有逻辑应留在 Provider 内，核心层只处理公共生命周期。配置、锁文件、安装目录、下载缓存、并发锁、代理/镜像、命令路由和错误模型不得为每种语言复制一套实现。
+
+## 验证边界
+
+Pinset 的运行时安装会写入用户目录、下载缓存并改变命令解析结果，因此开发机和 WSL 不作为本项目的运行验证环境。
+
+- 本地只进行代码和文档编辑、只读检查，以及 `git diff --check` 这类不执行项目代码的静态差异检查。
+- 不在本机或 WSL 执行 Cargo build/test、Pinset 安装命令、运行时下载、全局切换或项目切换测试。
+- Pull Request 的 Quality 工作流在 GitHub Actions Ubuntu 虚拟机执行格式、Clippy、单元测试和脚本测试。
+- Provider 变更在合并和发布前必须通过可手动触发的 Ubuntu、Windows、macOS 三平台真实运行时验收。
+- 任一必需平台失败时不得发布；修复后必须重新运行完整矩阵。
+- 本地静态检查不等同于运行验证，最终结论以 GitHub Actions 记录和虚拟机人工验收为准。
 
 ## 发布流程
 
-1. 更新版本号、README、PRD、Plans 和 Release Notes；
-2. 在本地完成格式检查、Clippy、测试、release build 和脚本测试；
-3. 合并到 `main`，确认 Quality 工作流通过；
-4. 在该提交上创建签名 tag；
-5. Release 工作流构建三个平台，并运行真实 Node 测试；
-6. 生成归档、校验和、SBOM 和构建来源证明；
-7. 发布后下载公开文件，复查归档内容和 `SHA256SUMS`。
+1. 在功能分支完成代码、文档、版本号和变更记录。
+2. 经用户明确授权后暂存、提交、推送并创建 Pull Request。
+3. 等待 Pull Request Quality 工作流通过。
+4. 对新增或修改的 Provider 手动触发 Ubuntu、Windows、macOS 三平台真实运行时验收。
+5. 经用户明确确认后合并到 `main`。
+6. 创建签名版本标签并触发 Release 工作流。
+7. 确认 release assets、checksums、SBOM/provenance 和各平台安装脚本可用后宣布发布完成。
 
-如果任一平台测试失败，本次 Release 不发布残缺资产，也不手动绕过工作流。
+## 跨版本加固项
 
-## 稳定版计划
-
-稳定版在 Node、pnpm、Bun 三个 Provider 基础上继续完成：
-
-1. 验证 Node 上游 `SHASUMS256.txt.sig`，整理发布密钥的更新和撤销方式；
-2. 冻结 schema 1 读取兼容与 schema 2 写入规则；
-3. 修复 Beta 用户在代理、镜像、断点续传、离线导入和旧管理器迁移中发现的问题；
-4. 增加更多三平台实际使用测试；
-5. 制定 Release 撤回和安全公告流程；
-6. 决定是否发布 Linux arm64 和 macOS Intel 安装包。
-
-## 后续 Provider
-
-Python 和 Flutter 放在当前三个 Provider 稳定后评估。
-
-Python 需要先确定解释器来源、校验方式、虚拟环境职责和系统 Python 回退规则。Flutter 需要确定 SDK 索引、channel、精确版本、Flutter/Dart 命令路由，以及 Android/iOS 工具链与 Pinset 的职责范围。
-
-新 Provider 应复用现有的配置、锁文件、安装源、缓存、安装器、命令路由、诊断和卸载机制。
+- 继续加强 Node.js 上游签名验证和供应链证据。
+- 为配置与锁文件 schema 建立明确的兼容、迁移和拒绝策略。
+- 完善代理、镜像、断点续传、离线缓存和受损缓存恢复体验。
+- 增加 Provider 契约测试，确保 available、resolve、install、activate、doctor 的行为一致。
+- 将平台扩展与新 Provider 分开规划，避免在同一个小版本中同时扩大运行时和目标平台范围。
+- 根据真实用户反馈决定后续是否支持更多 Java 发行版、Flutter 渠道和 Python 实现。
 
 ## 主要风险
 
-| 风险 | 当前处理 | 后续工作 |
-| --- | --- | --- |
-| 国内网络无法访问官方元数据 | 可配置可信 HTTPS 元数据镜像 | 收集常用镜像的兼容反馈 |
-| 下载中断浪费流量 | Range 续传和 `Content-Range` 校验 | 测试更多代理和 CDN |
-| 并发安装损坏目录 | 文件锁和临时目录安装 | 增加三平台压力测试 |
-| 镜像归档被替换 | 使用可信元数据中的 SHA-256 | 稳定版增加上游 PGP 验证 |
-| 命令路由覆盖外部工具 | 写入前检查所有权，冲突时停止 | 增加旧管理器共存测试 |
-| CI 消耗过高 | 本地测试优先，真实 Node 只在 Release 测试 | 保持普通提交不下载运行时 |
-| 预发布配置发生变化 | schema 版本和 Release Notes | 稳定版确认兼容规则 |
+| 风险 | 应对 |
+| --- | --- |
+| Provider 数量增加导致核心逻辑出现大量分支 | 在 `v0.3.0` 先完成 Native Provider 生命周期和元数据模型收敛 |
+| Go 自动工具链下载绕过项目锁定 | 受管子进程默认使用 `GOTOOLCHAIN=local`，同时尊重并诊断用户显式配置 |
+| Flutter SDK 会原地更新并维护可变 cache | 将 SDK 和 cache 生命周期显式建模，阻止受管安装原地切换版本 |
+| Python 第三方预构建工件无法只靠语言版本复现 | 锁定 build ID、variant、来源和校验值 |
+| Java 厂商、JDK/JRE 和 JVM 类型产生歧义 | 首期仅 Temurin JDK/HotSpot/GA，并在新 schema 中显式记录分发属性 |
+| Rust 与 rustup 重复管理造成命令和状态冲突 | 使用 Delegated Provider，不重做 rustup 的安装与组件能力 |
+| 本地运行验证污染用户开发环境 | 所有构建、测试和真实安装验证放到 GitHub Actions 虚拟机 |
+| 三平台矩阵消耗较高 | PR 默认运行 Quality；完整矩阵用于 Provider 变更、合并前验收和发布 |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,14 +1,14 @@
 # Pinset PRD
 
-文档版本：`v0.2.1`
-产品阶段：`Multi-provider development`
+文档版本：`v0.3.0`
+产品阶段：`Go Provider development`
 更新时间：`2026-08-13`
 
 ## 1. 产品简介
 
 Pinset 是一个本地优先、跨平台的运行时版本管理 CLI。它用一致的命令完成版本选择、锁定、安装、执行、镜像、缓存和诊断，减少在 nvm/fnm、uv、FVM 等工具之间切换的成本。
 
-`v0.2.1` 支持 Node.js、pnpm 和 Bun。Python 和 Flutter 暂不纳入。
+`v0.3.0` 在 Node.js、pnpm 和 Bun 基础上新增 Go Provider。Python、Flutter、Java 和 Rust 暂不纳入本版本。
 
 ### 1.1 目标
 
@@ -28,7 +28,7 @@ Pinset 是一个本地优先、跨平台的运行时版本管理 CLI。它用一
 
 ### 1.3 本版本不做
 
-- 不接入 Python、Flutter、Java 等其他 Provider；
+- 不接入 Python、Flutter、Java、Rust 等其他 Provider；
 - 不管理 npm、pnpm、Bun 中的项目依赖或全局包；
 - 不管理项目依赖包或全局 npm 包；
 - 不自动修改 shell profile、系统 PATH、IDE 配置或系统注册表；
@@ -61,7 +61,7 @@ Pinset 是一个本地优先、跨平台的运行时版本管理 CLI。它用一
 
 ### 2.5 运行时中立
 
-curl 安装器只安装 `pinset` 与 `pinset-shim`。Node Provider 注册 `node`、`npm`、`npx`、`corepack`，pnpm Provider 注册 `pnpm`，Bun Provider 注册 `bun`、`bunx`。
+curl 安装器只安装 `pinset` 与 `pinset-shim`。Node Provider 注册 `node`、`npm`、`npx`、`corepack`，pnpm Provider 注册 `pnpm`，Bun Provider 注册 `bun`、`bunx`，Go Provider 注册 `go`、`gofmt`。
 
 ## 3. 支持矩阵
 
@@ -86,6 +86,17 @@ curl 安装器只安装 `pinset` 与 `pinset-shim`。Node Provider 注册 `node`
 
 WSL 使用 Linux 归档，不能运行 Windows `.exe`，也不能复用 Windows 中的 Node 安装。
 
+### 3.3 Go 官方归档目标
+
+| 目标 | 状态 |
+| --- | --- |
+| `windows-x86_64` | 支持 ZIP |
+| `linux-x86_64` | 支持 TAR.GZ |
+| `macos-x86_64` | Provider 支持 TAR.GZ |
+| `macos-aarch64` | Provider 支持 TAR.GZ |
+
+Go available 列表只显示稳定、具有全部上述工件且每个工件都带有效 SHA-256 的版本。
+
 ## 4. 配置和数据
 
 ### 4.1 项目配置 `pinset.toml`
@@ -99,6 +110,7 @@ schema = 2
 node = "24.0.0"
 pnpm = "11.21.0"
 bun = "1.3.14"
+go = "1.25.1"
 ```
 
 ### 4.2 项目锁文件 `pinset.lock`
@@ -127,7 +139,7 @@ Provider 声明：
 - 运行时命令集合；
 - 安装、验证和命令路由规则。
 
-Node Provider 声明 `node`、`npm`、`npx`、`corepack`；pnpm Provider 声明 `pnpm`；Bun Provider 声明 `bun`、`bunx`。
+Node Provider 声明 `node`、`npm`、`npx`、`corepack`；pnpm Provider 声明 `pnpm`；Bun Provider 声明 `bun`、`bunx`；Go Provider 声明 `go`、`gofmt`、`GOROOT` 和工具链切换策略。
 
 ### 4.5 通用命令路由
 
@@ -253,7 +265,7 @@ pinset list node --available
 9. 写完整安装收据；
 10. 原子发布到最终目录。
 
-ZIP/TAR.XZ 必须拒绝路径穿越、绝对路径、特殊文件、逃逸符号链接、冲突路径、条目数超限和展开大小超限。
+ZIP/TAR.XZ/TAR.GZ 必须拒绝路径穿越、绝对路径、特殊文件、逃逸符号链接、冲突路径、条目数超限和展开大小超限。
 
 ### 5.10 下载体验
 
@@ -268,7 +280,7 @@ ZIP/TAR.XZ 必须拒绝路径穿越、绝对路径、特殊文件、逃逸符号
 
 ### 5.11 镜像和回退
 
-普通镜像只替换归档 URL，SHA-256 仍从 Node 官方 HTTPS `SHASUMS256.txt` 获取。使用 `--trust-metadata` 后，自定义 HTTPS 镜像也可以提供 `index.json` 和 SHASUMS，`source list` 会标记这类来源。
+普通镜像只替换归档 URL，SHA-256 仍从 Node 官方 HTTPS `SHASUMS256.txt` 或 Go 官方 HTTPS 下载索引获取。使用 `--trust-metadata` 后，自定义 HTTPS 镜像也可以提供对应元数据，`source list` 会标记这类来源。
 
 `--allow-insecure` 只用于可信的 HTTP 内网服务，不能与 `--trust-metadata` 同时使用。
 
@@ -313,7 +325,7 @@ pinset cache import <archive> --sha256 <hash>
 - `PINSET_HOME`；
 - 项目和全局配置/锁文件；
 - 生效来源和安装状态；
-- 四个 Node 命令的 PATH 候选和遮挡；
+- 所有已开放 Provider 命令的 PATH 候选和遮挡；
 - Pinset 路由所有权；
 - 旧 shim 和已知旧管理器；
 - 可执行的修复建议。
@@ -345,6 +357,20 @@ pnpm Provider 支持稳定版 10 和 11，Bun Provider 支持稳定版 1.x。两
 
 多个 Provider 同时选择时，子进程 PATH 依次包含当前命令目录和其他已选择、已安装 Provider 的命令目录，再追加继承 PATH；Pinset shim 目录必须排除，以防脚本中的跨工具调用递归进入 shim。
 
+## 6.2 Go Provider
+
+Go Provider 支持精确版本、主版本、主次版本、`latest` 和 `current` 选择器，并通过 `pinset list go --available` 查看满足全部发布目标的稳定版本。
+
+- 官方元数据来自 `https://go.dev/dl/?mode=json&include=all`；
+- 版本索引必须同时提供 filename、OS、arch、version、size、kind 和 SHA-256；
+- 只接受 `kind=archive` 且身份与内置目标规划完全一致的工件；
+- Windows 使用 ZIP，Linux/macOS 使用 TAR.GZ，均 strip 顶层 `go/` 后验证 `bin/go` 和 `bin/gofmt`；
+- 锁文件记录规范化的精确 `x.y.z`，历史补丁零版本仍映射到上游省略 `.0` 的归档名；
+- 受管进程的 `GOROOT` 必须指向所选安装目录；
+- 用户未显式设置 `GOTOOLCHAIN` 时注入 `local`，用户显式设置时保留原值并由诊断提示可能绕过锁定；
+- 保留用户的 `GOPATH`、`GOMODCACHE`、`GOCACHE`，不修改 `go.mod` 或 `go.work`；
+- 不管理 Go module 依赖、代理凭据、交叉编译器、TinyGo 或系统 C 工具链。
+
 ## 7. 安全和供应链
 
 ### 7.1 Provider 归档
@@ -354,6 +380,7 @@ pnpm Provider 支持稳定版 10 和 11，Bun Provider 支持稳定版 1.x。两
 - 所有归档在解压前校验；
 - Beta 尚未验证 Node 上游 `SHASUMS256.txt.sig` 的 OpenPGP 签名，计划在稳定版加入。
 - pnpm/Bun 使用 npm 平台包的 SHA-512 SRI，并在锁定阶段验证 npm registry ECDSA 签名；安装阶段重新计算 SHA-512。
+- Go 使用官方下载 JSON 中逐工件提供的 SHA-256；锁文件中的规范 URL、目标和归档格式必须与内置 Go Provider 一致。
 
 ### 7.2 Pinset Release
 
@@ -429,6 +456,6 @@ pnpm Provider 支持稳定版 10 和 11，Bun Provider 支持稳定版 1.x。两
 - 完成 Beta 用户在代理、镜像、离线和旧管理器迁移场景的反馈修复；
 - 决定 Linux arm64 与 macOS Intel 正式归档策略；
 - 完成发布回滚、撤回和安全公告流程；
-- 完成 Node、pnpm、Bun 的三平台真实运行时验收。
+- 完成 Node、pnpm、Bun、Go 的三平台真实运行时验收。
 
-Python 和 Flutter 排在当前三个 Provider 稳定之后。实现时复用现有 Provider、来源、缓存、路由和安全机制，不在 CLI 中增加语言专用的零散逻辑。
+后续按 Flutter、CPython、Java、Rustup 的顺序扩展。实现时复用现有 Provider、来源、缓存、路由和安全机制，不在 CLI 中增加语言专用的零散逻辑。

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,14 +1,15 @@
 # Pinset Release Notes
 
-## v0.3.0（开发中）
+## v0.3.0
 
-- 阶段：Go Provider / Native Provider 通用化；
+- 发布日期：`2026-08-13`
+- 阶段：Go Provider / Native Provider 通用化
+- GitHub Release：[v0.3.0](https://github.com/Future-Element/pinset/releases/tag/v0.3.0)
 - 新增 `pinset list go --available`、`go@latest`、主版本、主次版本和精确版本选择；
 - 新增 Go 官方下载 JSON、四平台归档身份和逐工件 SHA-256 锁定；
 - 新增 `go`、`gofmt` 命令路由，以及受管 `GOROOT` 和默认 `GOTOOLCHAIN=local`；
 - Provider 清单开始统一描述元数据、安装器、命令目录和受管环境策略；
 - GitHub Actions 三平台真实运行时验收扩展到 Go；
-- 尚未发布，运行验证结果以对应 Pull Request 的 GitHub Actions 为准。
 
 ## v0.2.1
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Pinset Release Notes
 
+## v0.3.0（开发中）
+
+- 阶段：Go Provider / Native Provider 通用化；
+- 新增 `pinset list go --available`、`go@latest`、主版本、主次版本和精确版本选择；
+- 新增 Go 官方下载 JSON、四平台归档身份和逐工件 SHA-256 锁定；
+- 新增 `go`、`gofmt` 命令路由，以及受管 `GOROOT` 和默认 `GOTOOLCHAIN=local`；
+- Provider 清单开始统一描述元数据、安装器、命令目录和受管环境策略；
+- GitHub Actions 三平台真实运行时验收扩展到 Go；
+- 尚未发布，运行验证结果以对应 Pull Request 的 GitHub Actions 为准。
+
 ## v0.2.1
 
 - 发布日期：`2026-08-13`

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="0.2.1"
+DEFAULT_VERSION="0.3.0"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -18,7 +18,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 0.2.1.
+  --version VERSION       Install an exact release, for example 0.3.0.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.

--- a/scripts/tests/install_sh_test.sh
+++ b/scripts/tests/install_sh_test.sh
@@ -57,7 +57,7 @@ sh "$ROOT/install.sh" --install-dir "$INSTALL_DIR"
 [ "$("$INSTALL_DIR/pinset" --version)" = "pinset 9.8.7-test" ]
 INSTALLED_ENTRIES=$(find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 -print | wc -l | awk '{ print $1 }')
 [ "$INSTALLED_ENTRIES" = "2" ]
-for runtime_command in node npm npx corepack python flutter java; do
+for runtime_command in node npm npx corepack pnpm bun bunx go gofmt python flutter java; do
     [ ! -e "$INSTALL_DIR/$runtime_command" ]
 done
 

--- a/scripts/tests/ubuntu_runtime_acceptance.sh
+++ b/scripts/tests/ubuntu_runtime_acceptance.sh
@@ -9,6 +9,8 @@ BUN_VERSION="${PINSET_BUN_VERSION:-1.3.14}"
 GLOBAL_PNPM_SELECTOR="${PINSET_GLOBAL_PNPM_SELECTOR:-latest}"
 PROJECT_PNPM_SELECTOR="${PINSET_PROJECT_PNPM_SELECTOR:-10}"
 PROJECT_BUN_SELECTOR="${PINSET_PROJECT_BUN_SELECTOR:-1.2}"
+GLOBAL_GO_SELECTOR="${PINSET_GLOBAL_GO_SELECTOR:-latest}"
+PROJECT_GO_SELECTOR="${PINSET_PROJECT_GO_SELECTOR:-1.24}"
 VERSION_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+$'
 
 if [[ ! "$GLOBAL_VERSION" =~ $VERSION_PATTERN ]] || [[ ! "$PROJECT_VERSION" =~ $VERSION_PATTERN ]] ||
@@ -26,6 +28,7 @@ trap 'rm -rf "$TEST_ROOT"' EXIT
 
 export PINSET_HOME="$TEST_ROOT/pinset-home"
 unset PINSET_LANG
+unset GOTOOLCHAIN
 
 cd "$TEST_ROOT"
 
@@ -36,10 +39,14 @@ grep -F 'language = "zh-CN"' "$PINSET_HOME/settings.toml"
 "$PINSET_BIN" use "node@$GLOBAL_VERSION" --global
 "$PINSET_BIN" list pnpm --available | grep -E '^pnpm@10\.'
 "$PINSET_BIN" list bun --available | grep -F "bun@$BUN_VERSION"
+"$PINSET_BIN" list go --available | grep -E '^go@[0-9]+\.[0-9]+\.[0-9]+$'
 "$PINSET_BIN" global "pnpm@$GLOBAL_PNPM_SELECTOR"
 GLOBAL_PNPM_VERSION="$("$PINSET_BIN" exec -- pnpm --version)"
 printf '%s\n' "$GLOBAL_PNPM_VERSION" | grep -E '^11\.'
 "$PINSET_BIN" use "bun@$BUN_VERSION" --global
+"$PINSET_BIN" global "go@$GLOBAL_GO_SELECTOR"
+GLOBAL_GO_VERSION="$("$PINSET_BIN" exec -- go version | sed -E 's/^go version go([^ ]+).*/\1/')"
+printf '%s\n' "$GLOBAL_GO_VERSION" | grep -E "$VERSION_PATTERN"
 "$PINSET_BIN" current node | tee global-current.txt
 grep -F "Node.js $GLOBAL_VERSION" global-current.txt
 grep -F '来源=全局' global-current.txt
@@ -50,6 +57,10 @@ grep -F '来源=全局' global-current.txt
 "$PINSET_BIN" exec -- pnpm --version | grep -Fx "$GLOBAL_PNPM_VERSION"
 "$PINSET_BIN" exec -- bun --version | grep -Fx "$BUN_VERSION"
 "$PINSET_BIN" exec -- bunx --version | grep -Fx "$BUN_VERSION"
+"$PINSET_BIN" exec -- go version | grep -F "go version go$GLOBAL_GO_VERSION"
+"$PINSET_BIN" exec -- go env GOTOOLCHAIN | grep -Fx 'local'
+"$PINSET_BIN" exec -- go env GOROOT | grep -F "$PINSET_HOME/installs/go/$GLOBAL_GO_VERSION/"
+printf 'package p\nfunc f( ){ }\n' | "$PINSET_BIN" exec -- gofmt | grep -F 'func f() {}'
 
 SHIM_DIR="$("$PINSET_BIN" shim path)"
 export PATH="$SHIM_DIR:$PATH"
@@ -60,6 +71,8 @@ corepack --version | grep -E '^[0-9]+\.[0-9]+\.[0-9]+'
 pnpm --version | grep -Fx "$GLOBAL_PNPM_VERSION"
 bun --version | grep -Fx "$BUN_VERSION"
 bunx --version | grep -Fx "$BUN_VERSION"
+go version | grep -F "go version go$GLOBAL_GO_VERSION"
+go env GOTOOLCHAIN | grep -Fx 'local'
 
 mkdir project
 cd project
@@ -73,6 +86,9 @@ printf '%s\n' "$PROJECT_PNPM_VERSION" | grep -E '^10\.'
 "$PINSET_BIN" use "bun@$PROJECT_BUN_SELECTOR"
 PROJECT_BUN_VERSION="$(bun --version)"
 printf '%s\n' "$PROJECT_BUN_VERSION" | grep -E '^1\.2\.'
+"$PINSET_BIN" use "go@$PROJECT_GO_SELECTOR"
+PROJECT_GO_VERSION="$(go version | sed -E 's/^go version go([^ ]+).*/\1/')"
+printf '%s\n' "$PROJECT_GO_VERSION" | grep -E "^${PROJECT_GO_SELECTOR//./\.}\."
 test -f pinset.toml
 test -f pinset.lock
 "$PINSET_BIN" current node | tee project-current.txt
@@ -89,6 +105,9 @@ corepack --version | grep -E '^[0-9]+\.[0-9]+\.[0-9]+'
 pnpm --version | grep -Fx "$PROJECT_PNPM_VERSION"
 bun --version | grep -Fx "$PROJECT_BUN_VERSION"
 bunx --version | grep -Fx "$PROJECT_BUN_VERSION"
+go version | grep -F "go version go$PROJECT_GO_VERSION"
+go env GOTOOLCHAIN | grep -Fx 'local'
+go env GOROOT | grep -F "$PINSET_HOME/installs/go/$PROJECT_GO_VERSION/"
 set +e
 PNPM_CHILD_NODE_OUTPUT="$(pnpm exec node --version 2>&1)"
 PNPM_CHILD_NODE_STATUS=$?
@@ -106,5 +125,7 @@ grep -F '来源=全局' restored-global-current.txt
 node --version | grep -Fx "v$GLOBAL_VERSION"
 pnpm --version | grep -Fx "$GLOBAL_PNPM_VERSION"
 bun --version | grep -Fx "$BUN_VERSION"
+go version | grep -F "go version go$GLOBAL_GO_VERSION"
+go env GOTOOLCHAIN | grep -Fx 'local'
 
-echo "Unix real Node, pnpm and Bun acceptance passed"
+echo "Unix real Node, pnpm, Bun and Go acceptance passed"

--- a/scripts/tests/uninstall_ps1_test.ps1
+++ b/scripts/tests/uninstall_ps1_test.ps1
@@ -30,7 +30,7 @@ try {
     [IO.File]::WriteAllText($cli, 'pinset test binary')
     [IO.File]::WriteAllText($router, 'pinset shim test binary')
 
-    foreach ($command in @('node', 'npm')) {
+    foreach ($command in @('node', 'npm', 'go')) {
         $escapedRouter = $router.Replace('%', '%%')
         $wrapper = "@echo off`r`nsetlocal DisableDelayedExpansion`r`n`"$escapedRouter`" --as $command -- %*`r`nexit /b %ERRORLEVEL%`r`n"
         [IO.File]::WriteAllText((Join-Path $installDir "$command.cmd"), $wrapper)
@@ -117,6 +117,7 @@ try {
         (Join-Path $installDir 'node.cmd'),
         (Join-Path $installDir 'npm.cmd'),
         (Join-Path $shimDir 'corepack.exe'),
+        (Join-Path $installDir 'go.cmd'),
         (Join-Path $pathDir 'npx.exe'),
         $pinsetHome
     )) {

--- a/scripts/tests/uninstall_sh_test.sh
+++ b/scripts/tests/uninstall_sh_test.sh
@@ -45,6 +45,7 @@ ln -s "$INSTALL_DIR/pinset-shim" "$INSTALL_DIR/node"
 ln "$INSTALL_DIR/pinset-shim" "$INSTALL_DIR/npm"
 cp "$INSTALL_DIR/pinset-shim" "$INSTALL_DIR/npx"
 ln -s "$INSTALL_DIR/pinset-shim" "$SHIM_DIR/corepack"
+ln -s "$INSTALL_DIR/pinset-shim" "$SHIM_DIR/go"
 cp "$INSTALL_DIR/pinset-shim" "$PATH_DIR/npx"
 printf 'foreign command\n' > "$PATH_DIR/python"
 printf 'project config\n' > "$PROJECT_DIR/pinset.toml"
@@ -110,6 +111,7 @@ HOME="$TEST_HOME" PATH="$PATH_DIR:$PATH" sh "$ROOT/uninstall.sh" --yes \
 [ ! -e "$INSTALL_DIR/npm" ]
 [ ! -e "$INSTALL_DIR/npx" ]
 [ ! -e "$SHIM_DIR/corepack" ]
+[ ! -e "$SHIM_DIR/go" ]
 [ ! -e "$PATH_DIR/npx" ]
 [ ! -e "$PINSET_DATA_HOME" ]
 [ -f "$PATH_DIR/python" ]

--- a/scripts/tests/windows_runtime_acceptance.ps1
+++ b/scripts/tests/windows_runtime_acceptance.ps1
@@ -12,6 +12,8 @@ $BunVersion = if ($env:PINSET_BUN_VERSION) { $env:PINSET_BUN_VERSION } else { '1
 $GlobalPnpmSelector = if ($env:PINSET_GLOBAL_PNPM_SELECTOR) { $env:PINSET_GLOBAL_PNPM_SELECTOR } else { 'latest' }
 $ProjectPnpmSelector = if ($env:PINSET_PROJECT_PNPM_SELECTOR) { $env:PINSET_PROJECT_PNPM_SELECTOR } else { '10' }
 $ProjectBunSelector = if ($env:PINSET_PROJECT_BUN_SELECTOR) { $env:PINSET_PROJECT_BUN_SELECTOR } else { '1.2' }
+$GlobalGoSelector = if ($env:PINSET_GLOBAL_GO_SELECTOR) { $env:PINSET_GLOBAL_GO_SELECTOR } else { 'latest' }
+$ProjectGoSelector = if ($env:PINSET_PROJECT_GO_SELECTOR) { $env:PINSET_PROJECT_GO_SELECTOR } else { '1.24' }
 $VersionPattern = '^\d+\.\d+\.\d+$'
 
 if ($GlobalVersion -notmatch $VersionPattern -or $ProjectVersion -notmatch $VersionPattern -or
@@ -52,6 +54,7 @@ try {
     New-Item -ItemType Directory -Path $TestRoot | Out-Null
     $env:PINSET_HOME = Join-Path $TestRoot 'pinset-home'
     Remove-Item Env:PINSET_LANG -ErrorAction SilentlyContinue
+    Remove-Item Env:GOTOOLCHAIN -ErrorAction SilentlyContinue
     Set-Location $TestRoot
 
     & $Pinset --lang zh-CN | Out-Null
@@ -66,12 +69,22 @@ try {
     if (-not ((& $Pinset list bun --available) -contains "bun@$BunVersion")) {
         throw "bun@$BunVersion was not listed as available"
     }
+    if (-not ((& $Pinset list go --available) -match '^go@\d+\.\d+\.\d+$')) {
+        throw 'no supported Go release was listed as available'
+    }
     & $Pinset global "pnpm@$GlobalPnpmSelector"
     $GlobalPnpmVersion = ((& $Pinset exec -- pnpm --version) | Out-String).Trim()
     if ($GlobalPnpmVersion -notmatch '^11\.') {
         throw "global pnpm selector resolved to unexpected version '$GlobalPnpmVersion'"
     }
     & $Pinset use "bun@$BunVersion" --global
+    & $Pinset global "go@$GlobalGoSelector"
+    $GlobalGoOutput = ((& $Pinset exec -- go version) | Out-String).Trim()
+    $GlobalGoMatch = [regex]::Match($GlobalGoOutput, '^go version go(\d+\.\d+\.\d+)')
+    if (-not $GlobalGoMatch.Success) {
+        throw "global Go returned an invalid version: '$GlobalGoOutput'"
+    }
+    $GlobalGoVersion = $GlobalGoMatch.Groups[1].Value
     Assert-ExactOutput "v$GlobalVersion" (& $Pinset exec -- node --version) 'global pinset exec node'
     Assert-VersionOutput (& $Pinset exec -- npm --version) 'global pinset exec npm'
     Assert-VersionOutput (& $Pinset exec -- npx --version) 'global pinset exec npx'
@@ -79,6 +92,14 @@ try {
     Assert-ExactOutput $GlobalPnpmVersion (& $Pinset exec -- pnpm --version) 'global pinset exec pnpm'
     Assert-ExactOutput $BunVersion (& $Pinset exec -- bun --version) 'global pinset exec bun'
     Assert-ExactOutput $BunVersion (& $Pinset exec -- bunx --version) 'global pinset exec bunx'
+    if (((& $Pinset exec -- go version) | Out-String).Trim() -notmatch "^go version go$([regex]::Escape($GlobalGoVersion))") {
+        throw 'global pinset exec Go returned an unexpected version'
+    }
+    Assert-ExactOutput 'local' (& $Pinset exec -- go env GOTOOLCHAIN) 'global pinset exec Go toolchain policy'
+    $GlobalGoRoot = ((& $Pinset exec -- go env GOROOT) | Out-String).Trim()
+    if ($GlobalGoRoot -notlike "$(Join-Path $env:PINSET_HOME "installs\go\$GlobalGoVersion")*") {
+        throw "global Go reported an unmanaged GOROOT: '$GlobalGoRoot'"
+    }
 
     $ShimDirectory = ((& $Pinset shim path) | Out-String).Trim()
     if (-not $ShimDirectory) {
@@ -92,6 +113,10 @@ try {
     Assert-ExactOutput $GlobalPnpmVersion (& pnpm --version) 'global direct pnpm'
     Assert-ExactOutput $BunVersion (& bun --version) 'global direct bun'
     Assert-ExactOutput $BunVersion (& bunx --version) 'global direct bunx'
+    if (((& go version) | Out-String).Trim() -notmatch "^go version go$([regex]::Escape($GlobalGoVersion))") {
+        throw 'global direct Go returned an unexpected version'
+    }
+    Assert-ExactOutput 'local' (& go env GOTOOLCHAIN) 'global direct Go toolchain policy'
 
     $Project = Join-Path $TestRoot 'project'
     New-Item -ItemType Directory -Path $Project | Out-Null
@@ -110,12 +135,24 @@ try {
     if ($ProjectBunVersion -notmatch '^1\.2\.') {
         throw "project Bun selector resolved to unexpected version '$ProjectBunVersion'"
     }
+    & $Pinset use "go@$ProjectGoSelector"
+    $ProjectGoOutput = ((& go version) | Out-String).Trim()
+    $ProjectGoMatch = [regex]::Match($ProjectGoOutput, '^go version go(\d+\.\d+\.\d+)')
+    if (-not $ProjectGoMatch.Success -or $ProjectGoMatch.Groups[1].Value -notmatch "^$([regex]::Escape($ProjectGoSelector))\.") {
+        throw "project Go selector resolved to unexpected version '$ProjectGoOutput'"
+    }
+    $ProjectGoVersion = $ProjectGoMatch.Groups[1].Value
     Assert-ExactOutput "v$ProjectVersion" (& node --version) 'project direct node'
     Assert-VersionOutput (& npm --version) 'project direct npm'
     Assert-VersionOutput (& npx --version) 'project direct npx'
     Assert-VersionOutput (& corepack --version) 'project direct corepack'
     Assert-ExactOutput $ProjectPnpmVersion (& pnpm --version) 'project direct pnpm'
     Assert-ExactOutput $ProjectBunVersion (& bun --version) 'project direct bun'
+    Assert-ExactOutput 'local' (& go env GOTOOLCHAIN) 'project direct Go toolchain policy'
+    $ProjectGoRoot = ((& go env GOROOT) | Out-String).Trim()
+    if ($ProjectGoRoot -notlike "$(Join-Path $env:PINSET_HOME "installs\go\$ProjectGoVersion")*") {
+        throw "project Go reported an unmanaged GOROOT: '$ProjectGoRoot'"
+    }
     $PnpmChildNodeOutput = @(& pnpm exec node --version 2>&1 | ForEach-Object { $_.ToString() })
     $PnpmChildNodeStatus = $LASTEXITCODE
     Write-Host "pnpm exec node --version => status=$PnpmChildNodeStatus output=$($PnpmChildNodeOutput -join ' | ')"
@@ -133,7 +170,11 @@ try {
     Assert-ExactOutput "v$GlobalVersion" (& node --version) 'restored global direct node'
     Assert-ExactOutput $GlobalPnpmVersion (& pnpm --version) 'restored global direct pnpm'
     Assert-ExactOutput $BunVersion (& bun --version) 'restored global direct bun'
-    Write-Host 'Windows real Node, pnpm and Bun acceptance passed'
+    if (((& go version) | Out-String).Trim() -notmatch "^go version go$([regex]::Escape($GlobalGoVersion))") {
+        throw 'restored global direct Go returned an unexpected version'
+    }
+    Assert-ExactOutput 'local' (& go env GOTOOLCHAIN) 'restored global Go toolchain policy'
+    Write-Host 'Windows real Node, pnpm, Bun and Go acceptance passed'
 }
 finally {
     $env:PATH = $OriginalPath

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -108,7 +108,7 @@ if (Test-Path -LiteralPath $PinsetHome) {
 
 $cliPath = Join-Path $InstallDir 'pinset.exe'
 $routerPath = Join-Path $InstallDir 'pinset-shim.exe'
-$routeCommands = @('node', 'npm', 'npx', 'corepack')
+$routeCommands = @('node', 'npm', 'npx', 'corepack', 'pnpm', 'bun', 'bunx', 'go', 'gofmt')
 
 function Test-ManagedRoute([string]$Path) {
     if ((Paths-Equal $Path $cliPath) -or (Paths-Equal $Path $routerPath)) {

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -9,7 +9,7 @@ SHIM_BINARY="${PINSET_SHIM_BINARY:-}"
 ASSUME_YES=0
 DRY_RUN=0
 ALLOW_NONSTANDARD_HOME=0
-ROUTE_COMMANDS="node npm npx corepack"
+ROUTE_COMMANDS="node npm npx corepack pnpm bun bunx go gofmt"
 
 usage() {
     cat <<'EOF'


### PR DESCRIPTION
## Summary

- add Go official metadata, selector, lockfile, and archive installation
- route `go` and `gofmt` with managed `GOROOT` and default `GOTOOLCHAIN=local`
- generalize provider metadata, install, and environment dispatch
- extend documentation, uninstallers, and three-platform runtime acceptance for v0.3.0

## Validation

- local: `cargo fmt --all` and `git diff --check` only
- intentionally not run locally: builds, tests, Pinset execution, or runtime installation
- GitHub Actions `workflow_dispatch` will validate quality plus Ubuntu, Windows, and macOS real-runtime acceptance