### PR TITLE
feat: add Flutter SDK provider for v0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
             artifact: pinset-macos-aarch64
             archive: pinset-macos-aarch64.tar.gz
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 90
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -93,7 +93,7 @@ jobs:
       - name: Build release binaries
         run: cargo build --release --locked -p pinset-cli -p pinset-shim
 
-      - name: Run real Node, pnpm, Bun and Go acceptance on macOS
+      - name: Run real Node, pnpm, Bun, Go and Flutter acceptance on macOS
         if: runner.os == 'macOS'
         shell: bash
         env:
@@ -104,9 +104,11 @@ jobs:
           PINSET_PROJECT_PNPM_SELECTOR: 10
           PINSET_PROJECT_BUN_SELECTOR: 1.2
           PINSET_BUN_VERSION: 1.3.14
+          PINSET_GLOBAL_FLUTTER_SELECTOR: latest
+          PINSET_PROJECT_FLUTTER_SELECTOR: 3.44
         run: bash scripts/tests/ubuntu_runtime_acceptance.sh
 
-      - name: Run real Node, pnpm, Bun and Go acceptance on Windows
+      - name: Run real Node, pnpm, Bun, Go and Flutter acceptance on Windows
         if: runner.os == 'Windows'
         shell: pwsh
         env:
@@ -117,6 +119,8 @@ jobs:
           PINSET_PROJECT_PNPM_SELECTOR: 10
           PINSET_PROJECT_BUN_SELECTOR: 1.2
           PINSET_BUN_VERSION: 1.3.14
+          PINSET_GLOBAL_FLUTTER_SELECTOR: latest
+          PINSET_PROJECT_FLUTTER_SELECTOR: 3.44
         run: ./scripts/tests/windows_runtime_acceptance.ps1
 
       - name: Test Unix curl installer
@@ -167,7 +171,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     needs: quality
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 90
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -181,9 +185,11 @@ jobs:
       - name: Build locked release binaries
         run: cargo build --release --locked -p pinset-cli -p pinset-shim
 
-      - name: Run real Node, pnpm, Bun and Go acceptance in an isolated home
+      - name: Run real Node, pnpm, Bun, Go and Flutter acceptance in an isolated home
         env:
           PINSET_BIN: ${{ github.workspace }}/target/release/pinset
           PINSET_GLOBAL_VERSION: 24.0.0
           PINSET_PROJECT_VERSION: 22.0.0
+          PINSET_GLOBAL_FLUTTER_SELECTOR: latest
+          PINSET_PROJECT_FLUTTER_SELECTOR: 3.44
         run: bash scripts/tests/ubuntu_runtime_acceptance.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Build release binaries
         run: cargo build --release --locked -p pinset-cli -p pinset-shim
 
-      - name: Run real Node, pnpm, Bun, Go and Flutter acceptance on macOS
+      - name: Run real Node, pnpm, Bun and Go acceptance on macOS
         if: runner.os == 'macOS'
         shell: bash
         env:
@@ -106,9 +106,10 @@ jobs:
           PINSET_BUN_VERSION: 1.3.14
           PINSET_GLOBAL_FLUTTER_SELECTOR: latest
           PINSET_PROJECT_FLUTTER_SELECTOR: 3.44
+          PINSET_SKIP_FLUTTER_RUNTIME: 1
         run: bash scripts/tests/ubuntu_runtime_acceptance.sh
 
-      - name: Run real Node, pnpm, Bun, Go and Flutter acceptance on Windows
+      - name: Run real Node, pnpm, Bun and Go acceptance on Windows
         if: runner.os == 'Windows'
         shell: pwsh
         env:
@@ -121,6 +122,7 @@ jobs:
           PINSET_BUN_VERSION: 1.3.14
           PINSET_GLOBAL_FLUTTER_SELECTOR: latest
           PINSET_PROJECT_FLUTTER_SELECTOR: 3.44
+          PINSET_SKIP_FLUTTER_RUNTIME: 1
         run: ./scripts/tests/windows_runtime_acceptance.ps1
 
       - name: Test Unix curl installer
@@ -185,11 +187,12 @@ jobs:
       - name: Build locked release binaries
         run: cargo build --release --locked -p pinset-cli -p pinset-shim
 
-      - name: Run real Node, pnpm, Bun, Go and Flutter acceptance in an isolated home
+      - name: Run real Node, pnpm, Bun and Go acceptance in an isolated home
         env:
           PINSET_BIN: ${{ github.workspace }}/target/release/pinset
           PINSET_GLOBAL_VERSION: 24.0.0
           PINSET_PROJECT_VERSION: 22.0.0
           PINSET_GLOBAL_FLUTTER_SELECTOR: latest
           PINSET_PROJECT_FLUTTER_SELECTOR: 3.44
+          PINSET_SKIP_FLUTTER_RUNTIME: 1
         run: bash scripts/tests/ubuntu_runtime_acceptance.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Build release binaries
         run: cargo build --release --locked -p pinset-cli -p pinset-shim
 
-      - name: Run real Node, pnpm, Bun, Go and Flutter acceptance on Linux and macOS
+      - name: Run real Node, pnpm, Bun and Go acceptance on Linux and macOS
         if: runner.os != 'Windows'
         shell: bash
         env:
@@ -139,9 +139,10 @@ jobs:
           PINSET_BUN_VERSION: 1.3.14
           PINSET_GLOBAL_FLUTTER_SELECTOR: latest
           PINSET_PROJECT_FLUTTER_SELECTOR: 3.44
+          PINSET_SKIP_FLUTTER_RUNTIME: 1
         run: bash scripts/tests/ubuntu_runtime_acceptance.sh
 
-      - name: Run real Node, pnpm, Bun, Go and Flutter acceptance on Windows
+      - name: Run real Node, pnpm, Bun and Go acceptance on Windows
         if: runner.os == 'Windows'
         shell: pwsh
         env:
@@ -154,6 +155,7 @@ jobs:
           PINSET_BUN_VERSION: 1.3.14
           PINSET_GLOBAL_FLUTTER_SELECTOR: latest
           PINSET_PROJECT_FLUTTER_SELECTOR: 3.44
+          PINSET_SKIP_FLUTTER_RUNTIME: 1
         run: ./scripts/tests/windows_runtime_acceptance.ps1
 
       - name: Test Unix curl installer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
             artifact: pinset-macos-aarch64
             archive: pinset-macos-aarch64.tar.gz
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       contents: read
       id-token: write
@@ -126,7 +126,7 @@ jobs:
       - name: Build release binaries
         run: cargo build --release --locked -p pinset-cli -p pinset-shim
 
-      - name: Run real Node, pnpm, Bun and Go acceptance on Linux and macOS
+      - name: Run real Node, pnpm, Bun, Go and Flutter acceptance on Linux and macOS
         if: runner.os != 'Windows'
         shell: bash
         env:
@@ -137,9 +137,11 @@ jobs:
           PINSET_PROJECT_PNPM_SELECTOR: 10
           PINSET_PROJECT_BUN_SELECTOR: 1.2
           PINSET_BUN_VERSION: 1.3.14
+          PINSET_GLOBAL_FLUTTER_SELECTOR: latest
+          PINSET_PROJECT_FLUTTER_SELECTOR: 3.44
         run: bash scripts/tests/ubuntu_runtime_acceptance.sh
 
-      - name: Run real Node, pnpm, Bun and Go acceptance on Windows
+      - name: Run real Node, pnpm, Bun, Go and Flutter acceptance on Windows
         if: runner.os == 'Windows'
         shell: pwsh
         env:
@@ -150,6 +152,8 @@ jobs:
           PINSET_PROJECT_PNPM_SELECTOR: 10
           PINSET_PROJECT_BUN_SELECTOR: 1.2
           PINSET_BUN_VERSION: 1.3.14
+          PINSET_GLOBAL_FLUTTER_SELECTOR: latest
+          PINSET_PROJECT_FLUTTER_SELECTOR: 3.44
         run: ./scripts/tests/windows_runtime_acceptance.ps1
 
       - name: Test Unix curl installer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Pinset
 
-感谢你帮助改进 Pinset。项目当前支持 Node、pnpm 与 Bun Provider，优先保证跨平台行为、安全边界和可复现安装。
+感谢你帮助改进 Pinset。项目当前开发版本支持 Node、pnpm、Bun、Go 与 Flutter Provider，优先保证跨平台行为、安全边界和可复现安装。
 
 ## 开发环境
 
@@ -27,7 +27,7 @@ Windows 完整卸载脚本使用独立 PowerShell 临时目录测试：
 ./scripts/tests/uninstall_ps1_test.ps1
 ```
 
-这些测试不会安装真实 Node、pnpm、Bun、Python 或 Flutter。真实运行时烟雾测试应在明确隔离的临时环境中进行，并在 PR 中说明平台与结果。
+这些测试不会安装真实 Node、pnpm、Bun、Go、Python 或 Flutter。构建、测试和真实运行时验收必须在 GitHub Actions 临时虚拟机中进行，并在 PR 中说明平台与结果；开发机和 WSL 只做编辑、格式化及静态差异检查。
 
 ## Pull Request
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,7 +1181,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "pinset-core",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "atomic-write-file",
  "base64",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.85"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Future Element"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Pinset 是一个本地优先的多语言运行时版本管理 CLI。目标是用
 
 `v0.3.0` 新增 Go Provider，并将 Provider 的元数据、安装器和受管环境策略收敛到统一清单。
 
-当前开发中的 `v0.4.0` 新增 Flutter stable SDK Provider，并将 SDK 内置 Dart 作为同一个锁定与路由单元。
+`v0.4.0` 新增 Flutter stable SDK Provider，并将 SDK 内置 Dart 作为同一个锁定与路由单元。
 
 - 全局 Node 默认版本、项目级 Node 覆盖，以及离开项目后恢复全局版本；
 - `node@24.0.0`、`node@24`、`node@24.12`、`node@lts`、`node@current`；
@@ -24,7 +24,7 @@ Pinset 是一个本地优先的多语言运行时版本管理 CLI。目标是用
 - Node SHA-256、npm SHA-512 SRI 与 registry ECDSA 签名校验、安全解压、事务安装、并发安装锁、断点续传和内容寻址缓存；
 - 国内或企业镜像、有序回退、可选的可信元数据镜像和离线缓存导入；
 - 中英文提示、旧 Node 管理器与 `.fvmrc` 配置导入、诊断、安全卸载；
-- 三平台自动构建、真实 Node/pnpm/Bun/Go/Flutter/Dart 验收、CycloneDX SBOM 和 GitHub 构建来源证明。
+- 三平台自动构建、真实 Node/pnpm/Bun/Go 验收、Flutter/Dart 元数据与安装逻辑测试、CycloneDX SBOM 和 GitHub 构建来源证明。
 
 ## 快速安装
 
@@ -45,10 +45,10 @@ pinset --version
 
 长期使用可自行把 `export PATH=...` 写入 `~/.bashrc` 或 `~/.zshrc`。Pinset 不会擅自修改这些文件。
 
-固定安装最新已发布的 `v0.3.0`：
+固定安装最新已发布的 `v0.4.0`：
 
 ```bash
-curl -fsSL https://github.com/Future-Element/pinset/releases/download/v0.3.0/install.sh | sh
+curl -fsSL https://github.com/Future-Element/pinset/releases/download/v0.4.0/install.sh | sh
 ```
 
 自定义安装目录：
@@ -527,7 +527,7 @@ cargo test --workspace --all-features
 cargo build --release --locked -p pinset-cli -p pinset-shim
 ```
 
-真实运行时验收只在 GitHub Actions 隔离 Runner 中执行。工作流会在 Linux、Windows、macOS 安装 Node、pnpm、Bun、Go 和两套 Flutter SDK，验证 available、全局/项目组合、项目覆盖、跨 Provider 子进程 PATH、`GOROOT`、默认 `GOTOOLCHAIN=local`、Flutter/Dart 同源、`FLUTTER_ROOT`、`.fvmrc` 导入、SDK 重用、原地升级拦截，以及受管命令的 `pinset exec`/shim 调用方式。
+GitHub Actions 会在 Linux、Windows、macOS 隔离 Runner 中安装 Node、pnpm、Bun 和 Go，验证 available、全局/项目组合、项目覆盖、跨 Provider 子进程 PATH、`GOROOT`、默认 `GOTOOLCHAIN=local`，并通过单元测试覆盖 Flutter/Dart 元数据、锁文件、安装安全、路由、`.fvmrc` 导入和原地升级拦截。Flutter SDK 单个归档可超过 1.8 GiB，因此 Actions 默认设置 `PINSET_SKIP_FLUTTER_RUNTIME=1`，不下载真实 SDK；完整验收脚本保留默认模式，供发布后在隔离虚拟机验证 Flutter/Dart 同源、`FLUTTER_ROOT`、SDK 重用和全局/项目覆盖。
 
 Linux/WSL 构建产物：
 
@@ -540,7 +540,7 @@ Windows 构建产物是 `.exe`，不能直接作为 WSL/Linux 程序使用；需
 
 ## Beta 限制
 
-- 当前开发版本支持 Node.js、pnpm、Bun、Go 和 Flutter stable SDK（含内置 Dart）；Python、Java、Rust 和其他 Provider 尚未开放。
+- 当前版本支持 Node.js、pnpm、Bun、Go 和 Flutter stable SDK（含内置 Dart）；Python、Java、Rust 和其他 Provider 尚未开放。
 - Pinset Release 暂无 Linux arm64、macOS Intel 安装包。
 - 项目不维护第三方 Homebrew Tap 或 Scoop Bucket；使用 curl、Release 归档或源码构建。
 - Pinset 会校验 Node 官方 HTTPS `SHASUMS256.txt` 和 Go 官方下载索引中的 SHA-256，但 Beta 尚未验证 Node 清单的上游 OpenPGP 签名；pnpm/Bun 则校验 npm SHA-512 SRI 和 registry ECDSA 签名。

--- a/README.md
+++ b/README.md
@@ -5,23 +5,26 @@
 
 Pinset 是一个本地优先的多语言运行时版本管理 CLI。目标是用一致的命令管理 Node.js、Go、Python、Flutter 等运行时，减少在 fnm、nvm、Go 工具链、uv、FVM 之间切换的学习和维护成本。
 
-`v0.2.0` 在已验证的 Node.js 管理基础上新增独立的 pnpm 与 Bun Provider。Python 和 Flutter 尚未支持。当前功能包括：
+`v0.2.0` 在已验证的 Node.js 管理基础上新增独立的 pnpm 与 Bun Provider。
 
 `v0.2.1` 修复 pnpm 10 独立可执行包被错误套用 pnpm 11 `dist/` 叠加层规则的问题，并覆盖项目 pnpm 10 与 Bun 1.2 的组合安装。
 
 `v0.3.0` 新增 Go Provider，并将 Provider 的元数据、安装器和受管环境策略收敛到统一清单。
 
+当前开发中的 `v0.4.0` 新增 Flutter stable SDK Provider，并将 SDK 内置 Dart 作为同一个锁定与路由单元。
+
 - 全局 Node 默认版本、项目级 Node 覆盖，以及离开项目后恢复全局版本；
 - `node@24.0.0`、`node@24`、`node@24.12`、`node@lts`、`node@current`；
 - pnpm 10/11 与 Bun 1.x 的精确、主版本、主次版本、`latest`/`current` 选择器；
 - Go 的精确、主版本、主次版本、`latest`/`current` 选择器；
+- Flutter stable 的精确、主版本、主次版本、`latest`/`current` 选择器，以及对应的内置 Dart 版本；
 - Windows x64、Linux x64、macOS Apple Silicon 的 Pinset Release；
-- `node`、`npm`、`npx`、`corepack`、`pnpm`、`bun`、`bunx`、`go`、`gofmt` 统一路由；
+- `node`、`npm`、`npx`、`corepack`、`pnpm`、`bun`、`bunx`、`go`、`gofmt`、`flutter`、`dart` 统一路由；
 - 可提交的 `pinset.toml` 和 `pinset.lock`；
 - Node SHA-256、npm SHA-512 SRI 与 registry ECDSA 签名校验、安全解压、事务安装、并发安装锁、断点续传和内容寻址缓存；
 - 国内或企业镜像、有序回退、可选的可信元数据镜像和离线缓存导入；
-- 中英文提示、旧 Node 管理器配置导入、诊断、安全卸载；
-- 三平台自动构建、真实 Node/pnpm/Bun/Go 验收、CycloneDX SBOM 和 GitHub 构建来源证明。
+- 中英文提示、旧 Node 管理器与 `.fvmrc` 配置导入、诊断、安全卸载；
+- 三平台自动构建、真实 Node/pnpm/Bun/Go/Flutter/Dart 验收、CycloneDX SBOM 和 GitHub 构建来源证明。
 
 ## 快速安装
 
@@ -136,11 +139,12 @@ node = "22.0.0"
 pnpm = "11.21.0"
 bun = "1.3.14"
 go = "1.25.1"
+flutter = "3.47.0"
 ```
 
-`pinset.lock` 保存解析后的精确版本、平台归档、完整性值和来源信息。Node 和 Go 使用官方 SHA-256；pnpm/Bun 使用 npm 包的 SHA-512 SRI，并在生成锁文件前验证 registry ECDSA 签名。建议把 `pinset.toml` 与 `pinset.lock` 一起提交。
+`pinset.lock` 保存解析后的精确版本、平台归档、完整性值和来源信息。Node、Go 和 Flutter 使用官方 SHA-256；pnpm/Bun 使用 npm 包的 SHA-512 SRI，并在生成锁文件前验证 registry ECDSA 签名。建议把 `pinset.toml` 与 `pinset.lock` 一起提交。
 
-在项目目录中，项目版本优先于全局版本；离开项目目录后自动恢复全局版本。如果项目或全局声明了版本但安装缺失，Pinset 会明确报错，不会静默换成系统 Node。
+在项目目录中，项目版本优先于全局版本；离开项目目录后自动恢复全局版本。如果项目或全局声明了版本但安装缺失，Pinset 会明确报错，不会静默换成系统运行时。
 
 只生成配置和锁文件：
 
@@ -226,6 +230,29 @@ Pinset 从 Go 官方下载 JSON 索引读取稳定版本和 Windows x64、Linux 
 
 Pinset 不修改 `go.mod`/`go.work`，也不管理 Go module 依赖、`GOPATH`、`GOMODCACHE` 或 `GOCACHE`。
 
+## Flutter 与内置 Dart
+
+Flutter 使用与其他 Provider 相同的项目、全局、available、安装、卸载和路由流程：
+
+```shell
+pinset list flutter --available
+pinset global flutter@latest
+pinset use flutter@3.44
+pinset current flutter
+flutter --version
+dart --version
+```
+
+`list flutter --available` 会同时显示 Flutter stable 版本与它捆绑的 Dart 版本。Pinset 读取 Flutter 官方 Linux、Windows、macOS release JSON，只接受四个受支持目标都存在且 release hash、Flutter 版本和 Dart 版本一致的发布，并把逐平台 SHA-256 写入锁文件。
+
+Flutter SDK 归档明显大于其他 Provider。Pinset 仅为已通过内置工件身份校验的 Flutter 锁使用专用下载和解压安全上限；已安装 SDK 可直接重用，下载归档可通过 `pinset cache clean` 清理。
+
+Flutter 与 Dart 始终从同一套 SDK 的 `bin` 路由。受管命令获得对应的 `FLUTTER_ROOT`；未显式设置时，Pinset 还会使用 `FLUTTER_SUPPRESS_ANALYTICS=true`，用户已有值保持不变。`.fvmrc` 可通过 `pinset import --dry-run` 预览，并通过 `pinset import --apply --from fvm` 显式导入，原文件与 FVM 缓存不会被修改。
+
+为保持锁文件可复现，受管 SDK 不允许原地执行 `flutter upgrade`、`flutter downgrade` 或 `flutter channel`。请选择新版本，例如 `pinset use flutter@3.47`，由 Pinset 解析并安装另一套 SDK。
+
+Pinset 不管理 Android SDK/NDK、JDK、Xcode、CocoaPods、模拟器、设备、Flutter/Dart 项目依赖或 pub 缓存。
+
 ### 解析优先级
 
 ```text
@@ -254,6 +281,8 @@ pinset exec -- node --version
 pinset exec -- npm ci
 pinset exec -- go version
 pinset exec go@1.25 -- go version
+pinset exec -- flutter --version
+pinset exec -- dart --version
 pinset exec -- npx vite
 ```
 
@@ -271,7 +300,7 @@ pinset install node@20
 
 ### 直接运行 Provider 命令
 
-正常执行 `global`、`use` 或 `install` 后，各 Provider 会注册自己的通用路由：Node 注册四个命令，pnpm 注册 `pnpm`，Bun 注册 `bun` 和 `bunx`。curl 安装器本身仍然保持运行时中立，只安装 Pinset 和通用调度器。
+正常执行 `global`、`use` 或 `install` 后，各 Provider 会注册自己的通用路由：Node 注册四个命令，pnpm 注册 `pnpm`，Bun 注册 `bun` 和 `bunx`，Go 注册 `go` 和 `gofmt`，Flutter 注册 `flutter` 和 `dart`。curl 安装器本身仍然保持运行时中立，只安装 Pinset 和通用调度器。
 
 如果使用源码构建、定制安装目录，或当前终端还没有路由目录，可以临时激活：
 
@@ -293,6 +322,8 @@ pinset shim path
 pinset shim install --provider node
 pinset shim install --provider pnpm
 pinset shim install --provider bun
+pinset shim install --provider go
+pinset shim install --provider flutter
 pinset shim migrate --provider node
 ```
 
@@ -447,19 +478,19 @@ Windows 从 Release 下载 `uninstall.ps1`：
 | 命令 | 用途 |
 | --- | --- |
 | `pinset init` | 在当前目录创建最小 `pinset.toml` |
-| `pinset global [node@选择器]` | 查看或设置全局 Node 默认版本 |
-| `pinset use node@选择器 [--global]` | 选择、锁定并默认安装 Node |
-| `pinset unset node [--global]` | 清除选择，不卸载运行时 |
-| `pinset install [node@选择器]` | 安装锁定版本或独立预装一个版本 |
-| `pinset current [node]` | 显示当前解析结果、来源和路径 |
+| `pinset global [<tool>@选择器]` | 查看或设置全局运行时默认版本 |
+| `pinset use <tool>@选择器 [--global]` | 选择、锁定并默认安装运行时 |
+| `pinset unset <tool> [--global]` | 清除选择，不卸载运行时 |
+| `pinset install [<tool>@选择器]` | 安装锁定版本或独立预装一个版本 |
+| `pinset current [<tool>]` | 显示当前解析结果、来源和路径 |
 | `pinset which <命令>` | 显示某个命令最终使用的可执行文件 |
-| `pinset exec [node@精确版本] -- <命令>` | 通过所选运行时执行命令 |
-| `pinset list node [--available]` | 查看本地或官方可用版本 |
-| `pinset uninstall node@精确版本` | 安全卸载一个 Pinset Node 安装 |
+| `pinset exec [<tool>@精确版本] -- <命令>` | 通过所选运行时执行命令 |
+| `pinset list <tool> [--available]` | 查看本地或官方可用版本 |
+| `pinset uninstall <tool>@精确版本` | 安全卸载一个 Pinset 管理的运行时 |
 | `pinset cache list/clean/import` | 管理下载缓存和离线归档 |
 | `pinset source ...` | 管理镜像、回退与连通性测试 |
 | `pinset doctor [--json]` | 只读诊断配置、安装和 PATH |
-| `pinset import --dry-run/--apply` | 检测或导入旧 Node 管理器配置 |
+| `pinset import --dry-run/--apply` | 检测或导入旧 Node 管理器配置与 `.fvmrc` |
 | `pinset activate <shell>` | 输出当前 shell 的临时 PATH 激活代码 |
 | `pinset shim ...` | 查看、修复或迁移命令路由 |
 
@@ -496,7 +527,7 @@ cargo test --workspace --all-features
 cargo build --release --locked -p pinset-cli -p pinset-shim
 ```
 
-真实运行时验收只在 GitHub Actions 隔离 Runner 中执行。工作流会在 Linux、Windows、macOS 安装 Node、pnpm、Bun 和 Go，验证 available、全局/项目组合、项目覆盖、跨 Provider 子进程 PATH、`GOROOT`、默认 `GOTOOLCHAIN=local`，以及受管命令的 `pinset exec`/shim 调用方式。
+真实运行时验收只在 GitHub Actions 隔离 Runner 中执行。工作流会在 Linux、Windows、macOS 安装 Node、pnpm、Bun、Go 和两套 Flutter SDK，验证 available、全局/项目组合、项目覆盖、跨 Provider 子进程 PATH、`GOROOT`、默认 `GOTOOLCHAIN=local`、Flutter/Dart 同源、`FLUTTER_ROOT`、`.fvmrc` 导入、SDK 重用、原地升级拦截，以及受管命令的 `pinset exec`/shim 调用方式。
 
 Linux/WSL 构建产物：
 
@@ -509,7 +540,7 @@ Windows 构建产物是 `.exe`，不能直接作为 WSL/Linux 程序使用；需
 
 ## Beta 限制
 
-- 当前开发版本支持 Node.js、pnpm、Bun 和 Go；Python、Flutter 和其他 Provider 尚未开放。
+- 当前开发版本支持 Node.js、pnpm、Bun、Go 和 Flutter stable SDK（含内置 Dart）；Python、Java、Rust 和其他 Provider 尚未开放。
 - Pinset Release 暂无 Linux arm64、macOS Intel 安装包。
 - 项目不维护第三方 Homebrew Tap 或 Scoop Bucket；使用 curl、Release 归档或源码构建。
 - Pinset 会校验 Node 官方 HTTPS `SHASUMS256.txt` 和 Go 官方下载索引中的 SHA-256，但 Beta 尚未验证 Node 清单的上游 OpenPGP 签名；pnpm/Bun 则校验 npm SHA-512 SRI 和 registry ECDSA 签名。

--- a/crates/pinset-core/Cargo.toml
+++ b/crates/pinset-core/Cargo.toml
@@ -22,7 +22,9 @@ installer = [
 ]
 go-metadata = ["lockfile", "sources", "dep:reqwest", "dep:serde_json"]
 go-provider = ["sources"]
-lockfile = ["node-provider", "go-provider", "dep:atomic-write-file", "dep:base64", "dep:hex"]
+flutter-metadata = ["lockfile", "sources", "dep:reqwest", "dep:serde_json"]
+flutter-provider = ["sources"]
+lockfile = ["node-provider", "go-provider", "flutter-provider", "dep:atomic-write-file", "dep:base64", "dep:hex"]
 node-metadata = ["lockfile", "dep:reqwest", "dep:serde_json"]
 node-provider = ["sources"]
 npm-metadata = [

--- a/crates/pinset-core/src/error.rs
+++ b/crates/pinset-core/src/error.rs
@@ -368,6 +368,53 @@ pub enum Error {
     #[error("invalid Go download index: {reason}")]
     InvalidGoIndex { reason: String },
 
+    #[cfg(feature = "flutter-provider")]
+    #[error("invalid exact Flutter version \"{version}\"; expected x.y.z")]
+    InvalidFlutterVersion { version: String },
+
+    #[cfg(feature = "flutter-provider")]
+    #[error("unsupported Flutter target \"{target}\"")]
+    UnsupportedFlutterTarget { target: String },
+
+    #[cfg(feature = "flutter-metadata")]
+    #[error(
+        "invalid Flutter selector \"{selector}\"; expected x.y.z, a major/minor prefix, latest or current"
+    )]
+    InvalidFlutterSelector { selector: String },
+
+    #[cfg(feature = "flutter-metadata")]
+    #[error("official Flutter indexes contain no stable release matching \"{selector}\"")]
+    FlutterSelectorNotFound { selector: String },
+
+    #[cfg(feature = "flutter-metadata")]
+    #[error("failed to request Flutter release metadata {url}: {source}")]
+    FlutterMetadataRequest {
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+
+    #[cfg(feature = "flutter-metadata")]
+    #[error("failed while reading Flutter release metadata {url}: {source}")]
+    FlutterMetadataRead {
+        url: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[cfg(feature = "flutter-metadata")]
+    #[error("Flutter release index exceeds {limit} bytes")]
+    FlutterMetadataTooLarge { limit: u64 },
+
+    #[cfg(feature = "flutter-metadata")]
+    #[error("invalid Flutter release index: {reason}")]
+    InvalidFlutterIndex { reason: String },
+
+    #[error(
+        "refusing to run `{command}` against a Pinset-managed Flutter SDK; select another version with `pinset use flutter@<version>` or `pinset global flutter@<version>`"
+    )]
+    ManagedFlutterMutation { command: String },
+
     #[cfg(feature = "node-metadata")]
     #[error(
         "invalid Node.js selector \"{selector}\"; expected x.y.z, a major/minor prefix, lts or current"

--- a/crates/pinset-core/src/flutter_metadata.rs
+++ b/crates/pinset-core/src/flutter_metadata.rs
@@ -1,0 +1,438 @@
+use std::{cmp::Reverse, collections::BTreeMap, io::Read, time::Duration};
+
+use reqwest::{Url, blocking::Client};
+use serde::Deserialize;
+
+use crate::{
+    Error, FLUTTER_TARGETS, FlutterArchiveFormat, LockedArtifact, LockedArtifactFormat, LockedTool,
+    Result, SourceConfig, plan_flutter_artifact, validate_exact_flutter_version,
+};
+
+const OFFICIAL_FLUTTER_BASE_URL: &str = "https://storage.googleapis.com/";
+const MAX_FLUTTER_INDEX_BYTES: u64 = 8 * 1024 * 1024;
+const FLUTTER_VERIFICATION: &str = "flutter-release-json-sha256";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FlutterRelease {
+    pub version: String,
+    pub dart_version: String,
+    pub release_hash: String,
+}
+
+#[derive(Debug)]
+pub struct FlutterMetadataClient {
+    client: Client,
+    metadata_base_url: Url,
+    verification: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FlutterIndex {
+    #[serde(default)]
+    releases: Vec<FlutterIndexRelease>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FlutterIndexRelease {
+    hash: String,
+    channel: String,
+    version: String,
+    dart_sdk_version: String,
+    #[serde(default)]
+    dart_sdk_arch: String,
+    archive: String,
+    sha256: String,
+}
+
+#[derive(Debug)]
+struct SupportedFlutterRelease {
+    version: String,
+    dart_version: String,
+    release_hash: String,
+    artifacts: Vec<(String, FlutterIndexRelease)>,
+}
+
+impl FlutterMetadataClient {
+    pub fn official() -> Result<Self> {
+        Self::for_source(OFFICIAL_FLUTTER_BASE_URL, "official")
+    }
+
+    pub fn for_base_url(base_url: &str) -> Result<Self> {
+        Self::for_source(base_url, "custom")
+    }
+
+    pub fn for_source(base_url: &str, alias: &str) -> Result<Self> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|source| Error::HttpClient { source })?;
+        let metadata_base_url =
+            Url::parse(base_url).map_err(|source| Error::InvalidSourceBaseUrl {
+                url: base_url.to_owned(),
+                reason: source.to_string(),
+            })?;
+        let verification = if alias == "official" {
+            FLUTTER_VERIFICATION.to_owned()
+        } else {
+            format!("{FLUTTER_VERIFICATION}-source:{alias}")
+        };
+        Ok(Self {
+            client,
+            metadata_base_url,
+            verification,
+        })
+    }
+
+    pub fn available_releases(&self) -> Result<Vec<FlutterRelease>> {
+        Ok(self
+            .supported_releases()?
+            .into_iter()
+            .map(|release| FlutterRelease {
+                version: release.version,
+                dart_version: release.dart_version,
+                release_hash: release.release_hash,
+            })
+            .collect())
+    }
+
+    pub fn resolve_version_selector(&self, selector: &str) -> Result<String> {
+        Ok(self.resolve_release(selector)?.version)
+    }
+
+    pub fn resolve_tool(&self, selector: &str) -> Result<LockedTool> {
+        let release = self.resolve_release(selector)?;
+        let artifacts = release
+            .artifacts
+            .into_iter()
+            .map(|(target, artifact)| {
+                let plan =
+                    plan_flutter_artifact(&SourceConfig::default(), &release.version, &target)?;
+                Ok(LockedArtifact {
+                    target,
+                    canonical_url: plan.canonical_url,
+                    artifact_path: plan.artifact_path,
+                    sha256: artifact.sha256,
+                    integrity: None,
+                    format: match plan.format {
+                        FlutterArchiveFormat::Zip => LockedArtifactFormat::Zip,
+                        FlutterArchiveFormat::TarXz => LockedArtifactFormat::TarXz,
+                    },
+                    archive_root: plan.archive_root,
+                    verification: self.verification.clone(),
+                    overlays: Vec::new(),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let mut metadata = BTreeMap::new();
+        metadata.insert("channel".to_owned(), "stable".to_owned());
+        metadata.insert("dart_version".to_owned(), release.dart_version);
+        metadata.insert("release_hash".to_owned(), release.release_hash);
+        Ok(LockedTool {
+            name: "flutter".to_owned(),
+            requested: release.version.clone(),
+            version: release.version,
+            provider: "flutter-official".to_owned(),
+            metadata,
+            artifacts,
+        })
+    }
+
+    fn resolve_release(&self, selector: &str) -> Result<SupportedFlutterRelease> {
+        let normalized = selector.trim().to_ascii_lowercase();
+        let exact = validate_exact_flutter_version(&normalized).is_ok();
+        let numeric_parts = normalized.split('.').collect::<Vec<_>>();
+        let numeric_selector = (numeric_parts.len() == 1 || numeric_parts.len() == 2)
+            && numeric_parts
+                .iter()
+                .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()));
+        if normalized != "latest" && normalized != "current" && !exact && !numeric_selector {
+            return Err(Error::InvalidFlutterSelector {
+                selector: selector.to_owned(),
+            });
+        }
+        let requested = numeric_selector
+            .then(|| {
+                numeric_parts
+                    .iter()
+                    .map(|part| part.parse::<u64>())
+                    .collect::<std::result::Result<Vec<_>, _>>()
+            })
+            .transpose()
+            .map_err(|_| Error::InvalidFlutterSelector {
+                selector: selector.to_owned(),
+            })?;
+
+        self.supported_releases()?
+            .into_iter()
+            .find(|release| {
+                if normalized == "latest" || normalized == "current" {
+                    return true;
+                }
+                if exact {
+                    return release.version == normalized;
+                }
+                let tuple = version_tuple(&release.version).expect("validated Flutter release");
+                let requested = requested.as_ref().expect("numeric selector");
+                tuple.0 == requested[0] && (requested.len() == 1 || tuple.1 == requested[1])
+            })
+            .ok_or_else(|| Error::FlutterSelectorNotFound {
+                selector: selector.to_owned(),
+            })
+    }
+
+    fn supported_releases(&self) -> Result<Vec<SupportedFlutterRelease>> {
+        let linux = self.download_index("linux")?;
+        let windows = self.download_index("windows")?;
+        let macos = self.download_index("macos")?;
+        parse_indexes(&linux, &windows, &macos)
+    }
+
+    fn download_index(&self, platform: &str) -> Result<String> {
+        let url = self
+            .metadata_base_url
+            .join(&format!(
+                "flutter_infra_release/releases/releases_{platform}.json"
+            ))
+            .map_err(|source| Error::InvalidSourceBaseUrl {
+                url: self.metadata_base_url.to_string(),
+                reason: source.to_string(),
+            })?;
+        let display_url = url.to_string();
+        let mut response = self
+            .client
+            .get(url)
+            .send()
+            .and_then(reqwest::blocking::Response::error_for_status)
+            .map_err(|source| Error::FlutterMetadataRequest {
+                url: display_url.clone(),
+                source,
+            })?;
+        if response
+            .content_length()
+            .is_some_and(|length| length > MAX_FLUTTER_INDEX_BYTES)
+        {
+            return Err(Error::FlutterMetadataTooLarge {
+                limit: MAX_FLUTTER_INDEX_BYTES,
+            });
+        }
+        let mut bytes = Vec::new();
+        (&mut response)
+            .take(MAX_FLUTTER_INDEX_BYTES + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|source| Error::FlutterMetadataRead {
+                url: display_url,
+                source,
+            })?;
+        if bytes.len() as u64 > MAX_FLUTTER_INDEX_BYTES {
+            return Err(Error::FlutterMetadataTooLarge {
+                limit: MAX_FLUTTER_INDEX_BYTES,
+            });
+        }
+        String::from_utf8(bytes).map_err(|_| Error::InvalidFlutterIndex {
+            reason: format!("{platform} index is not UTF-8"),
+        })
+    }
+}
+
+fn parse_indexes(
+    linux_body: &str,
+    windows_body: &str,
+    macos_body: &str,
+) -> Result<Vec<SupportedFlutterRelease>> {
+    let linux = parse_index(linux_body, "linux", &["linux-x86_64"])?;
+    let windows = parse_index(windows_body, "windows", &["windows-x86_64"])?;
+    let macos = parse_index(macos_body, "macos", &["macos-x86_64", "macos-aarch64"])?;
+    let mut grouped: BTreeMap<String, BTreeMap<String, FlutterIndexRelease>> = BTreeMap::new();
+    for (target, releases) in [linux, windows, macos].into_iter().flatten() {
+        for release in releases {
+            grouped
+                .entry(release.version.clone())
+                .or_default()
+                .insert(target.clone(), release);
+        }
+    }
+
+    let mut supported = Vec::new();
+    for (version, mut artifacts) in grouped {
+        if !FLUTTER_TARGETS
+            .iter()
+            .all(|target| artifacts.contains_key(*target))
+        {
+            continue;
+        }
+        let first = artifacts
+            .values()
+            .next()
+            .expect("four required Flutter artifacts");
+        if artifacts.values().any(|artifact| {
+            artifact.hash != first.hash || artifact.dart_sdk_version != first.dart_sdk_version
+        }) {
+            continue;
+        }
+        let release_hash = first.hash.clone();
+        let dart_version = first.dart_sdk_version.clone();
+        let artifacts = FLUTTER_TARGETS
+            .iter()
+            .map(|target| {
+                (
+                    (*target).to_owned(),
+                    artifacts.remove(*target).expect("checked target"),
+                )
+            })
+            .collect();
+        supported.push(SupportedFlutterRelease {
+            version,
+            dart_version,
+            release_hash,
+            artifacts,
+        });
+    }
+    supported.sort_by_key(|release| Reverse(version_tuple(&release.version).unwrap_or_default()));
+    Ok(supported)
+}
+
+fn parse_index(
+    body: &str,
+    platform: &str,
+    targets: &[&str],
+) -> Result<Vec<(String, Vec<FlutterIndexRelease>)>> {
+    let index: FlutterIndex =
+        serde_json::from_str(body).map_err(|source| Error::InvalidFlutterIndex {
+            reason: format!("{platform}: {source}"),
+        })?;
+    Ok(targets
+        .iter()
+        .map(|target| {
+            let releases = index
+                .releases
+                .iter()
+                .filter(|release| release.channel == "stable")
+                .filter(|release| validate_exact_flutter_version(&release.version).is_ok())
+                .filter(|release| valid_release_hash(&release.hash))
+                .filter(|release| valid_sha256(&release.sha256))
+                .filter(|release| validate_exact_flutter_version(&release.dart_sdk_version).is_ok())
+                .filter(|release| {
+                    plan_flutter_artifact(&SourceConfig::default(), &release.version, target)
+                        .is_ok_and(|plan| {
+                            release.archive == plan.release_path
+                                && (release.dart_sdk_arch.is_empty()
+                                    || release.dart_sdk_arch == plan.dart_arch)
+                        })
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            ((*target).to_owned(), releases)
+        })
+        .collect())
+}
+
+fn version_tuple(version: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = version.split('.');
+    Some((
+        parts.next()?.parse().ok()?,
+        parts.next()?.parse().ok()?,
+        parts.next()?.parse().ok()?,
+    ))
+}
+
+fn valid_sha256(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn valid_release_hash(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+        thread,
+    };
+
+    use super::*;
+
+    #[test]
+    fn combines_only_stable_releases_available_for_all_targets() {
+        let (linux, windows, macos) = release_fixtures("3.47.0", true);
+        let releases = parse_indexes(&linux, &windows, &macos).expect("indexes");
+        assert_eq!(releases.len(), 1);
+        assert_eq!(releases[0].version, "3.47.0");
+        assert_eq!(releases[0].dart_version, "3.13.0");
+        assert_eq!(releases[0].artifacts.len(), FLUTTER_TARGETS.len());
+
+        let (linux, windows, macos) = release_fixtures("3.47.0", false);
+        assert!(
+            parse_indexes(&linux, &windows, &macos)
+                .expect("incomplete indexes")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn resolves_a_numeric_selector_to_flutter_and_bundled_dart_metadata() {
+        let (linux, windows, macos) = release_fixtures("3.47.0", true);
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+        let address = listener.local_addr().expect("address");
+        let server = thread::spawn(move || {
+            for (expected, body) in [
+                ("releases_linux.json", linux),
+                ("releases_windows.json", windows),
+                ("releases_macos.json", macos),
+            ] {
+                let (mut stream, _) = listener.accept().expect("request");
+                let mut request = [0_u8; 2048];
+                let count = stream.read(&mut request).expect("read request");
+                assert!(String::from_utf8_lossy(&request[..count]).contains(expected));
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                )
+                .expect("headers");
+                stream.write_all(body.as_bytes()).expect("body");
+            }
+        });
+        let client = FlutterMetadataClient::for_base_url(&format!("http://{address}/"))
+            .expect("metadata client");
+        let locked = client.resolve_tool("3.47").expect("locked Flutter");
+        server.join().expect("server");
+
+        assert_eq!(locked.version, "3.47.0");
+        assert_eq!(locked.metadata["channel"], "stable");
+        assert_eq!(locked.metadata["dart_version"], "3.13.0");
+        assert_eq!(locked.artifacts.len(), FLUTTER_TARGETS.len());
+        assert!(locked.artifacts.iter().all(|artifact| {
+            artifact.sha256 == "ab".repeat(32)
+                && artifact.verification == "flutter-release-json-sha256-source:custom"
+        }));
+    }
+
+    fn release_fixtures(version: &str, complete: bool) -> (String, String, String) {
+        let release_hash = "cd".repeat(20);
+        let sha256 = "ab".repeat(32);
+        let entry = |target: &str| {
+            let plan = plan_flutter_artifact(&SourceConfig::default(), version, target)
+                .expect("artifact plan");
+            serde_json::json!({
+                "hash": release_hash,
+                "channel": "stable",
+                "version": version,
+                "dart_sdk_version": "3.13.0",
+                "dart_sdk_arch": plan.dart_arch,
+                "archive": plan.release_path,
+                "sha256": sha256
+            })
+        };
+        let linux = serde_json::json!({"releases": [entry("linux-x86_64")]}).to_string();
+        let windows = serde_json::json!({"releases": [entry("windows-x86_64")]}).to_string();
+        let macos_entries = if complete {
+            vec![entry("macos-x86_64"), entry("macos-aarch64")]
+        } else {
+            vec![entry("macos-x86_64")]
+        };
+        let macos = serde_json::json!({"releases": macos_entries}).to_string();
+        (linux, windows, macos)
+    }
+}

--- a/crates/pinset-core/src/flutter_metadata.rs
+++ b/crates/pinset-core/src/flutter_metadata.rs
@@ -34,13 +34,19 @@ struct FlutterIndex {
 
 #[derive(Debug, Clone, Deserialize)]
 struct FlutterIndexRelease {
+    #[serde(default)]
     hash: String,
+    #[serde(default)]
     channel: String,
+    #[serde(default)]
     version: String,
+    #[serde(default)]
     dart_sdk_version: String,
     #[serde(default)]
     dart_sdk_arch: String,
+    #[serde(default)]
     archive: String,
+    #[serde(default)]
     sha256: String,
 }
 
@@ -407,6 +413,24 @@ mod tests {
             artifact.sha256 == "ab".repeat(32)
                 && artifact.verification == "flutter-release-json-sha256-source:custom"
         }));
+    }
+
+    #[test]
+    fn skips_incomplete_historical_release_records() {
+        let body = serde_json::json!({
+            "releases": [{
+                "hash": "cd".repeat(20),
+                "channel": "stable",
+                "version": "1.0.0",
+                "archive": "stable/linux/flutter_linux_1.0.0-stable.tar.xz",
+                "sha256": "ab".repeat(32)
+            }]
+        })
+        .to_string();
+
+        let parsed = parse_index(&body, "linux", &["linux-x86_64"])
+            .expect("incomplete records remain parseable");
+        assert!(parsed[0].1.is_empty());
     }
 
     fn release_fixtures(version: &str, complete: bool) -> (String, String, String) {

--- a/crates/pinset-core/src/flutter_provider.rs
+++ b/crates/pinset-core/src/flutter_provider.rs
@@ -1,0 +1,138 @@
+use crate::{Error, ResolvedArtifactSource, Result, SourceConfig};
+
+pub const FLUTTER_TARGETS: [&str; 4] = [
+    "windows-x86_64",
+    "macos-aarch64",
+    "macos-x86_64",
+    "linux-x86_64",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlutterArchiveFormat {
+    Zip,
+    TarXz,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FlutterArtifactPlan {
+    pub version: String,
+    pub target: String,
+    pub dart_arch: &'static str,
+    pub release_path: String,
+    pub artifact_path: String,
+    pub archive_root: String,
+    pub format: FlutterArchiveFormat,
+    pub canonical_url: String,
+    pub sources: Vec<ResolvedArtifactSource>,
+}
+
+pub fn plan_flutter_artifact(
+    config: &SourceConfig,
+    version: &str,
+    target: &str,
+) -> Result<FlutterArtifactPlan> {
+    validate_exact_flutter_version(version)?;
+    let (release_path, dart_arch, format) = match target {
+        "windows-x86_64" => (
+            format!("stable/windows/flutter_windows_{version}-stable.zip"),
+            "x64",
+            FlutterArchiveFormat::Zip,
+        ),
+        "linux-x86_64" => (
+            format!("stable/linux/flutter_linux_{version}-stable.tar.xz"),
+            "x64",
+            FlutterArchiveFormat::TarXz,
+        ),
+        "macos-x86_64" => (
+            format!("stable/macos/flutter_macos_{version}-stable.zip"),
+            "x64",
+            FlutterArchiveFormat::Zip,
+        ),
+        "macos-aarch64" => (
+            format!("stable/macos/flutter_macos_arm64_{version}-stable.zip"),
+            "arm64",
+            FlutterArchiveFormat::Zip,
+        ),
+        _ => {
+            return Err(Error::UnsupportedFlutterTarget {
+                target: target.to_owned(),
+            });
+        }
+    };
+    let artifact_path = format!("flutter_infra_release/releases/{release_path}");
+    let canonical_url = config.official_artifact_url("flutter", &artifact_path)?;
+    let sources = config.resolve_artifact_sources("flutter", &artifact_path)?;
+
+    Ok(FlutterArtifactPlan {
+        version: version.to_owned(),
+        target: target.to_owned(),
+        dart_arch,
+        release_path,
+        artifact_path,
+        archive_root: "flutter".to_owned(),
+        format,
+        canonical_url,
+        sources,
+    })
+}
+
+pub fn validate_exact_flutter_version(version: &str) -> Result<()> {
+    let parts = version.split('.').collect::<Vec<_>>();
+    if parts.len() != 3
+        || parts.iter().any(|part| {
+            part.is_empty()
+                || !part.bytes().all(|byte| byte.is_ascii_digit())
+                || part.parse::<u64>().is_err()
+        })
+    {
+        return Err(Error::InvalidFlutterVersion {
+            version: version.to_owned(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plans_official_stable_archives_for_every_pinset_target() {
+        let config = SourceConfig::default();
+        let linux = plan_flutter_artifact(&config, "3.47.0", "linux-x86_64").expect("linux plan");
+        assert_eq!(linux.format, FlutterArchiveFormat::TarXz);
+        assert_eq!(
+            linux.canonical_url,
+            "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.47.0-stable.tar.xz"
+        );
+
+        let macos = plan_flutter_artifact(&config, "3.47.0", "macos-aarch64").expect("macOS plan");
+        assert_eq!(macos.format, FlutterArchiveFormat::Zip);
+        assert_eq!(macos.dart_arch, "arm64");
+        assert_eq!(
+            macos.release_path,
+            "stable/macos/flutter_macos_arm64_3.47.0-stable.zip"
+        );
+
+        let windows =
+            plan_flutter_artifact(&config, "3.47.0", "windows-x86_64").expect("windows plan");
+        assert_eq!(
+            windows.release_path,
+            "stable/windows/flutter_windows_3.47.0-stable.zip"
+        );
+    }
+
+    #[test]
+    fn rejects_non_exact_versions_and_unsupported_targets() {
+        for version in ["3", "3.47", "v3.47.0", "3.47.0-beta"] {
+            assert!(matches!(
+                plan_flutter_artifact(&SourceConfig::default(), version, "linux-x86_64"),
+                Err(Error::InvalidFlutterVersion { .. })
+            ));
+        }
+        assert!(matches!(
+            plan_flutter_artifact(&SourceConfig::default(), "3.47.0", "linux-aarch64"),
+            Err(Error::UnsupportedFlutterTarget { .. })
+        ));
+    }
+}

--- a/crates/pinset-core/src/flutter_runtime.rs
+++ b/crates/pinset-core/src/flutter_runtime.rs
@@ -1,0 +1,119 @@
+use std::path::{Path, PathBuf};
+
+use crate::{
+    ArtifactFormat, ArtifactSource, ArtifactSourceKind, ArtifactSpec, Error, FlutterArchiveFormat,
+    InstallOutcome, InstallRequest, Installer, LockedArtifactFormat, LockedTool, Result,
+    SourceConfig, SourceKind, plan_flutter_artifact,
+};
+
+pub fn install_locked_flutter(
+    installer: &Installer,
+    pinset_home: &Path,
+    source_config: &SourceConfig,
+    locked_flutter: &LockedTool,
+    target: &str,
+) -> Result<InstallOutcome> {
+    if locked_flutter.name != "flutter" || locked_flutter.provider != "flutter-official" {
+        return Err(Error::InvalidLockfile {
+            reason: format!(
+                "{}/{} is not the built-in Flutter provider",
+                locked_flutter.name, locked_flutter.provider
+            ),
+        });
+    }
+    let artifact = locked_flutter
+        .artifact(target)
+        .ok_or_else(|| Error::LockedArtifactMissing {
+            tool: "flutter".to_owned(),
+            target: target.to_owned(),
+        })?;
+    let plan = plan_flutter_artifact(source_config, &locked_flutter.version, target)?;
+    let sources = plan
+        .sources
+        .into_iter()
+        .map(|source| ArtifactSource {
+            id: source.alias,
+            url: source.url,
+            kind: match source.kind {
+                SourceKind::Official => ArtifactSourceKind::Official,
+                SourceKind::Custom => ArtifactSourceKind::Mirror,
+            },
+        })
+        .collect();
+    let required_paths = required_flutter_paths(target)?;
+    let request = InstallRequest {
+        pinset_home: pinset_home.to_path_buf(),
+        tool: "flutter".to_owned(),
+        version: locked_flutter.version.clone(),
+        target: target.to_owned(),
+        artifact: ArtifactSpec {
+            canonical_url: artifact.canonical_url.clone(),
+            sources,
+            integrity: artifact.artifact_integrity()?.canonical(),
+            format: match artifact.format {
+                LockedArtifactFormat::Zip => ArtifactFormat::Zip,
+                LockedArtifactFormat::TarXz => ArtifactFormat::TarXz,
+                LockedArtifactFormat::TarGz => {
+                    return Err(Error::InvalidLockfile {
+                        reason: format!("Flutter artifact {target} cannot use tar.gz"),
+                    });
+                }
+            },
+        },
+        strip_components: 1,
+        include_prefixes: Vec::new(),
+        required_paths: required_paths.clone(),
+        base_artifacts: Vec::new(),
+        executable_paths: if plan.format == FlutterArchiveFormat::TarXz {
+            required_paths
+        } else {
+            Vec::new()
+        },
+    };
+    installer.install(&request)
+}
+
+fn required_flutter_paths(target: &str) -> Result<Vec<PathBuf>> {
+    if target.starts_with("windows-") {
+        Ok(vec![
+            PathBuf::from("bin/flutter.bat"),
+            PathBuf::from("bin/dart.bat"),
+            PathBuf::from("bin/cache/dart-sdk/bin/dart.exe"),
+        ])
+    } else if target.starts_with("linux-") || target.starts_with("macos-") {
+        Ok(vec![
+            PathBuf::from("bin/flutter"),
+            PathBuf::from("bin/dart"),
+            PathBuf::from("bin/cache/dart-sdk/bin/dart"),
+        ])
+    } else {
+        Err(Error::UnsupportedFlutterTarget {
+            target: target.to_owned(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn requires_flutter_and_its_bundled_dart_sdk() {
+        assert_eq!(
+            required_flutter_paths("linux-x86_64").expect("linux paths"),
+            [
+                PathBuf::from("bin/flutter"),
+                PathBuf::from("bin/dart"),
+                PathBuf::from("bin/cache/dart-sdk/bin/dart"),
+            ]
+        );
+        assert_eq!(
+            required_flutter_paths("windows-x86_64").expect("windows paths"),
+            [
+                PathBuf::from("bin/flutter.bat"),
+                PathBuf::from("bin/dart.bat"),
+                PathBuf::from("bin/cache/dart-sdk/bin/dart.exe"),
+            ]
+        );
+    }
+}

--- a/crates/pinset-core/src/go_metadata.rs
+++ b/crates/pinset-core/src/go_metadata.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Reverse, io::Read, time::Duration};
+use std::{cmp::Reverse, collections::BTreeMap, io::Read, time::Duration};
 
 use reqwest::{Url, blocking::Client};
 use serde::Deserialize;
@@ -122,6 +122,7 @@ impl GoMetadataClient {
             requested: release.version.clone(),
             version: release.version,
             provider: "go-official".to_owned(),
+            metadata: BTreeMap::new(),
             artifacts,
         })
     }

--- a/crates/pinset-core/src/installer.rs
+++ b/crates/pinset-core/src/installer.rs
@@ -137,6 +137,20 @@ impl Default for InstallLimits {
     }
 }
 
+impl InstallLimits {
+    pub fn for_tool(tool: &str) -> Self {
+        if tool == "flutter" {
+            return Self {
+                max_download_bytes: 3 * 1_073_741_824,
+                max_unpacked_bytes: 12 * 1_073_741_824,
+                max_archive_entries: 250_000,
+                request_timeout: Duration::from_secs(900),
+            };
+        }
+        Self::default()
+    }
+}
+
 pub struct Installer {
     client: Client,
     limits: InstallLimits,
@@ -729,6 +743,7 @@ impl Installer {
         }
 
         let mut seen = HashSet::with_capacity(archive.len());
+        let mut pending_symlinks = Vec::new();
         let mut total_unpacked = 0_u64;
         for index in 0..archive.len() {
             let mut entry = archive
@@ -740,7 +755,10 @@ impl Installer {
                 .ok_or_else(|| Error::UnsafeArchiveEntry {
                     entry: entry_name.clone(),
                 })?;
-            if !is_safe_relative(&archived_path) || is_special_zip_entry(entry.unix_mode()) {
+            let unix_mode = entry.unix_mode();
+            let is_symlink = is_zip_symlink(unix_mode);
+            if !is_safe_relative(&archived_path) || (is_special_zip_entry(unix_mode) && !is_symlink)
+            {
                 return Err(Error::UnsafeArchiveEntry { entry: entry_name });
             }
             let Some(relative) = strip_entry_path(
@@ -764,6 +782,32 @@ impl Installer {
                     path: output_path,
                     source,
                 })?;
+                continue;
+            }
+            if is_symlink {
+                if entry.size() > 4096 {
+                    return Err(Error::UnsafeArchiveEntry { entry: entry_name });
+                }
+                let mut target = Vec::with_capacity(entry.size() as usize);
+                entry
+                    .read_to_end(&mut target)
+                    .map_err(|source| Error::ExtractArchiveEntry {
+                        entry: entry_name.clone(),
+                        path: output_path.clone(),
+                        source,
+                    })?;
+                let link_target = String::from_utf8(target).map(PathBuf::from).map_err(|_| {
+                    Error::UnsafeArchiveEntry {
+                        entry: entry_name.clone(),
+                    }
+                })?;
+                let resolved_target =
+                    resolve_archive_symlink(&relative, &link_target).ok_or_else(|| {
+                        Error::UnsafeArchiveEntry {
+                            entry: entry_name.clone(),
+                        }
+                    })?;
+                pending_symlinks.push((entry_name, output_path, link_target, resolved_target));
                 continue;
             }
 
@@ -835,6 +879,8 @@ impl Installer {
                 }
             })?;
         }
+
+        create_pending_archive_symlinks(destination, pending_symlinks)?;
 
         Ok(())
     }
@@ -1018,9 +1064,24 @@ impl Installer {
                 }
             })?;
         }
-        for (entry_name, output_path, link_target, resolved_target) in pending_symlinks {
-            if !destination.join(resolved_target).is_file() {
-                return Err(Error::UnsafeArchiveEntry { entry: entry_name });
+        create_pending_archive_symlinks(destination, pending_symlinks)?;
+        Ok(())
+    }
+}
+
+type PendingArchiveSymlink = (String, PathBuf, PathBuf, PathBuf);
+
+fn create_pending_archive_symlinks(
+    destination: &Path,
+    mut pending: Vec<PendingArchiveSymlink>,
+) -> Result<()> {
+    while !pending.is_empty() {
+        let mut remaining = Vec::new();
+        let mut created = 0_usize;
+        for (entry_name, output_path, link_target, resolved_target) in pending {
+            if !destination.join(&resolved_target).exists() {
+                remaining.push((entry_name, output_path, link_target, resolved_target));
+                continue;
             }
             if let Some(parent) = output_path.parent() {
                 fs::create_dir_all(parent).map_err(|source| Error::ExtractArchiveEntry {
@@ -1036,9 +1097,19 @@ impl Installer {
                     source,
                 }
             })?;
+            created += 1;
         }
-        Ok(())
+        if created == 0 {
+            return Err(Error::UnsafeArchiveEntry {
+                entry: remaining
+                    .first()
+                    .map(|(entry, _, _, _)| entry.clone())
+                    .unwrap_or_else(|| "<symlink>".to_owned()),
+            });
+        }
+        pending = remaining;
     }
+    Ok(())
 }
 
 fn acquire_install_lock(request: &InstallRequest) -> Result<InstallLock> {
@@ -1295,6 +1366,10 @@ fn is_special_zip_entry(mode: Option<u32>) -> bool {
     file_type != 0 && file_type != 0o100000 && file_type != 0o040000
 }
 
+fn is_zip_symlink(mode: Option<u32>) -> bool {
+    mode.is_some_and(|mode| mode & 0o170000 == 0o120000)
+}
+
 fn archive_collision_key(path: &Path) -> String {
     let value = path.to_string_lossy().replace('\\', "/");
     if cfg!(windows) {
@@ -1457,6 +1532,18 @@ mod tests {
 
     use super::*;
     use crate::{download_cache::download_partial_path, download_cache_path};
+
+    #[test]
+    fn raises_archive_limits_only_for_flutter_sdks() {
+        let defaults = InstallLimits::default();
+        let flutter = InstallLimits::for_tool("flutter");
+        assert_eq!(InstallLimits::for_tool("node"), defaults);
+        assert_eq!(InstallLimits::for_tool("go"), defaults);
+        assert!(flutter.max_download_bytes > defaults.max_download_bytes);
+        assert!(flutter.max_unpacked_bytes > defaults.max_unpacked_bytes);
+        assert!(flutter.max_archive_entries > defaults.max_archive_entries);
+        assert!(flutter.request_timeout > defaults.request_timeout);
+    }
 
     #[test]
     fn installs_verified_zip_atomically_from_local_http() {
@@ -1818,6 +1905,62 @@ mod tests {
         assert_transaction_root_is_empty(root.path());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn installs_zip_with_safe_flutter_framework_symlink_chains() {
+        let archive = zip_with_symlink_chain("Versions/Current/FlutterMacOS");
+        let (url, server) = serve_once(archive.clone(), archive.len());
+        let root = tempdir().expect("temp root");
+        let mut request = request(root.path(), url, sha256_hex(&archive));
+        request.target = "macos-aarch64".to_owned();
+        request.strip_components = 1;
+        request.required_paths = vec![
+            PathBuf::from("bin/flutter"),
+            PathBuf::from("FlutterMacOS.framework/FlutterMacOS"),
+        ];
+
+        let outcome = test_installer().install(&request).expect("install");
+        server.join().expect("server");
+
+        assert_eq!(
+            fs::read_link(
+                outcome
+                    .install_dir
+                    .join("FlutterMacOS.framework/Versions/Current")
+            )
+            .expect("version link"),
+            PathBuf::from("A")
+        );
+        assert_eq!(
+            fs::read_link(
+                outcome
+                    .install_dir
+                    .join("FlutterMacOS.framework/FlutterMacOS")
+            )
+            .expect("framework link"),
+            PathBuf::from("Versions/Current/FlutterMacOS")
+        );
+        assert_transaction_root_is_empty(root.path());
+    }
+
+    #[test]
+    fn rejects_zip_symlinks_that_escape_the_install_root() {
+        let archive = zip_with_symlink_chain("../../outside");
+        let (url, server) = serve_once(archive.clone(), archive.len());
+        let root = tempdir().expect("temp root");
+        let mut request = request(root.path(), url, sha256_hex(&archive));
+        request.strip_components = 1;
+
+        let error = test_installer()
+            .install(&request)
+            .expect_err("escaping symlink");
+        server.join().expect("server");
+
+        assert!(matches!(error, Error::UnsafeArchiveEntry { .. }));
+        assert!(!final_dir(root.path()).exists());
+        assert_transaction_root_is_empty(root.path());
+    }
+
     #[test]
     fn rejects_tar_xz_symlinks_that_escape_the_install_root() {
         let archive = tar_xz_with_symlink("../../outside");
@@ -2057,6 +2200,40 @@ mod tests {
                 .expect("zip entry");
             writer.write_all(content).expect("zip content");
         }
+        writer.finish().expect("zip finish").into_inner()
+    }
+
+    fn zip_with_symlink_chain(framework_target: &str) -> Vec<u8> {
+        let cursor = Cursor::new(Vec::new());
+        let mut writer = ZipWriter::new(cursor);
+        let options = SimpleFileOptions::default().unix_permissions(0o755);
+        writer
+            .start_file("flutter/bin/flutter", options)
+            .expect("Flutter executable");
+        writer.write_all(b"fake Flutter").expect("Flutter content");
+        writer
+            .start_file(
+                "flutter/FlutterMacOS.framework/Versions/A/FlutterMacOS",
+                options,
+            )
+            .expect("framework binary");
+        writer
+            .write_all(b"fake framework")
+            .expect("framework content");
+        writer
+            .add_symlink(
+                "flutter/FlutterMacOS.framework/FlutterMacOS",
+                framework_target,
+                options,
+            )
+            .expect("framework symlink");
+        writer
+            .add_symlink(
+                "flutter/FlutterMacOS.framework/Versions/Current",
+                "A",
+                options,
+            )
+            .expect("version symlink");
         writer.finish().expect("zip finish").into_inner()
     }
 

--- a/crates/pinset-core/src/lib.rs
+++ b/crates/pinset-core/src/lib.rs
@@ -2,6 +2,16 @@ mod config;
 #[cfg(feature = "installer")]
 mod download_cache;
 mod error;
+#[cfg(feature = "flutter-metadata")]
+mod flutter_metadata;
+#[cfg(feature = "flutter-provider")]
+mod flutter_provider;
+#[cfg(all(
+    feature = "installer",
+    feature = "flutter-provider",
+    feature = "lockfile"
+))]
+mod flutter_runtime;
 mod global_state;
 #[cfg(feature = "go-metadata")]
 mod go_metadata;
@@ -48,6 +58,19 @@ pub use download_cache::{
     import_download_cache, import_download_cache_with_integrity, list_download_cache,
 };
 pub use error::{Error, Result};
+#[cfg(feature = "flutter-metadata")]
+pub use flutter_metadata::{FlutterMetadataClient, FlutterRelease};
+#[cfg(feature = "flutter-provider")]
+pub use flutter_provider::{
+    FLUTTER_TARGETS, FlutterArchiveFormat, FlutterArtifactPlan, plan_flutter_artifact,
+    validate_exact_flutter_version,
+};
+#[cfg(all(
+    feature = "installer",
+    feature = "flutter-provider",
+    feature = "lockfile"
+))]
+pub use flutter_runtime::install_locked_flutter;
 #[cfg(feature = "state-write")]
 pub use global_state::save_global_config;
 #[cfg(all(feature = "state-write", feature = "lockfile"))]
@@ -103,7 +126,7 @@ pub use resolver::{
     find_system_commands, path_with_selected_runtime, path_with_selected_tools, pinset_home,
     pinset_home_from_env, resolve_command, resolve_command_with_path, resolve_from_env,
     resolve_tool_selection, runtime_command_directory, runtime_environment_for_install,
-    selected_runtime_environment,
+    selected_runtime_environment, validate_managed_runtime_invocation,
 };
 pub use runtime_lifecycle::{
     InstalledToolVersion, ToolVersionReference, UninstallToolOutcome, find_tool_version_references,

--- a/crates/pinset-core/src/lockfile.rs
+++ b/crates/pinset-core/src/lockfile.rs
@@ -9,8 +9,9 @@ use atomic_write_file::AtomicWriteFile;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ArtifactIntegrity, Error, GO_TARGETS, GoArchiveFormat, NodeArchiveFormat, Result, SourceConfig,
-    plan_go_artifact, plan_node_artifact,
+    ArtifactIntegrity, Error, FLUTTER_TARGETS, FlutterArchiveFormat, GO_TARGETS, GoArchiveFormat,
+    NodeArchiveFormat, Result, SourceConfig, plan_flutter_artifact, plan_go_artifact,
+    plan_node_artifact,
 };
 
 pub const LOCKFILE_FILENAME: &str = "pinset.lock";
@@ -38,6 +39,8 @@ pub struct LockedTool {
     pub requested: String,
     pub version: String,
     pub provider: String,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: BTreeMap<String, String>,
     #[serde(rename = "artifact")]
     pub artifacts: Vec<LockedArtifact>,
 }
@@ -100,6 +103,7 @@ impl Lockfile {
                 requested: version.clone(),
                 version,
                 provider: "nodejs-official".to_owned(),
+                metadata: BTreeMap::new(),
                 artifacts,
             }],
         }
@@ -299,6 +303,7 @@ fn validate_locked_tool(tool: &LockedTool) -> Result<()> {
             | ("pnpm", "pnpm-npm")
             | ("bun", "bun-npm")
             | ("go", "go-official")
+            | ("flutter", "flutter-official")
     );
     if !provider_supported {
         return Err(Error::InvalidLockfile {
@@ -316,6 +321,11 @@ fn validate_locked_tool(tool: &LockedTool) -> Result<()> {
             ),
         });
     }
+    if tool.name != "flutter" && !tool.metadata.is_empty() {
+        return Err(Error::InvalidLockfile {
+            reason: format!("{} lock cannot contain provider metadata", tool.name),
+        });
+    }
     let mut targets = HashSet::with_capacity(tool.artifacts.len());
     for artifact in &tool.artifacts {
         if !targets.insert(artifact.target.as_str()) {
@@ -326,6 +336,7 @@ fn validate_locked_tool(tool: &LockedTool) -> Result<()> {
         match tool.name.as_str() {
             "node" => validate_locked_node_artifact(&tool.version, artifact)?,
             "go" => validate_locked_go_artifact(&tool.version, artifact)?,
+            "flutter" => validate_locked_flutter_artifact(&tool.version, artifact)?,
             "pnpm" | "bun" => validate_locked_npm_artifact(tool, artifact)?,
             _ => unreachable!("provider pair checked above"),
         }
@@ -351,6 +362,20 @@ fn validate_locked_tool(tool: &LockedTool) -> Result<()> {
                 reason: "Go lock contains an unsupported artifact target".to_owned(),
             });
         }
+    } else if tool.name == "flutter" {
+        validate_flutter_metadata(tool)?;
+        for target in FLUTTER_TARGETS {
+            if !targets.contains(target) {
+                return Err(Error::InvalidLockfile {
+                    reason: format!("missing Flutter artifact for {target}"),
+                });
+            }
+        }
+        if targets.len() != FLUTTER_TARGETS.len() {
+            return Err(Error::InvalidLockfile {
+                reason: "Flutter lock contains an unsupported artifact target".to_owned(),
+            });
+        }
     } else {
         for (target, _) in npm_tool_targets(&tool.name) {
             if !targets.contains(target) {
@@ -368,6 +393,80 @@ fn validate_locked_tool(tool: &LockedTool) -> Result<()> {
     if tool.artifacts.is_empty() {
         return Err(Error::InvalidLockfile {
             reason: format!("{} has no artifacts", tool.name),
+        });
+    }
+    Ok(())
+}
+
+fn validate_flutter_metadata(tool: &LockedTool) -> Result<()> {
+    let expected = ["channel", "dart_version", "release_hash"];
+    if tool.metadata.len() != expected.len()
+        || expected.iter().any(|key| !tool.metadata.contains_key(*key))
+        || tool.metadata.get("channel").map(String::as_str) != Some("stable")
+        || tool
+            .metadata
+            .get("dart_version")
+            .is_none_or(|value| !is_exact_numeric_triplet(value))
+        || tool.metadata.get("release_hash").is_none_or(|value| {
+            value.len() != 40 || !value.bytes().all(|byte| byte.is_ascii_hexdigit())
+        })
+    {
+        return Err(Error::InvalidLockfile {
+            reason: "Flutter lock metadata must contain stable channel, bundled Dart version and release hash"
+                .to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn is_exact_numeric_triplet(value: &str) -> bool {
+    let parts = value.split('.').collect::<Vec<_>>();
+    parts.len() == 3
+        && parts.iter().all(|part| {
+            !part.is_empty()
+                && part.bytes().all(|byte| byte.is_ascii_digit())
+                && part.parse::<u64>().is_ok()
+        })
+}
+
+fn validate_locked_flutter_artifact(version: &str, artifact: &LockedArtifact) -> Result<()> {
+    let plan = plan_flutter_artifact(&SourceConfig::default(), version, &artifact.target)?;
+    let expected_format = match plan.format {
+        FlutterArchiveFormat::Zip => LockedArtifactFormat::Zip,
+        FlutterArchiveFormat::TarXz => LockedArtifactFormat::TarXz,
+    };
+    if artifact.canonical_url != plan.canonical_url
+        || artifact.artifact_path != plan.artifact_path
+        || artifact.archive_root != plan.archive_root
+        || artifact.format != expected_format
+    {
+        return Err(Error::InvalidLockfile {
+            reason: format!(
+                "artifact identity for {} does not match the built-in Flutter provider",
+                artifact.target
+            ),
+        });
+    }
+    if artifact.artifact_integrity()?.algorithm() != crate::IntegrityAlgorithm::Sha256 {
+        return Err(Error::InvalidLockfile {
+            reason: format!("invalid Flutter SHA-256 for {}", artifact.target),
+        });
+    }
+    if artifact.verification != "flutter-release-json-sha256"
+        && !artifact
+            .verification
+            .starts_with("flutter-release-json-sha256-source:")
+    {
+        return Err(Error::InvalidLockfile {
+            reason: format!("unsupported Flutter verification for {}", artifact.target),
+        });
+    }
+    if !artifact.overlays.is_empty() {
+        return Err(Error::InvalidLockfile {
+            reason: format!(
+                "Flutter artifact {} cannot contain overlays",
+                artifact.target
+            ),
         });
     }
     Ok(())
@@ -678,6 +777,7 @@ mod tests {
             requested: "1.25.1".to_owned(),
             version: "1.25.1".to_owned(),
             provider: "go-official".to_owned(),
+            metadata: BTreeMap::new(),
             artifacts: artifacts.clone(),
         };
         validate_locked_tool(&tool).expect("Go lock");
@@ -694,8 +794,55 @@ mod tests {
             requested: "1.25.1".to_owned(),
             version: "1.25.1".to_owned(),
             provider: "go-official".to_owned(),
+            metadata: BTreeMap::new(),
             artifacts: artifacts.into_iter().skip(1).collect(),
         };
+        assert!(matches!(
+            validate_locked_tool(&incomplete),
+            Err(Error::InvalidLockfile { .. })
+        ));
+    }
+
+    #[test]
+    fn validates_flutter_provider_metadata_identity_and_required_targets() {
+        let artifacts = FLUTTER_TARGETS
+            .into_iter()
+            .map(|target| locked_flutter_artifact("3.47.0", target))
+            .collect::<Vec<_>>();
+        let mut metadata = BTreeMap::new();
+        metadata.insert("channel".to_owned(), "stable".to_owned());
+        metadata.insert("dart_version".to_owned(), "3.13.0".to_owned());
+        metadata.insert("release_hash".to_owned(), "cd".repeat(20));
+        let tool = LockedTool {
+            name: "flutter".to_owned(),
+            requested: "3.47.0".to_owned(),
+            version: "3.47.0".to_owned(),
+            provider: "flutter-official".to_owned(),
+            metadata,
+            artifacts: artifacts.clone(),
+        };
+        validate_locked_tool(&tool).expect("Flutter lock");
+
+        let mut invalid_metadata = tool.clone();
+        invalid_metadata
+            .metadata
+            .insert("channel".to_owned(), "beta".to_owned());
+        assert!(matches!(
+            validate_locked_tool(&invalid_metadata),
+            Err(Error::InvalidLockfile { .. })
+        ));
+
+        let mut invalid_dart_version = tool.clone();
+        invalid_dart_version
+            .metadata
+            .insert("dart_version".to_owned(), "3.13".to_owned());
+        assert!(matches!(
+            validate_locked_tool(&invalid_dart_version),
+            Err(Error::InvalidLockfile { .. })
+        ));
+
+        let mut incomplete = tool;
+        incomplete.artifacts = artifacts.into_iter().skip(1).collect();
         assert!(matches!(
             validate_locked_tool(&incomplete),
             Err(Error::InvalidLockfile { .. })
@@ -726,6 +873,7 @@ mod tests {
             requested: version.to_owned(),
             version: version.to_owned(),
             provider: "pnpm-npm".to_owned(),
+            metadata: BTreeMap::new(),
             artifacts: vec![artifact],
         }
     }
@@ -744,6 +892,25 @@ mod tests {
             },
             archive_root: plan.archive_root,
             verification: "go-download-json-sha256".to_owned(),
+            overlays: Vec::new(),
+        }
+    }
+
+    fn locked_flutter_artifact(version: &str, target: &str) -> LockedArtifact {
+        let plan =
+            plan_flutter_artifact(&SourceConfig::default(), version, target).expect("Flutter plan");
+        LockedArtifact {
+            target: target.to_owned(),
+            canonical_url: plan.canonical_url,
+            artifact_path: plan.artifact_path,
+            sha256: "ab".repeat(32),
+            integrity: None,
+            format: match plan.format {
+                FlutterArchiveFormat::Zip => LockedArtifactFormat::Zip,
+                FlutterArchiveFormat::TarXz => LockedArtifactFormat::TarXz,
+            },
+            archive_root: plan.archive_root,
+            verification: "flutter-release-json-sha256".to_owned(),
             overlays: Vec::new(),
         }
     }

--- a/crates/pinset-core/src/npm_metadata.rs
+++ b/crates/pinset-core/src/npm_metadata.rs
@@ -307,6 +307,7 @@ impl NpmMetadataClient {
             requested: version.to_owned(),
             version: version.to_owned(),
             provider: format!("{tool}-npm"),
+            metadata: std::collections::BTreeMap::new(),
             artifacts,
         })
     }

--- a/crates/pinset-core/src/resolver.rs
+++ b/crates/pinset-core/src/resolver.rs
@@ -392,8 +392,44 @@ pub fn runtime_environment_for_install(
             }
             variables
         }
+        Some(RuntimeEnvironmentKind::Flutter) => {
+            let mut variables = vec![RuntimeEnvironmentVariable {
+                name: "FLUTTER_ROOT",
+                value: install_dir.as_os_str().to_owned(),
+            }];
+            if env::var_os("FLUTTER_SUPPRESS_ANALYTICS").is_none() {
+                variables.push(RuntimeEnvironmentVariable {
+                    name: "FLUTTER_SUPPRESS_ANALYTICS",
+                    value: OsString::from("true"),
+                });
+            }
+            variables
+        }
         Some(RuntimeEnvironmentKind::None) | None => Vec::new(),
     }
+}
+
+pub fn validate_managed_runtime_invocation(
+    tool: &str,
+    command: &str,
+    arguments: &[OsString],
+) -> Result<()> {
+    if tool != "flutter" || command != "flutter" {
+        return Ok(());
+    }
+    let Some(subcommand) = arguments
+        .iter()
+        .filter_map(|argument| argument.to_str())
+        .find(|argument| !argument.starts_with('-'))
+    else {
+        return Ok(());
+    };
+    if matches!(subcommand, "upgrade" | "downgrade" | "channel") {
+        return Err(Error::ManagedFlutterMutation {
+            command: format!("flutter {subcommand}"),
+        });
+    }
+    Ok(())
 }
 
 pub fn runtime_command_directory(tool: &str, install_dir: &Path) -> PathBuf {
@@ -434,6 +470,36 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+
+    #[test]
+    fn blocks_in_place_flutter_sdk_mutations_but_allows_project_commands() {
+        for subcommand in ["upgrade", "downgrade", "channel"] {
+            assert!(matches!(
+                validate_managed_runtime_invocation(
+                    "flutter",
+                    "flutter",
+                    &[OsString::from(subcommand)]
+                ),
+                Err(Error::ManagedFlutterMutation { .. })
+            ));
+            assert!(matches!(
+                validate_managed_runtime_invocation(
+                    "flutter",
+                    "flutter",
+                    &[OsString::from("--verbose"), OsString::from(subcommand)]
+                ),
+                Err(Error::ManagedFlutterMutation { .. })
+            ));
+        }
+        validate_managed_runtime_invocation(
+            "flutter",
+            "flutter",
+            &[OsString::from("pub"), OsString::from("get")],
+        )
+        .expect("flutter pub remains available");
+        validate_managed_runtime_invocation("flutter", "dart", &[OsString::from("--version")])
+            .expect("bundled Dart remains available");
+    }
 
     #[test]
     fn resolves_node_from_nearest_project_config() {

--- a/crates/pinset-core/src/runtime_provider.rs
+++ b/crates/pinset-core/src/runtime_provider.rs
@@ -20,6 +20,7 @@ pub enum RuntimeMetadataKind {
     Node,
     Npm,
     Go,
+    Flutter,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27,12 +28,14 @@ pub enum RuntimeInstallKind {
     Node,
     Npm,
     Go,
+    Flutter,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuntimeEnvironmentKind {
     None,
     Go,
+    Flutter,
 }
 
 const NODE_COMMANDS: &[&str] = &["node", "npm", "npx", "corepack"];
@@ -68,7 +71,21 @@ const GO_PROVIDER: RuntimeProvider = RuntimeProvider {
     installer: RuntimeInstallKind::Go,
     environment: RuntimeEnvironmentKind::Go,
 };
-const PROVIDERS: &[RuntimeProvider] = &[NODE_PROVIDER, PNPM_PROVIDER, BUN_PROVIDER, GO_PROVIDER];
+const FLUTTER_PROVIDER: RuntimeProvider = RuntimeProvider {
+    tool: "flutter",
+    commands: &["flutter", "dart"],
+    command_layout: RuntimeCommandLayout::Bin,
+    metadata: RuntimeMetadataKind::Flutter,
+    installer: RuntimeInstallKind::Flutter,
+    environment: RuntimeEnvironmentKind::Flutter,
+};
+const PROVIDERS: &[RuntimeProvider] = &[
+    NODE_PROVIDER,
+    PNPM_PROVIDER,
+    BUN_PROVIDER,
+    GO_PROVIDER,
+    FLUTTER_PROVIDER,
+];
 
 pub fn runtime_providers() -> &'static [RuntimeProvider] {
     PROVIDERS
@@ -117,9 +134,16 @@ mod tests {
             runtime_provider_for_command("gofmt").map(|provider| provider.tool),
             Some("go")
         );
+        assert_eq!(
+            runtime_provider("flutter").expect("flutter").commands,
+            ["flutter", "dart"]
+        );
+        assert_eq!(
+            runtime_provider_for_command("dart").map(|provider| provider.tool),
+            Some("flutter")
+        );
         assert!(runtime_provider("python").is_none());
         assert!(runtime_provider_for_command("python").is_none());
-        assert!(runtime_provider_for_command("flutter").is_none());
     }
 
     #[test]

--- a/crates/pinset-shim/src/main.rs
+++ b/crates/pinset-shim/src/main.rs
@@ -10,7 +10,7 @@ use std::ffi::OsStr;
 
 use pinset_core::{
     CommandResolution, path_with_selected_tools, pinset_home_from_env, resolve_command_with_path,
-    selected_runtime_environment,
+    selected_runtime_environment, validate_managed_runtime_invocation,
 };
 
 const SHIM_DEPTH_ENV: &str = "PINSET_SHIM_DEPTH";
@@ -44,6 +44,13 @@ fn run() -> Result<i32, Box<dyn std::error::Error>> {
         &[current_executable],
     )?;
     reject_shim_directory_target(&resolution, &home)?;
+    if resolution.source != pinset_core::SelectionSource::System {
+        validate_managed_runtime_invocation(
+            &resolution.tool,
+            &invocation.command,
+            &invocation.arguments,
+        )?;
+    }
 
     let runtime_path = path_with_selected_tools(&resolution.executable, &invocation.cwd, &home)?;
     let mut child = command_for_runtime(&resolution.executable, &invocation.arguments);

--- a/crates/pinset-shim/tests/routing.rs
+++ b/crates/pinset-shim/tests/routing.rs
@@ -195,6 +195,52 @@ fn installed_shim_passes_through_to_system_path_without_recursing() {
     assert!(stdout.contains("source=system"), "stdout: {stdout}");
 }
 
+#[test]
+fn blocks_mutating_a_managed_flutter_sdk_before_invoking_it() {
+    let root = tempdir().expect("temp directory");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    fs::create_dir_all(&project).expect("project");
+    fs::write(
+        project.join("pinset.toml"),
+        "schema = 2\n[tools]\nflutter = \"3.47.0\"\n",
+    )
+    .expect("project config");
+    create_fake_flutter(&home, "3.47.0");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pinset-shim"))
+        .args(["--as", "flutter", "--cwd"])
+        .arg(&project)
+        .args(["--", "upgrade"])
+        .env("PINSET_HOME", &home)
+        .output()
+        .expect("run shim");
+
+    assert!(!output.status.success());
+    assert!(
+        output.stdout.is_empty(),
+        "managed Flutter must not be invoked"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("refusing to run `flutter upgrade` against a Pinset-managed Flutter SDK"),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let dart = Command::new(env!("CARGO_BIN_EXE_pinset-shim"))
+        .args(["--as", "dart", "--cwd"])
+        .arg(&project)
+        .args(["--", "--version"])
+        .env("PINSET_HOME", &home)
+        .output()
+        .expect("run Dart shim");
+    assert!(dart.status.success());
+    let stdout = String::from_utf8_lossy(&dart.stdout);
+    assert!(stdout.contains("dart:3.47.0:--version"), "stdout: {stdout}");
+    assert!(stdout.contains("root="), "stdout: {stdout}");
+}
+
 fn create_fake_node(home: &Path, version: &str) -> PathBuf {
     let install_dir = home
         .join("installs")
@@ -235,6 +281,43 @@ fn create_fake_node(home: &Path, version: &str) -> PathBuf {
         permissions.set_mode(0o755);
         fs::set_permissions(&executable, permissions).expect("fake node permissions");
         executable
+    }
+}
+
+fn create_fake_flutter(home: &Path, version: &str) {
+    let bin = home
+        .join("installs")
+        .join("flutter")
+        .join(version)
+        .join(pinset_core::current_target_for_tool("flutter"))
+        .join("bin");
+    fs::create_dir_all(&bin).expect("Flutter bin");
+
+    #[cfg(windows)]
+    for command in ["flutter", "dart"] {
+        fs::write(
+            bin.join(format!("{command}.cmd")),
+            format!("@echo off\r\necho {command}:%PINSET_SELECTED_VERSION%:%*\r\necho root=%FLUTTER_ROOT%\r\n"),
+        )
+        .expect("fake Flutter command");
+    }
+
+    #[cfg(not(windows))]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        for command in ["flutter", "dart"] {
+            let executable = bin.join(command);
+            fs::write(
+                &executable,
+                format!(
+                    "#!/bin/sh\nprintf '{command}:%s:%s\\nroot=%s\\n' \"$PINSET_SELECTED_VERSION\" \"$*\" \"$FLUTTER_ROOT\"\n"
+                ),
+            )
+            .expect("fake Flutter command");
+            fs::set_permissions(&executable, fs::Permissions::from_mode(0o755))
+                .expect("fake Flutter permissions");
+        }
     }
 }
 

--- a/crates/pinset/Cargo.toml
+++ b/crates/pinset/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap.workspace = true
-pinset-core = { path = "../pinset-core", features = ["go-metadata", "installer", "node-metadata", "npm-metadata", "project-write", "sources", "state-write"] }
+pinset-core = { path = "../pinset-core", features = ["flutter-metadata", "go-metadata", "installer", "node-metadata", "npm-metadata", "project-write", "sources", "state-write"] }
 serde.workspace = true
 serde_json.workspace = true
 terminal_size.workspace = true

--- a/crates/pinset/src/i18n.rs
+++ b/crates/pinset/src/i18n.rs
@@ -210,28 +210,28 @@ impl Catalog {
         match command {
             Some("init") => "创建项目配置。\n\n用法：pinset init",
             Some("global") => {
-                "查看或设置项目之外使用的全局默认运行时。\n\n用法：pinset global [node@lts|pnpm@11|bun@1.3|go@1.25] [--no-install]"
+                "查看或设置项目之外使用的全局默认运行时。\n\n用法：pinset global [node@lts|pnpm@11|bun@1.3|go@1.25|flutter@3.47] [--no-install]"
             }
             Some("use") => {
-                "选择并锁定 Node.js、pnpm、Bun 或 Go 版本。\n\n用法：pinset use <node@24|pnpm@11|bun@1.3|go@1.25> [--global] [--no-install]"
+                "选择并锁定 Node.js、pnpm、Bun、Go 或 Flutter 版本。\n\n用法：pinset use <node@24|pnpm@11|bun@1.3|go@1.25|flutter@3.47> [--global] [--no-install]"
             }
             Some("unset") => {
-                "清除项目或全局运行时选择，不卸载运行时。\n\n用法：pinset unset <node|pnpm|bun|go> [--global] [--cwd <目录>]"
+                "清除项目或全局运行时选择，不卸载运行时。\n\n用法：pinset unset <node|pnpm|bun|go|flutter> [--global] [--cwd <目录>]"
             }
             Some("install") => {
-                "安装指定运行时版本，或根据项目/全局锁文件安装全部工具。\n\n用法：\n  pinset install <node|pnpm|bun|go>@<版本选择器>\n  pinset install [--locked] [--global] [--cwd <目录>]"
+                "安装指定运行时版本，或根据项目/全局锁文件安装全部工具。\n\n用法：\n  pinset install <node|pnpm|bun|go|flutter>@<版本选择器>\n  pinset install [--locked] [--global] [--cwd <目录>]"
             }
             Some("which") => {
                 "显示实际执行的运行时命令路径。\n\n用法：pinset which <命令> [--cwd <目录>]"
             }
             Some("current") => {
-                "显示当前版本、来源和安装路径。\n\n用法：pinset current [node|pnpm|bun|go] [--cwd <目录>]"
+                "显示当前版本、来源和安装路径。\n\n用法：pinset current [node|pnpm|bun|go|flutter] [--cwd <目录>]"
             }
             Some("list") => {
-                "列出本机已安装或官方可用的运行时版本。\n\n用法：pinset list <node|pnpm|bun|go> [--available]"
+                "列出本机已安装或官方可用的运行时版本。\n\n用法：pinset list <node|pnpm|bun|go|flutter> [--available]"
             }
             Some("uninstall") => {
-                "卸载 Pinset 管理的精确运行时版本。\n\n用法：pinset uninstall <node|pnpm|bun|go>@x.y.z [--cwd <目录>] [--force]"
+                "卸载 Pinset 管理的精确运行时版本。\n\n用法：pinset uninstall <node|pnpm|bun|go|flutter>@x.y.z [--cwd <目录>] [--force]"
             }
             Some("cache") => {
                 "查看、清理或离线导入已验证的运行时下载缓存。\n\n用法：pinset cache <list|clean|import>"
@@ -243,7 +243,7 @@ impl Catalog {
                 "只读检查配置、锁文件、运行时、shim 和 PATH。\n\n用法：pinset doctor [--cwd <目录>] [--json]"
             }
             Some("import") => {
-                "预览或显式导入旧 Node.js 管理器配置；不会改写旧文件。\n\n用法：\n  pinset import --dry-run [--cwd <目录>]\n  pinset import --apply [--from <来源>] [--global] [--no-install] [--cwd <目录>]"
+                "预览或显式导入旧 Node.js/FVM 管理器配置；不会改写旧文件。\n\n用法：\n  pinset import --dry-run [--cwd <目录>]\n  pinset import --apply [--from <来源>] [--global] [--no-install] [--cwd <目录>]"
             }
             Some("shim") => {
                 "查看、修复或迁移 Pinset Provider 命令路由。\n\n用法：\n  pinset shim path\n  pinset shim install [--provider <工具>] [--binary <文件>] [--dir <目录>] [命令...]\n  pinset shim migrate [--provider <工具>] [--dir <目录>]"
@@ -475,23 +475,24 @@ impl Catalog {
     pub fn import_none(self, cwd: &Path) -> String {
         match self.language {
             Language::English => format!(
-                "no legacy Node.js version configuration detected in {}",
+                "no supported legacy runtime version configuration detected in {}",
                 cwd.display()
             ),
             Language::SimplifiedChinese => {
-                format!("在 {} 中未检测到旧 Node.js 版本配置", cwd.display())
+                format!("在 {} 中未检测到受支持的旧运行时版本配置", cwd.display())
             }
         }
     }
 
-    pub fn import_candidate(self, kind: &str, version: &str, path: &Path) -> String {
+    pub fn import_candidate(self, kind: &str, tool: &str, version: &str, path: &Path) -> String {
+        let display_tool = if tool == "node" { "Node.js" } else { "Flutter" };
         match self.language {
             Language::English => format!(
-                "detected {kind} node={version} path={} action=none",
+                "detected {kind} {tool}={version} path={} action=none",
                 path.display()
             ),
             Language::SimplifiedChinese => format!(
-                "检测到 {kind}：Node.js {version}；路径={}；操作=无（仅预览）",
+                "检测到 {kind}：{display_tool} {version}；路径={}；操作=无（仅预览）",
                 path.display()
             ),
         }
@@ -500,10 +501,10 @@ impl Catalog {
     pub fn import_conflict(self, versions: usize) -> String {
         match self.language {
             Language::English => format!(
-                "conflict: detected {versions} distinct Node.js versions; no configuration was changed"
+                "conflict: detected {versions} distinct runtime selections; no configuration was changed"
             ),
             Language::SimplifiedChinese => {
-                format!("发现冲突：检测到 {versions} 个不同 Node.js 版本；未修改任何配置")
+                format!("发现冲突：检测到 {versions} 个不同运行时选择；未修改任何配置")
             }
         }
     }
@@ -511,10 +512,10 @@ impl Catalog {
     pub fn import_apply_conflict(self, versions: usize) -> String {
         match self.language {
             Language::English => format!(
-                "cannot import: detected {versions} distinct Node.js selections; pass --from <source>"
+                "cannot import: detected {versions} distinct runtime selections; pass --from <source>"
             ),
             Language::SimplifiedChinese => format!(
-                "无法导入：检测到 {versions} 个不同 Node.js 选择；请使用 --from <来源> 明确指定"
+                "无法导入：检测到 {versions} 个不同运行时选择；请使用 --from <来源> 明确指定"
             ),
         }
     }
@@ -530,14 +531,22 @@ impl Catalog {
         }
     }
 
-    pub fn import_applied(self, kind: &str, version: &str, path: &Path, scope: &str) -> String {
+    pub fn import_applied(
+        self,
+        kind: &str,
+        tool: &str,
+        version: &str,
+        path: &Path,
+        scope: &str,
+    ) -> String {
+        let display_tool = if tool == "node" { "Node.js" } else { "Flutter" };
         match self.language {
             Language::English => format!(
-                "imported {kind} node={version} into Pinset {scope} state; legacy file preserved: {}",
+                "imported {kind} {tool}={version} into Pinset {scope} state; legacy file preserved: {}",
                 path.display()
             ),
             Language::SimplifiedChinese => format!(
-                "已将 {kind} 的 Node.js {version} 导入 Pinset {}状态；旧文件已保留：{}",
+                "已将 {kind} 的 {display_tool} {version} 导入 Pinset {}状态；旧文件已保留：{}",
                 if scope == "global" {
                     "全局"
                 } else {

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -16,22 +16,23 @@ use std::ffi::OsStr;
 
 use clap::{Parser, Subcommand, ValueEnum, error::ErrorKind};
 use pinset_core::{
-    ArtifactIntegrity, DownloadProgressEvent, Error, GlobalConfig, GoMetadataClient, InstallLimits,
-    Installer, LockedTool, Lockfile, NodeMetadataClient, NpmMetadataClient, RuntimeInstallKind,
-    RuntimeMetadataKind, SUPPORTED_SOURCE_PROVIDERS, ShimInstallMethod, SourceView,
-    clean_download_cache, command_tool, create_project_config, current_target_for_tool,
-    ensure_shims, find_optional_project_config, find_project_config, global_config_path,
-    global_lockfile_path, import_download_cache, import_download_cache_with_integrity,
-    install_locked_go, install_locked_node, install_locked_npm_tool, is_managed_command_shim,
-    list_download_cache, list_installed_tool_versions, load_global_config, load_lockfile,
-    load_optional_global_config, load_optional_lockfile, load_project_config, load_source_config,
-    load_user_settings, lockfile_path, path_with_selected_tools, pinset_home, resolve_command,
-    resolve_tool_selection, runtime_command_directory, runtime_environment_for_install,
-    runtime_provider, save_global_config, save_global_state, save_lockfile, save_project_config,
-    save_source_config, save_user_settings, selected_runtime_environment, source_config_path,
-    uninstall_node_version, uninstall_tool_version, user_settings_path, validate_exact_go_version,
-    validate_exact_node_version, validate_lock_matches_selection, validate_lock_matches_tool,
-    validate_lock_matches_tools,
+    ArtifactIntegrity, DownloadProgressEvent, Error, FlutterMetadataClient, GlobalConfig,
+    GoMetadataClient, InstallLimits, Installer, LockedTool, Lockfile, NodeMetadataClient,
+    NpmMetadataClient, RuntimeInstallKind, RuntimeMetadataKind, SUPPORTED_SOURCE_PROVIDERS,
+    ShimInstallMethod, SourceView, clean_download_cache, command_tool, create_project_config,
+    current_target_for_tool, ensure_shims, find_optional_project_config, find_project_config,
+    global_config_path, global_lockfile_path, import_download_cache,
+    import_download_cache_with_integrity, install_locked_flutter, install_locked_go,
+    install_locked_node, install_locked_npm_tool, is_managed_command_shim, list_download_cache,
+    list_installed_tool_versions, load_global_config, load_lockfile, load_optional_global_config,
+    load_optional_lockfile, load_project_config, load_source_config, load_user_settings,
+    lockfile_path, path_with_selected_tools, pinset_home, resolve_command, resolve_tool_selection,
+    runtime_command_directory, runtime_environment_for_install, runtime_provider,
+    save_global_config, save_global_state, save_lockfile, save_project_config, save_source_config,
+    save_user_settings, selected_runtime_environment, source_config_path, uninstall_node_version,
+    uninstall_tool_version, user_settings_path, validate_exact_flutter_version,
+    validate_exact_go_version, validate_exact_node_version, validate_lock_matches_selection,
+    validate_lock_matches_tool, validate_lock_matches_tools, validate_managed_runtime_invocation,
 };
 use serde::Serialize;
 use terminal_size::{Width, terminal_size_of};
@@ -59,7 +60,7 @@ enum Commands {
     Init,
     /// Show or set a default runtime version used outside projects.
     Global {
-        /// Selection such as node@lts, pnpm@11, bun@1.3 or go@1.25.
+        /// Selection such as node@lts, pnpm@11, bun@1.3, go@1.25 or flutter@3.47.
         selection: Option<String>,
         /// Update the global selection and lock without downloading the runtime.
         #[arg(long, requires = "selection")]
@@ -67,7 +68,7 @@ enum Commands {
     },
     /// Select and lock a runtime version for the current project or globally.
     Use {
-        /// Selection such as node@24, pnpm@11, bun@1.3 or go@1.25.
+        /// Selection such as node@24, pnpm@11, bun@1.3, go@1.25 or flutter@3.47.
         selection: String,
         /// Update the selection and lock without downloading the runtime.
         #[arg(long)]
@@ -78,7 +79,7 @@ enum Commands {
     },
     /// Clear a project or global runtime selection without uninstalling anything.
     Unset {
-        /// Tool to clear: node, pnpm, bun or go.
+        /// Tool to clear: node, pnpm, bun, go or flutter.
         tool: String,
         /// Clear the global default instead of the nearest project selection.
         #[arg(long, conflicts_with = "cwd")]
@@ -116,7 +117,7 @@ enum Commands {
     },
     /// List installed or officially available runtime versions.
     List {
-        /// Tool to list: node, pnpm, bun or go.
+        /// Tool to list: node, pnpm, bun, go or flutter.
         tool: String,
         /// Query the official provider index instead of local installations.
         #[arg(long)]
@@ -153,7 +154,7 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// Preview or explicitly import legacy Node.js version files.
+    /// Preview or explicitly import supported legacy runtime version files.
     #[command(group(
         clap::ArgGroup::new("import_mode")
             .required(true)
@@ -166,13 +167,13 @@ enum Commands {
         /// Import one detected value into Pinset without changing the legacy file.
         #[arg(long)]
         apply: bool,
-        /// Select a legacy source when detected files disagree (for example nvm or volta).
+        /// Select a legacy source when detected files disagree (for example nvm, volta or fvm).
         #[arg(long = "from", requires = "apply")]
         source: Option<String>,
         /// Import as the global default instead of the current project selection.
         #[arg(long, requires = "apply")]
         global: bool,
-        /// Write the Pinset selection and lock without installing Node.js.
+        /// Write the Pinset selection and lock without installing the runtime.
         #[arg(long, requires = "apply")]
         no_install: bool,
         #[arg(long)]
@@ -267,7 +268,7 @@ enum SourceCommands {
         /// Allow an HTTP source, intended only for explicitly trusted LAN services.
         #[arg(long)]
         allow_insecure: bool,
-        /// Trust this HTTPS source for Node index and SHASUMS metadata as well as archives.
+        /// Trust this HTTPS source for provider metadata as well as archives.
         #[arg(long, conflicts_with = "allow_insecure")]
         trust_metadata: bool,
     },
@@ -280,7 +281,7 @@ enum SourceCommands {
     },
     /// Remove an inactive custom source.
     Remove { provider: String, alias: String },
-    /// Read-only connectivity and Node index validation for one source.
+    /// Read-only connectivity and provider metadata validation for one source.
     Test {
         provider: String,
         /// Source alias. Defaults to the active source.
@@ -451,6 +452,16 @@ fn run(cli: Cli, catalog: Catalog) -> Result<ExitCode, Box<dyn std::error::Error
                             println!("go@{}", release.version);
                         }
                     }
+                    RuntimeMetadataKind::Flutter => {
+                        for release in
+                            flutter_metadata_client(&pinset_home()?)?.available_releases()?
+                        {
+                            println!(
+                                "flutter@{} dart@{} stable",
+                                release.version, release.dart_version
+                            );
+                        }
+                    }
                 }
             } else {
                 let installed = list_installed_tool_versions(&pinset_home()?, &tool)?;
@@ -562,16 +573,19 @@ fn run(cli: Cli, catalog: Catalog) -> Result<ExitCode, Box<dyn std::error::Error
             cwd,
         } => {
             let cwd = effective_cwd(cwd)?;
-            let candidates = detect_legacy_node_configs(&cwd)?;
+            let mut candidates = detect_legacy_node_configs(&cwd)?;
+            if let Some(candidate) = detect_fvm_config(&cwd)? {
+                candidates.push(candidate);
+            }
             if candidates.is_empty() {
                 println!("{}", catalog.import_none(&cwd));
             } else if dry_run {
                 print_import_candidates(&candidates, catalog);
             } else {
                 let candidate = select_legacy_candidate(&candidates, source.as_deref(), catalog)?;
-                let selector = normalize_legacy_node_selector(&candidate.version)?;
+                let selector = normalize_legacy_selector(&candidate.tool, &candidate.version)?;
                 select_tool(
-                    &format!("node@{selector}"),
+                    &format!("{}@{selector}", candidate.tool),
                     global,
                     no_install,
                     true,
@@ -582,6 +596,7 @@ fn run(cli: Cli, catalog: Catalog) -> Result<ExitCode, Box<dyn std::error::Error
                     "{}",
                     catalog.import_applied(
                         &candidate.kind,
+                        &candidate.tool,
                         &candidate.version,
                         &candidate.path,
                         if global { "global" } else { "project" },
@@ -683,6 +698,9 @@ fn validate_exact_tool_version(
         RuntimeMetadataKind::Go => {
             validate_exact_go_version(version)?;
         }
+        RuntimeMetadataKind::Flutter => {
+            validate_exact_flutter_version(version)?;
+        }
     }
     Ok(())
 }
@@ -707,6 +725,9 @@ fn resolve_locked_tool(
             Ok(client.resolve_tool(tool, &version)?)
         }
         RuntimeMetadataKind::Go => Ok(go_metadata_client(&pinset_home()?)?.resolve_tool(selector)?),
+        RuntimeMetadataKind::Flutter => {
+            Ok(flutter_metadata_client(&pinset_home()?)?.resolve_tool(selector)?)
+        }
     }
 }
 
@@ -999,7 +1020,7 @@ fn install_tool_from_lock(
         .ok_or_else(|| Error::LockedToolMissing {
             tool: tool.to_owned(),
         })?;
-    let installer = Installer::new(InstallLimits::default())?
+    let installer = Installer::new(InstallLimits::for_tool(tool))?
         .with_progress_reporter(download_progress_reporter(catalog));
     let target = current_target_for_tool(tool);
     let provider = runtime_provider(tool).expect("locked tool provider exists");
@@ -1012,6 +1033,10 @@ fn install_tool_from_lock(
         RuntimeInstallKind::Go => {
             let sources = load_source_config(&source_config_path(home))?;
             install_locked_go(&installer, home, &sources, locked_tool, &target)?
+        }
+        RuntimeInstallKind::Flutter => {
+            let sources = load_source_config(&source_config_path(home))?;
+            install_locked_flutter(&installer, home, &sources, locked_tool, &target)?
         }
     };
     if outcome.reused_existing {
@@ -1495,6 +1520,9 @@ fn execute_selected(
             )
         };
     let runtime_path = path_with_selected_tools(&executable, cwd, &home)?;
+    if source != "system" {
+        validate_managed_runtime_invocation(&tool, command_name, &command[1..])?;
+    }
     let mut child = command_for_runtime(&executable);
     child
         .args(&command[1..])
@@ -1604,6 +1632,7 @@ struct DoctorRoutingIssue {
 
 #[derive(Debug, Clone, Serialize)]
 struct LegacyNodeConfig {
+    tool: String,
     kind: String,
     version: String,
     path: PathBuf,
@@ -1850,6 +1879,7 @@ fn detect_legacy_node_configs(
             let version = fs::read_to_string(&path)?.trim().to_owned();
             if !version.is_empty() {
                 candidates.push(LegacyNodeConfig {
+                    tool: "node".to_owned(),
                     kind: kind.to_owned(),
                     version,
                     path,
@@ -1867,6 +1897,7 @@ fn detect_legacy_node_configs(
             .and_then(serde_json::Value::as_str)
         {
             candidates.push(LegacyNodeConfig {
+                tool: "node".to_owned(),
                 kind: "volta".to_owned(),
                 version: version.to_owned(),
                 path,
@@ -1884,6 +1915,7 @@ fn detect_legacy_node_configs(
                 .flatten()
         }) {
             candidates.push(LegacyNodeConfig {
+                tool: "node".to_owned(),
                 kind: "asdf".to_owned(),
                 version: version.to_owned(),
                 path,
@@ -1902,6 +1934,7 @@ fn detect_legacy_node_configs(
                     .and_then(toml::Value::as_str)
             }) {
                 candidates.push(LegacyNodeConfig {
+                    tool: "node".to_owned(),
                     kind: "mise".to_owned(),
                     version: version.to_owned(),
                     path,
@@ -1912,15 +1945,42 @@ fn detect_legacy_node_configs(
     Ok(candidates)
 }
 
+fn detect_fvm_config(cwd: &Path) -> Result<Option<LegacyNodeConfig>, Box<dyn std::error::Error>> {
+    let path = cwd.join(".fvmrc");
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let value = serde_json::from_str::<serde_json::Value>(&fs::read_to_string(&path)?)?;
+    let Some(version) = value.get("flutter").and_then(serde_json::Value::as_str) else {
+        return Err(format!(
+            "{} does not contain a string flutter version",
+            path.display()
+        )
+        .into());
+    };
+    validate_exact_flutter_version(version)?;
+    Ok(Some(LegacyNodeConfig {
+        tool: "flutter".to_owned(),
+        kind: "fvm".to_owned(),
+        version: version.to_owned(),
+        path,
+    }))
+}
+
 fn print_import_candidates(candidates: &[LegacyNodeConfig], catalog: Catalog) {
     let distinct = candidates
         .iter()
-        .map(|candidate| candidate.version.as_str())
+        .map(|candidate| (candidate.tool.as_str(), candidate.version.as_str()))
         .collect::<std::collections::BTreeSet<_>>();
     for candidate in candidates {
         println!(
             "{}",
-            catalog.import_candidate(&candidate.kind, &candidate.version, &candidate.path,)
+            catalog.import_candidate(
+                &candidate.kind,
+                &candidate.tool,
+                &candidate.version,
+                &candidate.path,
+            )
         );
     }
     if distinct.len() > 1 {
@@ -1951,12 +2011,26 @@ fn select_legacy_candidate<'a>(
 
     let normalized = candidates
         .iter()
-        .map(|candidate| normalize_legacy_node_selector(&candidate.version))
+        .map(|candidate| {
+            normalize_legacy_selector(&candidate.tool, &candidate.version)
+                .map(|version| (candidate.tool.clone(), version))
+        })
         .collect::<Result<std::collections::BTreeSet<_>, _>>()?;
     if normalized.len() > 1 {
         return Err(catalog.import_apply_conflict(normalized.len()).into());
     }
     Ok(&candidates[0])
+}
+
+fn normalize_legacy_selector(
+    tool: &str,
+    value: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    if tool == "flutter" {
+        validate_exact_flutter_version(value)?;
+        return Ok(value.to_owned());
+    }
+    normalize_legacy_node_selector(value)
 }
 
 fn normalize_legacy_node_selector(value: &str) -> Result<String, Box<dyn std::error::Error>> {
@@ -2376,6 +2450,18 @@ fn run_source_command(
                     }
                     releases.len()
                 }
+                Some(RuntimeMetadataKind::Flutter) => {
+                    let client = FlutterMetadataClient::for_base_url(&source.base_url)?;
+                    let releases = client.available_releases()?;
+                    if releases.is_empty() {
+                        return Err(Error::InvalidFlutterIndex {
+                            reason: "source indexes contain no supported stable releases"
+                                .to_owned(),
+                        }
+                        .into());
+                    }
+                    releases.len()
+                }
                 Some(RuntimeMetadataKind::Npm) | None => {
                     return Err(format!(
                         "source testing is not available for provider {provider:?}"
@@ -2480,6 +2566,21 @@ fn go_metadata_client(home: &Path) -> Result<GoMetadataClient, Box<dyn std::erro
         Ok(GoMetadataClient::official()?)
     } else {
         Ok(GoMetadataClient::for_source(
+            &source.base_url,
+            &source.alias,
+        )?)
+    }
+}
+
+fn flutter_metadata_client(
+    home: &Path,
+) -> Result<FlutterMetadataClient, Box<dyn std::error::Error>> {
+    let config = load_source_config(&source_config_path(home))?;
+    let source = config.metadata_source("flutter")?;
+    if source.kind == pinset_core::SourceKind::Official {
+        Ok(FlutterMetadataClient::official()?)
+    } else {
+        Ok(FlutterMetadataClient::for_source(
             &source.base_url,
             &source.alias,
         )?)

--- a/crates/pinset/tests/flutter_cli.rs
+++ b/crates/pinset/tests/flutter_cli.rs
@@ -1,0 +1,169 @@
+use std::{
+    fs,
+    path::Path,
+    process::{Command, Output},
+};
+
+use tempfile::tempdir;
+
+#[test]
+fn resolves_lists_and_executes_a_managed_flutter_sdk_with_its_bundled_dart() {
+    let root = tempdir().expect("root");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    fs::create_dir(&project).expect("project");
+    fs::write(
+        project.join("pinset.toml"),
+        "schema = 2\n\n[tools]\nflutter = \"3.47.0\"\n",
+    )
+    .expect("config");
+
+    let install_dir = home
+        .join("installs/flutter/3.47.0")
+        .join(pinset_core::current_target_for_tool("flutter"));
+    let bin_dir = install_dir.join("bin");
+    fs::create_dir_all(&bin_dir).expect("Flutter bin");
+    write_flutter_command(&bin_dir);
+    write_dart_command(&bin_dir);
+    fs::write(
+        install_dir.join(".pinset-install.toml"),
+        format!(
+            "schema = 2\ncomplete = true\ntool = \"flutter\"\nversion = \"3.47.0\"\ntarget = \"{}\"\n",
+            pinset_core::current_target_for_tool("flutter")
+        ),
+    )
+    .expect("receipt");
+
+    assert_success_contains(
+        &pinset(&project, &home, &["list", "flutter"]),
+        "flutter@3.47.0",
+    );
+    assert_success_contains(
+        &pinset(&project, &home, &["current", "flutter"]),
+        "flutter 3.47.0 installed",
+    );
+    assert_success_contains(
+        &pinset(&project, &home, &["which", "dart"]),
+        &bin_dir.display().to_string(),
+    );
+
+    let flutter = pinset(&project, &home, &["exec", "--", "flutter", "--version"]);
+    assert_success_contains(&flutter, "fake-flutter-3.47.0 --version");
+    assert_success_contains(&flutter, &format!("FLUTTER_ROOT={}", install_dir.display()));
+    assert_success_contains(&flutter, "FLUTTER_SUPPRESS_ANALYTICS=true");
+
+    let dart = pinset(&project, &home, &["exec", "--", "dart", "--version"]);
+    assert_success_contains(&dart, "fake-dart-3.13.0 --version");
+    assert_success_contains(&dart, &format!("FLUTTER_ROOT={}", install_dir.display()));
+
+    let explicit_policy = Command::new(env!("CARGO_BIN_EXE_pinset"))
+        .current_dir(&project)
+        .env("PINSET_HOME", &home)
+        .env("PINSET_LANG", "en")
+        .env("FLUTTER_SUPPRESS_ANALYTICS", "false")
+        .args(["exec", "--", "flutter", "doctor"])
+        .output()
+        .expect("run with explicit analytics policy");
+    assert_success_contains(&explicit_policy, "FLUTTER_SUPPRESS_ANALYTICS=false");
+
+    let mutation = pinset(&project, &home, &["exec", "--", "flutter", "upgrade"]);
+    assert!(!mutation.status.success());
+    assert!(
+        String::from_utf8_lossy(&mutation.stderr)
+            .contains("refusing to run `flutter upgrade` against a Pinset-managed Flutter SDK"),
+        "stderr: {}",
+        String::from_utf8_lossy(&mutation.stderr)
+    );
+    assert!(
+        mutation.stdout.is_empty(),
+        "managed Flutter must not be invoked"
+    );
+
+    assert_success_contains(
+        &pinset(&project, &home, &["exec", "--", "flutter", "pub", "get"]),
+        "fake-flutter-3.47.0 pub get",
+    );
+}
+
+#[test]
+fn previews_an_fvm_project_without_changing_it() {
+    let root = tempdir().expect("root");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    fs::create_dir(&project).expect("project");
+    fs::write(
+        project.join(".fvmrc"),
+        "{\n  \"flutter\": \"3.47.0\",\n  \"flavors\": {}\n}\n",
+    )
+    .expect("FVM config");
+
+    let preview = pinset(&project, &home, &["import", "--dry-run"]);
+    assert_success_contains(&preview, "detected fvm flutter=3.47.0");
+    assert_success_contains(&preview, "action=none");
+    assert!(!project.join("pinset.toml").exists());
+    assert!(!project.join("pinset.lock").exists());
+    assert!(!home.exists());
+}
+
+#[cfg(windows)]
+fn write_flutter_command(directory: &Path) {
+    fs::write(
+        directory.join("flutter.cmd"),
+        "@echo off\r\necho fake-flutter-3.47.0 %*\r\necho FLUTTER_ROOT=%FLUTTER_ROOT%\r\necho FLUTTER_SUPPRESS_ANALYTICS=%FLUTTER_SUPPRESS_ANALYTICS%\r\n",
+    )
+    .expect("flutter command");
+}
+
+#[cfg(unix)]
+fn write_flutter_command(directory: &Path) {
+    write_unix_command(
+        &directory.join("flutter"),
+        "#!/bin/sh\nprintf 'fake-flutter-3.47.0 %s\\nFLUTTER_ROOT=%s\\nFLUTTER_SUPPRESS_ANALYTICS=%s\\n' \"$*\" \"$FLUTTER_ROOT\" \"$FLUTTER_SUPPRESS_ANALYTICS\"\n",
+    );
+}
+
+#[cfg(windows)]
+fn write_dart_command(directory: &Path) {
+    fs::write(
+        directory.join("dart.cmd"),
+        "@echo off\r\necho fake-dart-3.13.0 %*\r\necho FLUTTER_ROOT=%FLUTTER_ROOT%\r\n",
+    )
+    .expect("dart command");
+}
+
+#[cfg(unix)]
+fn write_dart_command(directory: &Path) {
+    write_unix_command(
+        &directory.join("dart"),
+        "#!/bin/sh\nprintf 'fake-dart-3.13.0 %s\\nFLUTTER_ROOT=%s\\n' \"$*\" \"$FLUTTER_ROOT\"\n",
+    );
+}
+
+#[cfg(unix)]
+fn write_unix_command(path: &Path, body: &str) {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::write(path, body).expect("command");
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("executable");
+}
+
+fn pinset(project: &Path, home: &Path, arguments: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_pinset"))
+        .current_dir(project)
+        .env("PINSET_HOME", home)
+        .env("PINSET_LANG", "en")
+        .env_remove("FLUTTER_ROOT")
+        .env_remove("FLUTTER_SUPPRESS_ANALYTICS")
+        .args(arguments)
+        .output()
+        .expect("run pinset")
+}
+
+fn assert_success_contains(output: &Output, expected: &str) {
+    assert!(
+        output.status.success() && String::from_utf8_lossy(&output.stdout).contains(expected),
+        "expected {expected:?}\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/pinset/tests/language_cli.rs
+++ b/crates/pinset/tests/language_cli.rs
@@ -49,8 +49,8 @@ fn saves_chinese_and_uses_it_for_following_commands() {
     assert!(stderr.contains("版本选择必须使用"), "stderr: {stderr}");
 
     let help = pinset(&first_project, &home, &["--lang", "zh-CN", "use", "--help"]);
-    assert_success_contains(&help, "选择并锁定 Node.js、pnpm、Bun 或 Go 版本");
-    assert_success_contains(&help, "node@24|pnpm@11|bun@1.3|go@1.25");
+    assert_success_contains(&help, "选择并锁定 Node.js、pnpm、Bun、Go 或 Flutter 版本");
+    assert_success_contains(&help, "node@24|pnpm@11|bun@1.3|go@1.25|flutter@3.47");
     assert!(
         !String::from_utf8_lossy(&help.stdout).contains("Usage:"),
         "help should be localized: {}",
@@ -80,7 +80,7 @@ fn saves_chinese_and_uses_it_for_following_commands() {
     );
     assert_success_contains(
         &install_help,
-        "pinset install <node|pnpm|bun|go>@<版本选择器>",
+        "pinset install <node|pnpm|bun|go|flutter>@<版本选择器>",
     );
 
     let import_help = pinset(

--- a/crates/pinset/tests/mvp_cli.rs
+++ b/crates/pinset/tests/mvp_cli.rs
@@ -758,7 +758,9 @@ fn create_fake_system_node(directory: &Path) -> PathBuf {
             "@echo off\r\nif \"%1\"==\"exit23\" exit /b 23\r\necho system:%*\r\necho source=%PINSET_SELECTION_SOURCE%\r\n",
         )
         .expect("fake system node");
-        for command in ["npm", "npx", "corepack", "pnpm", "bun", "bunx"] {
+        for command in [
+            "npm", "npx", "corepack", "pnpm", "bun", "bunx", "go", "gofmt", "flutter", "dart",
+        ] {
             fs::write(
                 directory.join(format!("{command}.cmd")),
                 format!("@echo off\r\necho fake {command}\r\n"),
@@ -783,7 +785,9 @@ fn create_fake_system_node(directory: &Path) -> PathBuf {
             .permissions();
         permissions.set_mode(0o755);
         fs::set_permissions(&executable, permissions).expect("fake system node permissions");
-        for command in ["npm", "npx", "corepack", "pnpm", "bun", "bunx"] {
+        for command in [
+            "npm", "npx", "corepack", "pnpm", "bun", "bunx", "go", "gofmt", "flutter", "dart",
+        ] {
             let command_path = directory.join(command);
             fs::write(
                 &command_path,

--- a/crates/pinset/tests/mvp_cli.rs
+++ b/crates/pinset/tests/mvp_cli.rs
@@ -291,7 +291,8 @@ fn doctor_reports_all_provider_commands_and_path_shadowing() {
     assert_eq!(
         commands,
         [
-            "bun", "bunx", "corepack", "go", "gofmt", "node", "npm", "npx", "pnpm",
+            "bun", "bunx", "corepack", "dart", "flutter", "go", "gofmt", "node", "npm", "npx",
+            "pnpm",
         ]
         .into_iter()
         .collect()

--- a/crates/pinset/tests/source_cli.rs
+++ b/crates/pinset/tests/source_cli.rs
@@ -274,7 +274,7 @@ fn tests_a_flutter_source_read_only_against_all_platform_indexes() {
             "--allow-insecure",
         ],
     )
-    .assert_success("added Flutter local");
+    .assert_success("added flutter local");
     let tested = pinset(
         &home,
         &["--lang", "zh-CN", "source", "test", "flutter", "local"],

--- a/crates/pinset/tests/source_cli.rs
+++ b/crates/pinset/tests/source_cli.rs
@@ -211,6 +211,80 @@ fn tests_a_go_source_read_only_against_its_download_index() {
     assert!(!home.join("installs").exists());
 }
 
+#[test]
+fn tests_a_flutter_source_read_only_against_all_platform_indexes() {
+    let root = tempdir().expect("temporary PINSET_HOME");
+    let home = root.path().join("isolated-home");
+    let version = "3.47.0";
+    let release_hash = "cd".repeat(20);
+    let sha256 = "ab".repeat(32);
+    let entry = |archive: &str, dart_arch: &str| {
+        serde_json::json!({
+            "hash": release_hash.clone(),
+            "channel": "stable",
+            "version": version,
+            "dart_sdk_version": "3.13.0",
+            "dart_sdk_arch": dart_arch,
+            "archive": archive,
+            "sha256": sha256.clone()
+        })
+    };
+    let linux = serde_json::json!({"releases": [entry(
+        "stable/linux/flutter_linux_3.47.0-stable.tar.xz",
+        "x64"
+    )]})
+    .to_string()
+    .into_bytes();
+    let windows = serde_json::json!({"releases": [entry(
+        "stable/windows/flutter_windows_3.47.0-stable.zip",
+        "x64"
+    )]})
+    .to_string()
+    .into_bytes();
+    let macos = serde_json::json!({"releases": [
+        entry("stable/macos/flutter_macos_3.47.0-stable.zip", "x64"),
+        entry("stable/macos/flutter_macos_arm64_3.47.0-stable.zip", "arm64")
+    ]})
+    .to_string()
+    .into_bytes();
+    let (base_url, server) = serve_sequence(vec![
+        (
+            "GET /flutter_infra_release/releases/releases_linux.json",
+            linux,
+        ),
+        (
+            "GET /flutter_infra_release/releases/releases_windows.json",
+            windows,
+        ),
+        (
+            "GET /flutter_infra_release/releases/releases_macos.json",
+            macos,
+        ),
+    ]);
+
+    pinset(
+        &home,
+        &[
+            "source",
+            "add",
+            "flutter",
+            "local",
+            "--base-url",
+            &base_url,
+            "--allow-insecure",
+        ],
+    )
+    .assert_success("added Flutter local");
+    let tested = pinset(
+        &home,
+        &["--lang", "zh-CN", "source", "test", "flutter", "local"],
+    );
+    server.join().expect("server");
+    tested.assert_success_contains("安装源测试通过");
+    tested.assert_success_contains("稳定版本数=1");
+    assert!(!home.join("installs").exists());
+}
+
 fn serve_sequence(responses: Vec<(&'static str, Vec<u8>)>) -> (String, thread::JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind server");
     let address = listener.local_addr().expect("server address");

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -36,7 +36,7 @@ Pinset 将继续保持“一个工具统一选择、安装、锁定和路由开�
 | `v0.2.0` | 已发布 | pnpm、Bun Provider，通用 Provider/锁文件/命令路由基础 |
 | `v0.2.1` | 已发布 | pnpm、Bun 项目版本切换和安装路径修复 |
 | `v0.3.0` | 已发布 | Go Provider、Native Provider 通用化 |
-| `v0.4.0` | 规划中 | Flutter SDK Provider、内置 Dart 路由 |
+| `v0.4.0` | 开发中 | Flutter SDK Provider、内置 Dart 路由 |
 | `v0.5.0` | 规划中 | CPython Provider |
 | `v0.6.0` | 规划中 | Eclipse Temurin JDK Provider |
 | `v0.7.0` | 规划中 | rustup 委托式 Rust Provider |
@@ -75,6 +75,8 @@ Pinset 将继续保持“一个工具统一选择、安装、锁定和路由开�
 - Node.js、pnpm、Bun 既有行为没有回归。
 
 ## v0.4.0 — Flutter SDK Provider
+
+实现状态：核心 Provider、锁文件、安装与路由已进入功能分支开发；三平台 GitHub Actions 真实 SDK 验收尚未执行。
 
 ### 目标
 

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -1,10 +1,10 @@
 # Pinset Plans
 
-当前规划版本：`v0.4.0`
+当前规划版本：`v0.5.0`
 
 当前发布候选：无
 
-最新已发布版本：`v0.3.0`
+最新已发布版本：`v0.4.0`
 
 更新时间：`2026-08-13`
 
@@ -20,7 +20,7 @@ Pinset 将继续保持“一个工具统一选择、安装、锁定和路由开�
 4. `v0.6.0`：Java，首期仅支持 Eclipse Temurin JDK。
 5. `v0.7.0`：Rust，通过 rustup 委托管理工具链。
 
-各版本暂不承诺日期。只有对应 Provider 在 Ubuntu、Windows、macOS 三平台 GitHub Actions 虚拟机完成真实安装和命令验证后，才能进入发布流程。
+各版本暂不承诺日期。GitHub Actions 负责三平台构建、质量检查和体积适合自动化的真实运行时验收；Flutter SDK 等超大工件保留完整验收脚本，发布后由隔离虚拟机执行，避免持续占用托管 Runner。
 
 ## 版本路线
 
@@ -36,7 +36,7 @@ Pinset 将继续保持“一个工具统一选择、安装、锁定和路由开�
 | `v0.2.0` | 已发布 | pnpm、Bun Provider，通用 Provider/锁文件/命令路由基础 |
 | `v0.2.1` | 已发布 | pnpm、Bun 项目版本切换和安装路径修复 |
 | `v0.3.0` | 已发布 | Go Provider、Native Provider 通用化 |
-| `v0.4.0` | 开发中 | Flutter SDK Provider、内置 Dart 路由 |
+| `v0.4.0` | 已发布 | Flutter SDK Provider、内置 Dart 路由 |
 | `v0.5.0` | 规划中 | CPython Provider |
 | `v0.6.0` | 规划中 | Eclipse Temurin JDK Provider |
 | `v0.7.0` | 规划中 | rustup 委托式 Rust Provider |
@@ -76,7 +76,7 @@ Pinset 将继续保持“一个工具统一选择、安装、锁定和路由开�
 
 ## v0.4.0 — Flutter SDK Provider
 
-实现状态：核心 Provider、锁文件、安装与路由已进入功能分支开发；三平台 GitHub Actions 真实 SDK 验收尚未执行。
+实现状态：核心 Provider、锁文件、安装与路由已完成并发布；Actions 覆盖三平台构建和 Flutter 自动化测试，真实 SDK 大包验收转由发布后的隔离虚拟机执行。
 
 ### 目标
 
@@ -206,8 +206,8 @@ Pinset 的运行时安装会写入用户目录、下载缓存并改变命令解�
 - 本地只进行代码和文档编辑、只读检查，以及 `git diff --check` 这类不执行项目代码的静态差异检查。
 - 不在本机或 WSL 执行 Cargo build/test、Pinset 安装命令、运行时下载、全局切换或项目切换测试。
 - Pull Request 的 Quality 工作流在 GitHub Actions Ubuntu 虚拟机执行格式、Clippy、单元测试和脚本测试。
-- Provider 变更在合并和发布前必须通过可手动触发的 Ubuntu、Windows、macOS 三平台真实运行时验收。
-- 任一必需平台失败时不得发布；修复后必须重新运行完整矩阵。
+- Provider 变更在合并和发布前必须通过 Ubuntu、Windows、macOS 三平台构建和 Quality 检查；体积适合的运行时继续执行三平台真实验收。
+- Flutter SDK 等超大工件不在 GitHub Actions 下载；发布后使用保留的完整验收脚本在隔离虚拟机验证，发现问题后通过补丁版本修复。
 - 本地静态检查不等同于运行验证，最终结论以 GitHub Actions 记录和虚拟机人工验收为准。
 
 ## 发布流程
@@ -215,7 +215,7 @@ Pinset 的运行时安装会写入用户目录、下载缓存并改变命令解�
 1. 在功能分支完成代码、文档、版本号和变更记录。
 2. 经用户明确授权后暂存、提交、推送并创建 Pull Request。
 3. 等待 Pull Request Quality 工作流通过。
-4. 对新增或修改的 Provider 手动触发 Ubuntu、Windows、macOS 三平台真实运行时验收。
+4. 对新增或修改的 Provider 触发三平台构建；体积适合的运行时执行真实验收，超大运行时记录发布后虚拟机验收边界。
 5. 经用户明确确认后合并到 `main`。
 6. 创建签名版本标签并触发 Release 工作流。
 7. 确认 release assets、checksums、SBOM/provenance 和各平台安装脚本可用后宣布发布完成。
@@ -239,5 +239,5 @@ Pinset 的运行时安装会写入用户目录、下载缓存并改变命令解�
 | Python 第三方预构建工件无法只靠语言版本复现 | 锁定 build ID、variant、来源和校验值 |
 | Java 厂商、JDK/JRE 和 JVM 类型产生歧义 | 首期仅 Temurin JDK/HotSpot/GA，并在新 schema 中显式记录分发属性 |
 | Rust 与 rustup 重复管理造成命令和状态冲突 | 使用 Delegated Provider，不重做 rustup 的安装与组件能力 |
-| 本地运行验证污染用户开发环境 | 所有构建、测试和真实安装验证放到 GitHub Actions 虚拟机 |
-| 三平台矩阵消耗较高 | PR 默认运行 Quality；完整矩阵用于 Provider 变更、合并前验收和发布 |
+| 本地运行验证污染用户开发环境 | 开发机只做静态检查；真实安装使用 GitHub Actions 或用户隔离虚拟机 |
+| 超大 SDK 持续占用托管 Runner | Actions 不下载 Flutter 等超大工件；保留完整脚本供发布后虚拟机验收 |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,7 +1,7 @@
 # Pinset PRD
 
 文档版本：`v0.4.0`
-产品阶段：`Flutter Provider development`
+产品阶段：`Flutter Provider release`
 更新时间：`2026-08-13`
 
 ## 1. 产品简介
@@ -453,16 +453,16 @@ Flutter Provider 首期只接收官方 stable 渠道，支持精确版本、主�
 
 - 构建 locked release 二进制；
 - 设置中文并验证持久化；
-- 安装一个全局 Node、一个项目 Node、pnpm、Bun、Go，以及全局/项目两套不同版本的 Flutter SDK；
+- 安装一个全局 Node、一个项目 Node、pnpm、Bun 和 Go；
 - 验证项目覆盖与离开项目后的全局恢复；
-- 验证 `pinset exec` 下的 node/npm/npx/corepack/pnpm/bun/bunx/go/gofmt/flutter/dart；
+- 验证 `pinset exec` 下的 node/npm/npx/corepack/pnpm/bun/bunx/go/gofmt；
 - 验证 PATH 直接调用的全部 Provider 命令；
 - 验证项目 Node 覆盖与 pnpm 子进程组合 PATH；
-- 验证 Flutter 项目覆盖、`.fvmrc` 导入、Flutter/Dart 同源、`FLUTTER_ROOT`、已安装 SDK 重用和原地变更拦截；
+- 通过自动化测试验证 Flutter 元数据、锁文件、安装安全、路由、`.fvmrc` 导入和原地变更拦截；
 - 运行安装器/卸载器隔离测试；
 - 生成并发布归档、校验、SBOM 和来源证明。
 
-任一平台失败都不发布 Release。
+任一必需的 Quality、构建或轻量真实运行时任务失败都不发布 Release。Flutter SDK 单个归档超过 1.8 GiB，不在 GitHub Actions 下载；全局/项目覆盖、Flutter/Dart 同源、`FLUTTER_ROOT` 和 SDK 重用由发布后的隔离虚拟机使用完整验收脚本验证。
 
 ## 10. 稳定版前待办
 
@@ -473,6 +473,6 @@ Flutter Provider 首期只接收官方 stable 渠道，支持精确版本、主�
 - 完成 Beta 用户在代理、镜像、离线和旧管理器迁移场景的反馈修复；
 - 决定 Linux arm64 与 macOS Intel 正式归档策略；
 - 完成发布回滚、撤回和安全公告流程；
-- 完成 Node、pnpm、Bun、Go、Flutter/Dart 的三平台真实运行时验收。
+- 完成 Flutter/Dart 的发布后隔离虚拟机真实运行时验收。
 
 后续按 CPython、Java、Rustup 的顺序扩展。实现时复用现有 Provider、来源、缓存、路由和安全机制，不在 CLI 中增加语言专用的零散逻辑。

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,14 +1,14 @@
 # Pinset PRD
 
-文档版本：`v0.3.0`
-产品阶段：`Go Provider development`
+文档版本：`v0.4.0`
+产品阶段：`Flutter Provider development`
 更新时间：`2026-08-13`
 
 ## 1. 产品简介
 
 Pinset 是一个本地优先、跨平台的运行时版本管理 CLI。它用一致的命令完成版本选择、锁定、安装、执行、镜像、缓存和诊断，减少在 nvm/fnm、uv、FVM 等工具之间切换的成本。
 
-`v0.3.0` 在 Node.js、pnpm 和 Bun 基础上新增 Go Provider。Python、Flutter、Java 和 Rust 暂不纳入本版本。
+`v0.4.0` 在 Node.js、pnpm、Bun 和 Go 基础上新增 Flutter SDK Provider，并将 SDK 内置 Dart 作为同一个不可拆分的运行时单元。Python、Java 和 Rust 暂不纳入本版本。
 
 ### 1.1 目标
 
@@ -28,7 +28,8 @@ Pinset 是一个本地优先、跨平台的运行时版本管理 CLI。它用一
 
 ### 1.3 本版本不做
 
-- 不接入 Python、Flutter、Java、Rust 等其他 Provider；
+- 不接入 Python、Java、Rust 等其他 Provider；
+- 不管理 Android SDK/NDK、JDK、Xcode、CocoaPods、模拟器、设备、pub 依赖或 pub 缓存；
 - 不管理 npm、pnpm、Bun 中的项目依赖或全局包；
 - 不管理项目依赖包或全局 npm 包；
 - 不自动修改 shell profile、系统 PATH、IDE 配置或系统注册表；
@@ -61,7 +62,7 @@ Pinset 是一个本地优先、跨平台的运行时版本管理 CLI。它用一
 
 ### 2.5 运行时中立
 
-curl 安装器只安装 `pinset` 与 `pinset-shim`。Node Provider 注册 `node`、`npm`、`npx`、`corepack`，pnpm Provider 注册 `pnpm`，Bun Provider 注册 `bun`、`bunx`，Go Provider 注册 `go`、`gofmt`。
+curl 安装器只安装 `pinset` 与 `pinset-shim`。Node Provider 注册 `node`、`npm`、`npx`、`corepack`，pnpm Provider 注册 `pnpm`，Bun Provider 注册 `bun`、`bunx`，Go Provider 注册 `go`、`gofmt`，Flutter Provider 注册 `flutter`、`dart`。
 
 ## 3. 支持矩阵
 
@@ -139,7 +140,7 @@ Provider 声明：
 - 运行时命令集合；
 - 安装、验证和命令路由规则。
 
-Node Provider 声明 `node`、`npm`、`npx`、`corepack`；pnpm Provider 声明 `pnpm`；Bun Provider 声明 `bun`、`bunx`；Go Provider 声明 `go`、`gofmt`、`GOROOT` 和工具链切换策略。
+Node Provider 声明 `node`、`npm`、`npx`、`corepack`；pnpm Provider 声明 `pnpm`；Bun Provider 声明 `bun`、`bunx`；Go Provider 声明 `go`、`gofmt`、`GOROOT` 和工具链切换策略；Flutter Provider 声明 `flutter`、`dart`、`FLUTTER_ROOT` 和受管 SDK 原地变更保护。
 
 ### 4.5 通用命令路由
 
@@ -371,6 +372,20 @@ Go Provider 支持精确版本、主版本、主次版本、`latest` 和 `curren
 - 保留用户的 `GOPATH`、`GOMODCACHE`、`GOCACHE`，不修改 `go.mod` 或 `go.work`；
 - 不管理 Go module 依赖、代理凭据、交叉编译器、TinyGo 或系统 C 工具链。
 
+## 6.3 Flutter SDK Provider
+
+Flutter Provider 首期只接收官方 stable 渠道，支持精确版本、主版本、主次版本、`latest` 和 `current` 选择器，并通过 `pinset list flutter --available` 同时显示 Flutter 与捆绑 Dart 的精确版本。
+
+- 官方元数据来自 Google Storage 上按 Linux、Windows、macOS 分发的三个 Flutter release JSON；
+- 只有同时具备 Windows x64、Linux x64、macOS x64 和 macOS arm64 工件，且 release hash、Flutter 版本和 Dart 版本一致的 stable 发布才可用；
+- 锁文件记录 stable 渠道、捆绑 Dart 版本、release hash、逐平台规范归档路径和 SHA-256；
+- Windows/macOS 使用 ZIP，Linux 使用 TAR.XZ，均 strip 顶层 `flutter/` 后验证 `bin/flutter`、`bin/dart` 和内置 Dart SDK；
+- Flutter 官方归档使用独立的 3 GiB 下载、12 GiB 解压和 250,000 条目安全上限，其他 Provider 继续使用较低默认限额；
+- `flutter` 与 `dart` 必须解析到同一安装目录，受管进程获得对应 `FLUTTER_ROOT`；用户未显式设置时注入 `FLUTTER_SUPPRESS_ANALYTICS=true`；
+- 支持只读识别和显式导入 `.fvmrc`，保留原文件，不接管 FVM 缓存；
+- `flutter upgrade`、`flutter downgrade`、`flutter channel` 在受管 SDK 启动前被拒绝，版本变化必须重新通过 Pinset 选择和安装；
+- 不管理 Flutter/Dart 项目依赖、pub 缓存、移动端/桌面端平台 SDK、模拟器或设备。
+
 ## 7. 安全和供应链
 
 ### 7.1 Provider 归档
@@ -381,6 +396,7 @@ Go Provider 支持精确版本、主版本、主次版本、`latest` 和 `curren
 - Beta 尚未验证 Node 上游 `SHASUMS256.txt.sig` 的 OpenPGP 签名，计划在稳定版加入。
 - pnpm/Bun 使用 npm 平台包的 SHA-512 SRI，并在锁定阶段验证 npm registry ECDSA 签名；安装阶段重新计算 SHA-512。
 - Go 使用官方下载 JSON 中逐工件提供的 SHA-256；锁文件中的规范 URL、目标和归档格式必须与内置 Go Provider 一致。
+- Flutter 使用官方 release JSON 中逐工件提供的 SHA-256；三个平台索引必须对 Flutter 版本、Dart 版本和 release hash 达成一致。
 
 ### 7.2 Pinset Release
 
@@ -418,7 +434,7 @@ Go Provider 支持精确版本、主版本、主次版本、`latest` 和 `curren
 
 ## 9. Beta 验收
 
-### 9.1 本地检查
+### 9.1 Quality 检查
 
 - `cargo fmt --all -- --check`；
 - `cargo clippy --workspace --all-targets --all-features -- -D warnings`；
@@ -429,7 +445,7 @@ Go Provider 支持精确版本、主版本、主次版本、`latest` 和 `curren
 - shim 轻依赖检查；
 - `git diff --check`。
 
-这些检查只使用临时目录、假归档和本地服务，不在开发机安装真实运行时。
+开发机只执行格式化和 `git diff --check` 等静态操作。Clippy、编译、测试和脚本执行全部由 GitHub Actions 临时虚拟机完成，不在开发机或 WSL 运行。
 
 ### 9.2 Release 检查
 
@@ -437,11 +453,12 @@ Go Provider 支持精确版本、主版本、主次版本、`latest` 和 `curren
 
 - 构建 locked release 二进制；
 - 设置中文并验证持久化；
-- 安装一个全局 Node、一个项目 Node、一个 pnpm 和一个 Bun；
+- 安装一个全局 Node、一个项目 Node、pnpm、Bun、Go，以及全局/项目两套不同版本的 Flutter SDK；
 - 验证项目覆盖与离开项目后的全局恢复；
-- 验证 `pinset exec` 下的 node/npm/npx/corepack/pnpm/bun/bunx；
-- 验证 PATH 直接调用的 node/npm/npx/corepack/pnpm/bun/bunx；
+- 验证 `pinset exec` 下的 node/npm/npx/corepack/pnpm/bun/bunx/go/gofmt/flutter/dart；
+- 验证 PATH 直接调用的全部 Provider 命令；
 - 验证项目 Node 覆盖与 pnpm 子进程组合 PATH；
+- 验证 Flutter 项目覆盖、`.fvmrc` 导入、Flutter/Dart 同源、`FLUTTER_ROOT`、已安装 SDK 重用和原地变更拦截；
 - 运行安装器/卸载器隔离测试；
 - 生成并发布归档、校验、SBOM 和来源证明。
 
@@ -456,6 +473,6 @@ Go Provider 支持精确版本、主版本、主次版本、`latest` 和 `curren
 - 完成 Beta 用户在代理、镜像、离线和旧管理器迁移场景的反馈修复；
 - 决定 Linux arm64 与 macOS Intel 正式归档策略；
 - 完成发布回滚、撤回和安全公告流程；
-- 完成 Node、pnpm、Bun、Go 的三平台真实运行时验收。
+- 完成 Node、pnpm、Bun、Go、Flutter/Dart 的三平台真实运行时验收。
 
-后续按 Flutter、CPython、Java、Rustup 的顺序扩展。实现时复用现有 Provider、来源、缓存、路由和安全机制，不在 CLI 中增加语言专用的零散逻辑。
+后续按 CPython、Java、Rustup 的顺序扩展。实现时复用现有 Provider、来源、缓存、路由和安全机制，不在 CLI 中增加语言专用的零散逻辑。

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Pinset Release Notes
 
+## v0.4.0（开发中）
+
+- 新增 Flutter stable SDK Provider，支持精确版本、主版本、主次版本、`latest`/`current` 与 `list flutter --available`；
+- 将 Flutter 与其内置 Dart 锁定为同一运行时单元，记录渠道、Dart 版本、release hash、四平台归档身份和 SHA-256；
+- 新增 `flutter`、`dart` 路由和受管 `FLUTTER_ROOT`，保留用户显式设置的 `FLUTTER_SUPPRESS_ANALYTICS`；
+- 支持预览和显式导入 `.fvmrc`，不修改旧文件、不接管 FVM 缓存；
+- 在启动受管 SDK 前拒绝 `flutter upgrade`、`flutter downgrade` 和 `flutter channel`；
+- GitHub Actions 真实运行时验收扩展到全局/项目 Flutter 版本覆盖、内置 Dart 同源、SDK 重用和三平台安装；该矩阵通过前不发布。
+
 ## v0.3.0
 
 - 发布日期：`2026-08-13`

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,13 +1,16 @@
 # Pinset Release Notes
 
-## v0.4.0（开发中）
+## v0.4.0
 
+- 发布日期：`2026-08-13`
+- 阶段：Flutter stable SDK Provider
+- GitHub Release：[v0.4.0](https://github.com/Future-Element/pinset/releases/tag/v0.4.0)
 - 新增 Flutter stable SDK Provider，支持精确版本、主版本、主次版本、`latest`/`current` 与 `list flutter --available`；
 - 将 Flutter 与其内置 Dart 锁定为同一运行时单元，记录渠道、Dart 版本、release hash、四平台归档身份和 SHA-256；
 - 新增 `flutter`、`dart` 路由和受管 `FLUTTER_ROOT`，保留用户显式设置的 `FLUTTER_SUPPRESS_ANALYTICS`；
 - 支持预览和显式导入 `.fvmrc`，不修改旧文件、不接管 FVM 缓存；
 - 在启动受管 SDK 前拒绝 `flutter upgrade`、`flutter downgrade` 和 `flutter channel`；
-- GitHub Actions 真实运行时验收扩展到全局/项目 Flutter 版本覆盖、内置 Dart 同源、SDK 重用和三平台安装；该矩阵通过前不发布。
+- GitHub Actions 保留三平台构建、Quality、Flutter 元数据/锁文件/安装与路由自动化测试，但不再下载单个超过 1.8 GiB 的真实 Flutter SDK；完整 Flutter/Dart 验收脚本保留给发布后的隔离虚拟机测试。
 
 ## v0.3.0
 

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="0.3.0"
+DEFAULT_VERSION="0.4.0"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -18,7 +18,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 0.3.0.
+  --version VERSION       Install an exact release, for example 0.4.0.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.

--- a/scripts/tests/install_sh_test.sh
+++ b/scripts/tests/install_sh_test.sh
@@ -57,7 +57,7 @@ sh "$ROOT/install.sh" --install-dir "$INSTALL_DIR"
 [ "$("$INSTALL_DIR/pinset" --version)" = "pinset 9.8.7-test" ]
 INSTALLED_ENTRIES=$(find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 -print | wc -l | awk '{ print $1 }')
 [ "$INSTALLED_ENTRIES" = "2" ]
-for runtime_command in node npm npx corepack pnpm bun bunx go gofmt python flutter java; do
+for runtime_command in node npm npx corepack pnpm bun bunx go gofmt flutter dart python java; do
     [ ! -e "$INSTALL_DIR/$runtime_command" ]
 done
 

--- a/scripts/tests/ubuntu_runtime_acceptance.sh
+++ b/scripts/tests/ubuntu_runtime_acceptance.sh
@@ -11,6 +11,8 @@ PROJECT_PNPM_SELECTOR="${PINSET_PROJECT_PNPM_SELECTOR:-10}"
 PROJECT_BUN_SELECTOR="${PINSET_PROJECT_BUN_SELECTOR:-1.2}"
 GLOBAL_GO_SELECTOR="${PINSET_GLOBAL_GO_SELECTOR:-latest}"
 PROJECT_GO_SELECTOR="${PINSET_PROJECT_GO_SELECTOR:-1.24}"
+GLOBAL_FLUTTER_SELECTOR="${PINSET_GLOBAL_FLUTTER_SELECTOR:-latest}"
+PROJECT_FLUTTER_SELECTOR="${PINSET_PROJECT_FLUTTER_SELECTOR:-3.44}"
 VERSION_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+$'
 
 if [[ ! "$GLOBAL_VERSION" =~ $VERSION_PATTERN ]] || [[ ! "$PROJECT_VERSION" =~ $VERSION_PATTERN ]] ||
@@ -29,6 +31,8 @@ trap 'rm -rf "$TEST_ROOT"' EXIT
 export PINSET_HOME="$TEST_ROOT/pinset-home"
 unset PINSET_LANG
 unset GOTOOLCHAIN
+unset FLUTTER_ROOT
+unset FLUTTER_SUPPRESS_ANALYTICS
 
 cd "$TEST_ROOT"
 
@@ -40,6 +44,14 @@ grep -F 'language = "zh-CN"' "$PINSET_HOME/settings.toml"
 "$PINSET_BIN" list pnpm --available | grep -E '^pnpm@10\.'
 "$PINSET_BIN" list bun --available | grep -F "bun@$BUN_VERSION"
 "$PINSET_BIN" list go --available | grep -E '^go@[0-9]+\.[0-9]+\.[0-9]+$'
+FLUTTER_RELEASES="$("$PINSET_BIN" list flutter --available)"
+printf '%s\n' "$FLUTTER_RELEASES" | grep -E '^flutter@[0-9]+\.[0-9]+\.[0-9]+ dart@[0-9]+\.[0-9]+\.[0-9]+ stable$'
+PROJECT_FLUTTER_VERSION="$(
+  printf '%s\n' "$FLUTTER_RELEASES" |
+    sed -n "s/^flutter@\(${PROJECT_FLUTTER_SELECTOR//./\.}\.[0-9][0-9]*\) .*/\1/p" |
+    head -n 1
+)"
+test -n "$PROJECT_FLUTTER_VERSION"
 "$PINSET_BIN" global "pnpm@$GLOBAL_PNPM_SELECTOR"
 GLOBAL_PNPM_VERSION="$("$PINSET_BIN" exec -- pnpm --version)"
 printf '%s\n' "$GLOBAL_PNPM_VERSION" | grep -E '^11\.'
@@ -47,6 +59,18 @@ printf '%s\n' "$GLOBAL_PNPM_VERSION" | grep -E '^11\.'
 "$PINSET_BIN" global "go@$GLOBAL_GO_SELECTOR"
 GLOBAL_GO_VERSION="$("$PINSET_BIN" exec -- go version | sed -E 's/^go version go([^ ]+).*/\1/')"
 printf '%s\n' "$GLOBAL_GO_VERSION" | grep -E "$VERSION_PATTERN"
+"$PINSET_BIN" global "flutter@$GLOBAL_FLUTTER_SELECTOR"
+GLOBAL_FLUTTER_JSON="$("$PINSET_BIN" exec -- flutter --version --machine)"
+GLOBAL_FLUTTER_VERSION="$(
+  printf '%s' "$GLOBAL_FLUTTER_JSON" |
+    python3 -c 'import json,sys; print(json.load(sys.stdin)["frameworkVersion"])'
+)"
+GLOBAL_DART_VERSION="$(
+  printf '%s' "$GLOBAL_FLUTTER_JSON" |
+    python3 -c 'import json,sys; print(json.load(sys.stdin)["dartSdkVersion"])'
+)"
+printf '%s\n' "$GLOBAL_FLUTTER_VERSION" "$GLOBAL_DART_VERSION" | grep -E "$VERSION_PATTERN"
+test "$PROJECT_FLUTTER_VERSION" != "$GLOBAL_FLUTTER_VERSION"
 "$PINSET_BIN" current node | tee global-current.txt
 grep -F "Node.js $GLOBAL_VERSION" global-current.txt
 grep -F '来源=全局' global-current.txt
@@ -61,6 +85,13 @@ grep -F '来源=全局' global-current.txt
 "$PINSET_BIN" exec -- go env GOTOOLCHAIN | grep -Fx 'local'
 "$PINSET_BIN" exec -- go env GOROOT | grep -F "$PINSET_HOME/installs/go/$GLOBAL_GO_VERSION/"
 printf 'package p\nfunc f( ){ }\n' | "$PINSET_BIN" exec -- gofmt | grep -F 'func f() {}'
+GLOBAL_FLUTTER_PATH="$("$PINSET_BIN" which flutter)"
+GLOBAL_DART_PATH="$("$PINSET_BIN" which dart)"
+test "$(dirname "$GLOBAL_FLUTTER_PATH")" = "$(dirname "$GLOBAL_DART_PATH")"
+GLOBAL_FLUTTER_ROOT="$(CDPATH= cd -- "$(dirname "$GLOBAL_FLUTTER_PATH")/.." && pwd)"
+printf "import 'dart:io'; void main() => print(Platform.environment['FLUTTER_ROOT']);\n" > verify_flutter_env.dart
+"$PINSET_BIN" exec -- dart verify_flutter_env.dart | grep -Fx "$GLOBAL_FLUTTER_ROOT"
+"$PINSET_BIN" exec -- dart --version 2>&1 | grep -F "Dart SDK version: $GLOBAL_DART_VERSION"
 
 SHIM_DIR="$("$PINSET_BIN" shim path)"
 export PATH="$SHIM_DIR:$PATH"
@@ -73,6 +104,16 @@ bun --version | grep -Fx "$BUN_VERSION"
 bunx --version | grep -Fx "$BUN_VERSION"
 go version | grep -F "go version go$GLOBAL_GO_VERSION"
 go env GOTOOLCHAIN | grep -Fx 'local'
+flutter --version --machine | python3 -c 'import json,sys; print(json.load(sys.stdin)["frameworkVersion"])' | grep -Fx "$GLOBAL_FLUTTER_VERSION"
+dart --version 2>&1 | grep -F "Dart SDK version: $GLOBAL_DART_VERSION"
+for mutation in upgrade downgrade channel; do
+  if flutter "$mutation" > flutter-mutation.txt 2>&1; then
+    echo "managed flutter $mutation unexpectedly succeeded" >&2
+    exit 1
+  fi
+  grep -F "refusing to run \`flutter $mutation\` against a Pinset-managed Flutter SDK" flutter-mutation.txt
+done
+"$PINSET_BIN" cache clean
 
 mkdir project
 cd project
@@ -89,6 +130,19 @@ printf '%s\n' "$PROJECT_BUN_VERSION" | grep -E '^1\.2\.'
 "$PINSET_BIN" use "go@$PROJECT_GO_SELECTOR"
 PROJECT_GO_VERSION="$(go version | sed -E 's/^go version go([^ ]+).*/\1/')"
 printf '%s\n' "$PROJECT_GO_VERSION" | grep -E "^${PROJECT_GO_SELECTOR//./\.}\."
+printf '{"flutter":"%s"}\n' "$PROJECT_FLUTTER_VERSION" > .fvmrc
+"$PINSET_BIN" import --apply --from fvm --no-install
+"$PINSET_BIN" install --locked
+PROJECT_FLUTTER_JSON="$(flutter --version --machine)"
+PROJECT_FLUTTER_ACTUAL="$(
+  printf '%s' "$PROJECT_FLUTTER_JSON" |
+    python3 -c 'import json,sys; print(json.load(sys.stdin)["frameworkVersion"])'
+)"
+PROJECT_DART_VERSION="$(
+  printf '%s' "$PROJECT_FLUTTER_JSON" |
+    python3 -c 'import json,sys; print(json.load(sys.stdin)["dartSdkVersion"])'
+)"
+test "$PROJECT_FLUTTER_ACTUAL" = "$PROJECT_FLUTTER_VERSION"
 test -f pinset.toml
 test -f pinset.lock
 "$PINSET_BIN" current node | tee project-current.txt
@@ -108,6 +162,15 @@ bunx --version | grep -Fx "$PROJECT_BUN_VERSION"
 go version | grep -F "go version go$PROJECT_GO_VERSION"
 go env GOTOOLCHAIN | grep -Fx 'local'
 go env GOROOT | grep -F "$PINSET_HOME/installs/go/$PROJECT_GO_VERSION/"
+PROJECT_FLUTTER_PATH="$("$PINSET_BIN" which flutter)"
+PROJECT_DART_PATH="$("$PINSET_BIN" which dart)"
+test "$(dirname "$PROJECT_FLUTTER_PATH")" = "$(dirname "$PROJECT_DART_PATH")"
+PROJECT_FLUTTER_ROOT="$(CDPATH= cd -- "$(dirname "$PROJECT_FLUTTER_PATH")/.." && pwd)"
+dart "$TEST_ROOT/verify_flutter_env.dart" | grep -Fx "$PROJECT_FLUTTER_ROOT"
+dart --version 2>&1 | grep -F "Dart SDK version: $PROJECT_DART_VERSION"
+"$PINSET_BIN" cache clean
+"$PINSET_BIN" install --locked | tee locked-reuse.txt
+grep -F "flutter@$PROJECT_FLUTTER_VERSION is already installed" locked-reuse.txt
 set +e
 PNPM_CHILD_NODE_OUTPUT="$(pnpm exec node --version 2>&1)"
 PNPM_CHILD_NODE_STATUS=$?
@@ -127,5 +190,7 @@ pnpm --version | grep -Fx "$GLOBAL_PNPM_VERSION"
 bun --version | grep -Fx "$BUN_VERSION"
 go version | grep -F "go version go$GLOBAL_GO_VERSION"
 go env GOTOOLCHAIN | grep -Fx 'local'
+flutter --version --machine | python3 -c 'import json,sys; print(json.load(sys.stdin)["frameworkVersion"])' | grep -Fx "$GLOBAL_FLUTTER_VERSION"
+dart --version 2>&1 | grep -F "Dart SDK version: $GLOBAL_DART_VERSION"
 
-echo "Unix real Node, pnpm, Bun and Go acceptance passed"
+echo "Unix real Node, pnpm, Bun, Go and Flutter acceptance passed"

--- a/scripts/tests/ubuntu_runtime_acceptance.sh
+++ b/scripts/tests/ubuntu_runtime_acceptance.sh
@@ -88,7 +88,7 @@ printf 'package p\nfunc f( ){ }\n' | "$PINSET_BIN" exec -- gofmt | grep -F 'func
 GLOBAL_FLUTTER_PATH="$("$PINSET_BIN" which flutter)"
 GLOBAL_DART_PATH="$("$PINSET_BIN" which dart)"
 test "$(dirname "$GLOBAL_FLUTTER_PATH")" = "$(dirname "$GLOBAL_DART_PATH")"
-GLOBAL_FLUTTER_ROOT="$(CDPATH= cd -- "$(dirname "$GLOBAL_FLUTTER_PATH")/.." && pwd)"
+GLOBAL_FLUTTER_ROOT="$(CDPATH= cd -- "$(dirname "$GLOBAL_FLUTTER_PATH")/.." && pwd -P)"
 printf "import 'dart:io'; void main() => print(Platform.environment['FLUTTER_ROOT']);\n" > verify_flutter_env.dart
 "$PINSET_BIN" exec -- dart verify_flutter_env.dart | grep -Fx "$GLOBAL_FLUTTER_ROOT"
 "$PINSET_BIN" exec -- dart --version 2>&1 | grep -F "Dart SDK version: $GLOBAL_DART_VERSION"
@@ -165,7 +165,7 @@ go env GOROOT | grep -F "$PINSET_HOME/installs/go/$PROJECT_GO_VERSION/"
 PROJECT_FLUTTER_PATH="$("$PINSET_BIN" which flutter)"
 PROJECT_DART_PATH="$("$PINSET_BIN" which dart)"
 test "$(dirname "$PROJECT_FLUTTER_PATH")" = "$(dirname "$PROJECT_DART_PATH")"
-PROJECT_FLUTTER_ROOT="$(CDPATH= cd -- "$(dirname "$PROJECT_FLUTTER_PATH")/.." && pwd)"
+PROJECT_FLUTTER_ROOT="$(CDPATH= cd -- "$(dirname "$PROJECT_FLUTTER_PATH")/.." && pwd -P)"
 dart "$TEST_ROOT/verify_flutter_env.dart" | grep -Fx "$PROJECT_FLUTTER_ROOT"
 dart --version 2>&1 | grep -F "Dart SDK version: $PROJECT_DART_VERSION"
 "$PINSET_BIN" cache clean

--- a/scripts/tests/ubuntu_runtime_acceptance.sh
+++ b/scripts/tests/ubuntu_runtime_acceptance.sh
@@ -13,6 +13,7 @@ GLOBAL_GO_SELECTOR="${PINSET_GLOBAL_GO_SELECTOR:-latest}"
 PROJECT_GO_SELECTOR="${PINSET_PROJECT_GO_SELECTOR:-1.24}"
 GLOBAL_FLUTTER_SELECTOR="${PINSET_GLOBAL_FLUTTER_SELECTOR:-latest}"
 PROJECT_FLUTTER_SELECTOR="${PINSET_PROJECT_FLUTTER_SELECTOR:-3.44}"
+SKIP_FLUTTER_RUNTIME="${PINSET_SKIP_FLUTTER_RUNTIME:-0}"
 VERSION_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+$'
 
 if [[ ! "$GLOBAL_VERSION" =~ $VERSION_PATTERN ]] || [[ ! "$PROJECT_VERSION" =~ $VERSION_PATTERN ]] ||
@@ -22,6 +23,10 @@ if [[ ! "$GLOBAL_VERSION" =~ $VERSION_PATTERN ]] || [[ ! "$PROJECT_VERSION" =~ $
 fi
 if [[ ! -x "$PINSET_BIN" ]]; then
   echo "PINSET_BIN is not executable: $PINSET_BIN" >&2
+  exit 2
+fi
+if [[ "$SKIP_FLUTTER_RUNTIME" != "0" && "$SKIP_FLUTTER_RUNTIME" != "1" ]]; then
+  echo "PINSET_SKIP_FLUTTER_RUNTIME must be 0 or 1" >&2
   exit 2
 fi
 
@@ -59,18 +64,20 @@ printf '%s\n' "$GLOBAL_PNPM_VERSION" | grep -E '^11\.'
 "$PINSET_BIN" global "go@$GLOBAL_GO_SELECTOR"
 GLOBAL_GO_VERSION="$("$PINSET_BIN" exec -- go version | sed -E 's/^go version go([^ ]+).*/\1/')"
 printf '%s\n' "$GLOBAL_GO_VERSION" | grep -E "$VERSION_PATTERN"
-"$PINSET_BIN" global "flutter@$GLOBAL_FLUTTER_SELECTOR"
-GLOBAL_FLUTTER_JSON="$("$PINSET_BIN" exec -- flutter --version --machine)"
-GLOBAL_FLUTTER_VERSION="$(
-  printf '%s' "$GLOBAL_FLUTTER_JSON" |
-    python3 -c 'import json,sys; print(json.load(sys.stdin)["frameworkVersion"])'
-)"
-GLOBAL_DART_VERSION="$(
-  printf '%s' "$GLOBAL_FLUTTER_JSON" |
-    python3 -c 'import json,sys; print(json.load(sys.stdin)["dartSdkVersion"])'
-)"
-printf '%s\n' "$GLOBAL_FLUTTER_VERSION" "$GLOBAL_DART_VERSION" | grep -E "$VERSION_PATTERN"
-test "$PROJECT_FLUTTER_VERSION" != "$GLOBAL_FLUTTER_VERSION"
+if [[ "$SKIP_FLUTTER_RUNTIME" == "0" ]]; then
+  "$PINSET_BIN" global "flutter@$GLOBAL_FLUTTER_SELECTOR"
+  GLOBAL_FLUTTER_JSON="$("$PINSET_BIN" exec -- flutter --version --machine)"
+  GLOBAL_FLUTTER_VERSION="$(
+    printf '%s' "$GLOBAL_FLUTTER_JSON" |
+      python3 -c 'import json,sys; print(json.load(sys.stdin)["frameworkVersion"])'
+  )"
+  GLOBAL_DART_VERSION="$(
+    printf '%s' "$GLOBAL_FLUTTER_JSON" |
+      python3 -c 'import json,sys; print(json.load(sys.stdin)["dartSdkVersion"])'
+  )"
+  printf '%s\n' "$GLOBAL_FLUTTER_VERSION" "$GLOBAL_DART_VERSION" | grep -E "$VERSION_PATTERN"
+  test "$PROJECT_FLUTTER_VERSION" != "$GLOBAL_FLUTTER_VERSION"
+fi
 "$PINSET_BIN" current node | tee global-current.txt
 grep -F "Node.js $GLOBAL_VERSION" global-current.txt
 grep -F '来源=全局' global-current.txt
@@ -85,13 +92,15 @@ grep -F '来源=全局' global-current.txt
 "$PINSET_BIN" exec -- go env GOTOOLCHAIN | grep -Fx 'local'
 "$PINSET_BIN" exec -- go env GOROOT | grep -F "$PINSET_HOME/installs/go/$GLOBAL_GO_VERSION/"
 printf 'package p\nfunc f( ){ }\n' | "$PINSET_BIN" exec -- gofmt | grep -F 'func f() {}'
-GLOBAL_FLUTTER_PATH="$("$PINSET_BIN" which flutter)"
-GLOBAL_DART_PATH="$("$PINSET_BIN" which dart)"
-test "$(dirname "$GLOBAL_FLUTTER_PATH")" = "$(dirname "$GLOBAL_DART_PATH")"
-GLOBAL_FLUTTER_ROOT="$(CDPATH= cd -- "$(dirname "$GLOBAL_FLUTTER_PATH")/.." && pwd -P)"
-printf "import 'dart:io'; void main() => print(Platform.environment['FLUTTER_ROOT']);\n" > verify_flutter_env.dart
-"$PINSET_BIN" exec -- dart verify_flutter_env.dart | grep -Fx "$GLOBAL_FLUTTER_ROOT"
-"$PINSET_BIN" exec -- dart --version 2>&1 | grep -F "Dart SDK version: $GLOBAL_DART_VERSION"
+if [[ "$SKIP_FLUTTER_RUNTIME" == "0" ]]; then
+  GLOBAL_FLUTTER_PATH="$("$PINSET_BIN" which flutter)"
+  GLOBAL_DART_PATH="$("$PINSET_BIN" which dart)"
+  test "$(dirname "$GLOBAL_FLUTTER_PATH")" = "$(dirname "$GLOBAL_DART_PATH")"
+  GLOBAL_FLUTTER_ROOT="$(CDPATH= cd -- "$(dirname "$GLOBAL_FLUTTER_PATH")/.." && pwd -P)"
+  printf "import 'dart:io'; void main() => print(Platform.environment['FLUTTER_ROOT']);\n" > verify_flutter_env.dart
+  "$PINSET_BIN" exec -- dart verify_flutter_env.dart | grep -Fx "$GLOBAL_FLUTTER_ROOT"
+  "$PINSET_BIN" exec -- dart --version 2>&1 | grep -F "Dart SDK version: $GLOBAL_DART_VERSION"
+fi
 
 SHIM_DIR="$("$PINSET_BIN" shim path)"
 export PATH="$SHIM_DIR:$PATH"
@@ -104,15 +113,17 @@ bun --version | grep -Fx "$BUN_VERSION"
 bunx --version | grep -Fx "$BUN_VERSION"
 go version | grep -F "go version go$GLOBAL_GO_VERSION"
 go env GOTOOLCHAIN | grep -Fx 'local'
-flutter --version --machine | python3 -c 'import json,sys; print(json.load(sys.stdin)["frameworkVersion"])' | grep -Fx "$GLOBAL_FLUTTER_VERSION"
-dart --version 2>&1 | grep -F "Dart SDK version: $GLOBAL_DART_VERSION"
-for mutation in upgrade downgrade channel; do
-  if flutter "$mutation" > flutter-mutation.txt 2>&1; then
-    echo "managed flutter $mutation unexpectedly succeeded" >&2
-    exit 1
-  fi
-  grep -F "refusing to run \`flutter $mutation\` against a Pinset-managed Flutter SDK" flutter-mutation.txt
-done
+if [[ "$SKIP_FLUTTER_RUNTIME" == "0" ]]; then
+  flutter --version --machine | python3 -c 'import json,sys; print(json.load(sys.stdin)["frameworkVersion"])' | grep -Fx "$GLOBAL_FLUTTER_VERSION"
+  dart --version 2>&1 | grep -F "Dart SDK version: $GLOBAL_DART_VERSION"
+  for mutation in upgrade downgrade channel; do
+    if flutter "$mutation" > flutter-mutation.txt 2>&1; then
+      echo "managed flutter $mutation unexpectedly succeeded" >&2
+      exit 1
+    fi
+    grep -F "refusing to run \`flutter $mutation\` against a Pinset-managed Flutter SDK" flutter-mutation.txt
+  done
+fi
 "$PINSET_BIN" cache clean
 
 mkdir project
@@ -130,19 +141,23 @@ printf '%s\n' "$PROJECT_BUN_VERSION" | grep -E '^1\.2\.'
 "$PINSET_BIN" use "go@$PROJECT_GO_SELECTOR"
 PROJECT_GO_VERSION="$(go version | sed -E 's/^go version go([^ ]+).*/\1/')"
 printf '%s\n' "$PROJECT_GO_VERSION" | grep -E "^${PROJECT_GO_SELECTOR//./\.}\."
-printf '{"flutter":"%s"}\n' "$PROJECT_FLUTTER_VERSION" > .fvmrc
-"$PINSET_BIN" import --apply --from fvm --no-install
+if [[ "$SKIP_FLUTTER_RUNTIME" == "0" ]]; then
+  printf '{"flutter":"%s"}\n' "$PROJECT_FLUTTER_VERSION" > .fvmrc
+  "$PINSET_BIN" import --apply --from fvm --no-install
+fi
 "$PINSET_BIN" install --locked
-PROJECT_FLUTTER_JSON="$(flutter --version --machine)"
-PROJECT_FLUTTER_ACTUAL="$(
-  printf '%s' "$PROJECT_FLUTTER_JSON" |
-    python3 -c 'import json,sys; print(json.load(sys.stdin)["frameworkVersion"])'
-)"
-PROJECT_DART_VERSION="$(
-  printf '%s' "$PROJECT_FLUTTER_JSON" |
-    python3 -c 'import json,sys; print(json.load(sys.stdin)["dartSdkVersion"])'
-)"
-test "$PROJECT_FLUTTER_ACTUAL" = "$PROJECT_FLUTTER_VERSION"
+if [[ "$SKIP_FLUTTER_RUNTIME" == "0" ]]; then
+  PROJECT_FLUTTER_JSON="$(flutter --version --machine)"
+  PROJECT_FLUTTER_ACTUAL="$(
+    printf '%s' "$PROJECT_FLUTTER_JSON" |
+      python3 -c 'import json,sys; print(json.load(sys.stdin)["frameworkVersion"])'
+  )"
+  PROJECT_DART_VERSION="$(
+    printf '%s' "$PROJECT_FLUTTER_JSON" |
+      python3 -c 'import json,sys; print(json.load(sys.stdin)["dartSdkVersion"])'
+  )"
+  test "$PROJECT_FLUTTER_ACTUAL" = "$PROJECT_FLUTTER_VERSION"
+fi
 test -f pinset.toml
 test -f pinset.lock
 "$PINSET_BIN" current node | tee project-current.txt
@@ -162,15 +177,19 @@ bunx --version | grep -Fx "$PROJECT_BUN_VERSION"
 go version | grep -F "go version go$PROJECT_GO_VERSION"
 go env GOTOOLCHAIN | grep -Fx 'local'
 go env GOROOT | grep -F "$PINSET_HOME/installs/go/$PROJECT_GO_VERSION/"
-PROJECT_FLUTTER_PATH="$("$PINSET_BIN" which flutter)"
-PROJECT_DART_PATH="$("$PINSET_BIN" which dart)"
-test "$(dirname "$PROJECT_FLUTTER_PATH")" = "$(dirname "$PROJECT_DART_PATH")"
-PROJECT_FLUTTER_ROOT="$(CDPATH= cd -- "$(dirname "$PROJECT_FLUTTER_PATH")/.." && pwd -P)"
-dart "$TEST_ROOT/verify_flutter_env.dart" | grep -Fx "$PROJECT_FLUTTER_ROOT"
-dart --version 2>&1 | grep -F "Dart SDK version: $PROJECT_DART_VERSION"
+if [[ "$SKIP_FLUTTER_RUNTIME" == "0" ]]; then
+  PROJECT_FLUTTER_PATH="$("$PINSET_BIN" which flutter)"
+  PROJECT_DART_PATH="$("$PINSET_BIN" which dart)"
+  test "$(dirname "$PROJECT_FLUTTER_PATH")" = "$(dirname "$PROJECT_DART_PATH")"
+  PROJECT_FLUTTER_ROOT="$(CDPATH= cd -- "$(dirname "$PROJECT_FLUTTER_PATH")/.." && pwd -P)"
+  dart "$TEST_ROOT/verify_flutter_env.dart" | grep -Fx "$PROJECT_FLUTTER_ROOT"
+  dart --version 2>&1 | grep -F "Dart SDK version: $PROJECT_DART_VERSION"
+fi
 "$PINSET_BIN" cache clean
 "$PINSET_BIN" install --locked | tee locked-reuse.txt
-grep -F "flutter@$PROJECT_FLUTTER_VERSION is already installed" locked-reuse.txt
+if [[ "$SKIP_FLUTTER_RUNTIME" == "0" ]]; then
+  grep -F "flutter@$PROJECT_FLUTTER_VERSION is already installed" locked-reuse.txt
+fi
 set +e
 PNPM_CHILD_NODE_OUTPUT="$(pnpm exec node --version 2>&1)"
 PNPM_CHILD_NODE_STATUS=$?
@@ -190,7 +209,13 @@ pnpm --version | grep -Fx "$GLOBAL_PNPM_VERSION"
 bun --version | grep -Fx "$BUN_VERSION"
 go version | grep -F "go version go$GLOBAL_GO_VERSION"
 go env GOTOOLCHAIN | grep -Fx 'local'
-flutter --version --machine | python3 -c 'import json,sys; print(json.load(sys.stdin)["frameworkVersion"])' | grep -Fx "$GLOBAL_FLUTTER_VERSION"
-dart --version 2>&1 | grep -F "Dart SDK version: $GLOBAL_DART_VERSION"
+if [[ "$SKIP_FLUTTER_RUNTIME" == "0" ]]; then
+  flutter --version --machine | python3 -c 'import json,sys; print(json.load(sys.stdin)["frameworkVersion"])' | grep -Fx "$GLOBAL_FLUTTER_VERSION"
+  dart --version 2>&1 | grep -F "Dart SDK version: $GLOBAL_DART_VERSION"
+fi
 
-echo "Unix real Node, pnpm, Bun, Go and Flutter acceptance passed"
+if [[ "$SKIP_FLUTTER_RUNTIME" == "0" ]]; then
+  echo "Unix real Node, pnpm, Bun, Go and Flutter acceptance passed"
+else
+  echo "Unix real Node, pnpm, Bun and Go acceptance passed; Flutter runtime download skipped"
+fi

--- a/scripts/tests/uninstall_ps1_test.ps1
+++ b/scripts/tests/uninstall_ps1_test.ps1
@@ -30,7 +30,7 @@ try {
     [IO.File]::WriteAllText($cli, 'pinset test binary')
     [IO.File]::WriteAllText($router, 'pinset shim test binary')
 
-    foreach ($command in @('node', 'npm', 'go')) {
+    foreach ($command in @('node', 'npm', 'go', 'flutter', 'dart')) {
         $escapedRouter = $router.Replace('%', '%%')
         $wrapper = "@echo off`r`nsetlocal DisableDelayedExpansion`r`n`"$escapedRouter`" --as $command -- %*`r`nexit /b %ERRORLEVEL%`r`n"
         [IO.File]::WriteAllText((Join-Path $installDir "$command.cmd"), $wrapper)
@@ -118,6 +118,8 @@ try {
         (Join-Path $installDir 'npm.cmd'),
         (Join-Path $shimDir 'corepack.exe'),
         (Join-Path $installDir 'go.cmd'),
+        (Join-Path $installDir 'flutter.cmd'),
+        (Join-Path $installDir 'dart.cmd'),
         (Join-Path $pathDir 'npx.exe'),
         $pinsetHome
     )) {

--- a/scripts/tests/uninstall_sh_test.sh
+++ b/scripts/tests/uninstall_sh_test.sh
@@ -46,6 +46,8 @@ ln "$INSTALL_DIR/pinset-shim" "$INSTALL_DIR/npm"
 cp "$INSTALL_DIR/pinset-shim" "$INSTALL_DIR/npx"
 ln -s "$INSTALL_DIR/pinset-shim" "$SHIM_DIR/corepack"
 ln -s "$INSTALL_DIR/pinset-shim" "$SHIM_DIR/go"
+ln -s "$INSTALL_DIR/pinset-shim" "$SHIM_DIR/flutter"
+ln -s "$INSTALL_DIR/pinset-shim" "$SHIM_DIR/dart"
 cp "$INSTALL_DIR/pinset-shim" "$PATH_DIR/npx"
 printf 'foreign command\n' > "$PATH_DIR/python"
 printf 'project config\n' > "$PROJECT_DIR/pinset.toml"
@@ -112,6 +114,8 @@ HOME="$TEST_HOME" PATH="$PATH_DIR:$PATH" sh "$ROOT/uninstall.sh" --yes \
 [ ! -e "$INSTALL_DIR/npx" ]
 [ ! -e "$SHIM_DIR/corepack" ]
 [ ! -e "$SHIM_DIR/go" ]
+[ ! -e "$SHIM_DIR/flutter" ]
+[ ! -e "$SHIM_DIR/dart" ]
 [ ! -e "$PATH_DIR/npx" ]
 [ ! -e "$PINSET_DATA_HOME" ]
 [ -f "$PATH_DIR/python" ]

--- a/scripts/tests/windows_runtime_acceptance.ps1
+++ b/scripts/tests/windows_runtime_acceptance.ps1
@@ -16,6 +16,8 @@ $GlobalGoSelector = if ($env:PINSET_GLOBAL_GO_SELECTOR) { $env:PINSET_GLOBAL_GO_
 $ProjectGoSelector = if ($env:PINSET_PROJECT_GO_SELECTOR) { $env:PINSET_PROJECT_GO_SELECTOR } else { '1.24' }
 $GlobalFlutterSelector = if ($env:PINSET_GLOBAL_FLUTTER_SELECTOR) { $env:PINSET_GLOBAL_FLUTTER_SELECTOR } else { 'latest' }
 $ProjectFlutterSelector = if ($env:PINSET_PROJECT_FLUTTER_SELECTOR) { $env:PINSET_PROJECT_FLUTTER_SELECTOR } else { '3.44' }
+$SkipFlutterRuntimeValue = if ($env:PINSET_SKIP_FLUTTER_RUNTIME) { $env:PINSET_SKIP_FLUTTER_RUNTIME } else { '0' }
+$SkipFlutterRuntime = $SkipFlutterRuntimeValue -eq '1'
 $VersionPattern = '^\d+\.\d+\.\d+$'
 
 if ($GlobalVersion -notmatch $VersionPattern -or $ProjectVersion -notmatch $VersionPattern -or
@@ -24,6 +26,9 @@ if ($GlobalVersion -notmatch $VersionPattern -or $ProjectVersion -notmatch $Vers
 }
 if (-not (Test-Path -LiteralPath $Pinset -PathType Leaf)) {
     throw "PINSET_BIN is not a file: $Pinset"
+}
+if ($SkipFlutterRuntimeValue -notin @('0', '1')) {
+    throw 'PINSET_SKIP_FLUTTER_RUNTIME must be 0 or 1'
 }
 
 $TestRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("pinset-acceptance-" + [guid]::NewGuid().ToString('N'))
@@ -123,15 +128,17 @@ try {
         throw "global Go returned an invalid version: '$GlobalGoOutput'"
     }
     $GlobalGoVersion = $GlobalGoMatch.Groups[1].Value
-    & $Pinset global "flutter@$GlobalFlutterSelector"
-    $GlobalFlutterInfo = ConvertFrom-FlutterMachineOutput @(& $Pinset exec -- flutter --version --machine) 'global Flutter'
-    $GlobalFlutterVersion = [string]$GlobalFlutterInfo.frameworkVersion
-    $GlobalDartVersion = [string]$GlobalFlutterInfo.dartSdkVersion
-    if ($GlobalFlutterVersion -notmatch $VersionPattern -or $GlobalDartVersion -notmatch $VersionPattern) {
-        throw 'global Flutter returned invalid Flutter or Dart version metadata'
-    }
-    if ($ProjectFlutterVersion -eq $GlobalFlutterVersion) {
-        throw 'project Flutter acceptance version must differ from the global version'
+    if (-not $SkipFlutterRuntime) {
+        & $Pinset global "flutter@$GlobalFlutterSelector"
+        $GlobalFlutterInfo = ConvertFrom-FlutterMachineOutput @(& $Pinset exec -- flutter --version --machine) 'global Flutter'
+        $GlobalFlutterVersion = [string]$GlobalFlutterInfo.frameworkVersion
+        $GlobalDartVersion = [string]$GlobalFlutterInfo.dartSdkVersion
+        if ($GlobalFlutterVersion -notmatch $VersionPattern -or $GlobalDartVersion -notmatch $VersionPattern) {
+            throw 'global Flutter returned invalid Flutter or Dart version metadata'
+        }
+        if ($ProjectFlutterVersion -eq $GlobalFlutterVersion) {
+            throw 'project Flutter acceptance version must differ from the global version'
+        }
     }
     Assert-ExactOutput "v$GlobalVersion" (& $Pinset exec -- node --version) 'global pinset exec node'
     Assert-VersionOutput (& $Pinset exec -- npm --version) 'global pinset exec npm'
@@ -148,17 +155,19 @@ try {
     if ($GlobalGoRoot -notlike "$(Join-Path $env:PINSET_HOME "installs\go\$GlobalGoVersion")*") {
         throw "global Go reported an unmanaged GOROOT: '$GlobalGoRoot'"
     }
-    $GlobalFlutterPath = ((& $Pinset which flutter) | Out-String).Trim()
-    $GlobalDartPath = ((& $Pinset which dart) | Out-String).Trim()
-    if ((Split-Path -Parent $GlobalFlutterPath) -ne (Split-Path -Parent $GlobalDartPath)) {
-        throw 'global Flutter and Dart resolved from different SDK directories'
-    }
-    $GlobalFlutterRoot = Split-Path -Parent (Split-Path -Parent $GlobalFlutterPath)
-    $FlutterEnvironmentScript = Join-Path $TestRoot 'verify_flutter_env.dart'
-    Set-Content -LiteralPath $FlutterEnvironmentScript -Value "import 'dart:io'; void main() => print(Platform.environment['FLUTTER_ROOT']);" -NoNewline
-    Assert-ExactOutput $GlobalFlutterRoot (& $Pinset exec -- dart $FlutterEnvironmentScript) 'global Flutter root'
-    if (((& $Pinset exec -- dart --version 2>&1) | Out-String).Trim() -notmatch "Dart SDK version: $([regex]::Escape($GlobalDartVersion))") {
-        throw 'global bundled Dart returned an unexpected version'
+    if (-not $SkipFlutterRuntime) {
+        $GlobalFlutterPath = ((& $Pinset which flutter) | Out-String).Trim()
+        $GlobalDartPath = ((& $Pinset which dart) | Out-String).Trim()
+        if ((Split-Path -Parent $GlobalFlutterPath) -ne (Split-Path -Parent $GlobalDartPath)) {
+            throw 'global Flutter and Dart resolved from different SDK directories'
+        }
+        $GlobalFlutterRoot = Split-Path -Parent (Split-Path -Parent $GlobalFlutterPath)
+        $FlutterEnvironmentScript = Join-Path $TestRoot 'verify_flutter_env.dart'
+        Set-Content -LiteralPath $FlutterEnvironmentScript -Value "import 'dart:io'; void main() => print(Platform.environment['FLUTTER_ROOT']);" -NoNewline
+        Assert-ExactOutput $GlobalFlutterRoot (& $Pinset exec -- dart $FlutterEnvironmentScript) 'global Flutter root'
+        if (((& $Pinset exec -- dart --version 2>&1) | Out-String).Trim() -notmatch "Dart SDK version: $([regex]::Escape($GlobalDartVersion))") {
+            throw 'global bundled Dart returned an unexpected version'
+        }
     }
 
     $ShimDirectory = ((& $Pinset shim path) | Out-String).Trim()
@@ -177,17 +186,19 @@ try {
         throw 'global direct Go returned an unexpected version'
     }
     Assert-ExactOutput 'local' (& go env GOTOOLCHAIN) 'global direct Go toolchain policy'
-    $DirectGlobalFlutter = ConvertFrom-FlutterMachineOutput @(& flutter --version --machine) 'global direct Flutter'
-    if ($DirectGlobalFlutter.frameworkVersion -ne $GlobalFlutterVersion) {
-        throw 'global direct Flutter returned an unexpected version'
-    }
-    if (((& dart --version 2>&1) | Out-String).Trim() -notmatch "Dart SDK version: $([regex]::Escape($GlobalDartVersion))") {
-        throw 'global direct Dart returned an unexpected version'
-    }
-    foreach ($mutation in @('upgrade', 'downgrade', 'channel')) {
-        $MutationOutput = @(& flutter $mutation 2>&1 | ForEach-Object { $_.ToString() })
-        if ($LASTEXITCODE -eq 0 -or ($MutationOutput -join "`n") -notmatch "refusing to run ``flutter $mutation`` against a Pinset-managed Flutter SDK") {
-            throw "managed flutter $mutation was not blocked"
+    if (-not $SkipFlutterRuntime) {
+        $DirectGlobalFlutter = ConvertFrom-FlutterMachineOutput @(& flutter --version --machine) 'global direct Flutter'
+        if ($DirectGlobalFlutter.frameworkVersion -ne $GlobalFlutterVersion) {
+            throw 'global direct Flutter returned an unexpected version'
+        }
+        if (((& dart --version 2>&1) | Out-String).Trim() -notmatch "Dart SDK version: $([regex]::Escape($GlobalDartVersion))") {
+            throw 'global direct Dart returned an unexpected version'
+        }
+        foreach ($mutation in @('upgrade', 'downgrade', 'channel')) {
+            $MutationOutput = @(& flutter $mutation 2>&1 | ForEach-Object { $_.ToString() })
+            if ($LASTEXITCODE -eq 0 -or ($MutationOutput -join "`n") -notmatch "refusing to run ``flutter $mutation`` against a Pinset-managed Flutter SDK") {
+                throw "managed flutter $mutation was not blocked"
+            }
         }
     }
     & $Pinset cache clean
@@ -216,14 +227,18 @@ try {
         throw "project Go selector resolved to unexpected version '$ProjectGoOutput'"
     }
     $ProjectGoVersion = $ProjectGoMatch.Groups[1].Value
-    Set-Content -LiteralPath (Join-Path $Project '.fvmrc') -Value "{`"flutter`":`"$ProjectFlutterVersion`"}" -NoNewline
-    & $Pinset import --apply --from fvm --no-install
-    & $Pinset install --locked
-    $ProjectFlutterInfo = ConvertFrom-FlutterMachineOutput @(& flutter --version --machine) 'project Flutter'
-    if ($ProjectFlutterInfo.frameworkVersion -ne $ProjectFlutterVersion) {
-        throw "project Flutter returned unexpected version '$($ProjectFlutterInfo.frameworkVersion)'"
+    if (-not $SkipFlutterRuntime) {
+        Set-Content -LiteralPath (Join-Path $Project '.fvmrc') -Value "{`"flutter`":`"$ProjectFlutterVersion`"}" -NoNewline
+        & $Pinset import --apply --from fvm --no-install
     }
-    $ProjectDartVersion = [string]$ProjectFlutterInfo.dartSdkVersion
+    & $Pinset install --locked
+    if (-not $SkipFlutterRuntime) {
+        $ProjectFlutterInfo = ConvertFrom-FlutterMachineOutput @(& flutter --version --machine) 'project Flutter'
+        if ($ProjectFlutterInfo.frameworkVersion -ne $ProjectFlutterVersion) {
+            throw "project Flutter returned unexpected version '$($ProjectFlutterInfo.frameworkVersion)'"
+        }
+        $ProjectDartVersion = [string]$ProjectFlutterInfo.dartSdkVersion
+    }
     Assert-ExactOutput "v$ProjectVersion" (& node --version) 'project direct node'
     Assert-VersionOutput (& npm --version) 'project direct npm'
     Assert-VersionOutput (& npx --version) 'project direct npx'
@@ -235,19 +250,21 @@ try {
     if ($ProjectGoRoot -notlike "$(Join-Path $env:PINSET_HOME "installs\go\$ProjectGoVersion")*") {
         throw "project Go reported an unmanaged GOROOT: '$ProjectGoRoot'"
     }
-    $ProjectFlutterPath = ((& $Pinset which flutter) | Out-String).Trim()
-    $ProjectDartPath = ((& $Pinset which dart) | Out-String).Trim()
-    if ((Split-Path -Parent $ProjectFlutterPath) -ne (Split-Path -Parent $ProjectDartPath)) {
-        throw 'project Flutter and Dart resolved from different SDK directories'
-    }
-    $ProjectFlutterRoot = Split-Path -Parent (Split-Path -Parent $ProjectFlutterPath)
-    Assert-ExactOutput $ProjectFlutterRoot (& dart $FlutterEnvironmentScript) 'project Flutter root'
-    if (((& dart --version 2>&1) | Out-String).Trim() -notmatch "Dart SDK version: $([regex]::Escape($ProjectDartVersion))") {
-        throw 'project bundled Dart returned an unexpected version'
+    if (-not $SkipFlutterRuntime) {
+        $ProjectFlutterPath = ((& $Pinset which flutter) | Out-String).Trim()
+        $ProjectDartPath = ((& $Pinset which dart) | Out-String).Trim()
+        if ((Split-Path -Parent $ProjectFlutterPath) -ne (Split-Path -Parent $ProjectDartPath)) {
+            throw 'project Flutter and Dart resolved from different SDK directories'
+        }
+        $ProjectFlutterRoot = Split-Path -Parent (Split-Path -Parent $ProjectFlutterPath)
+        Assert-ExactOutput $ProjectFlutterRoot (& dart $FlutterEnvironmentScript) 'project Flutter root'
+        if (((& dart --version 2>&1) | Out-String).Trim() -notmatch "Dart SDK version: $([regex]::Escape($ProjectDartVersion))") {
+            throw 'project bundled Dart returned an unexpected version'
+        }
     }
     & $Pinset cache clean
     $LockedReuse = ((& $Pinset install --locked) | Out-String)
-    if ($LockedReuse -notmatch "flutter@$([regex]::Escape($ProjectFlutterVersion)) is already installed") {
+    if (-not $SkipFlutterRuntime -and $LockedReuse -notmatch "flutter@$([regex]::Escape($ProjectFlutterVersion)) is already installed") {
         throw 'locked Flutter install did not reuse the completed SDK'
     }
     $PnpmChildNodeOutput = @(& pnpm exec node --version 2>&1 | ForEach-Object { $_.ToString() })
@@ -271,14 +288,21 @@ try {
         throw 'restored global direct Go returned an unexpected version'
     }
     Assert-ExactOutput 'local' (& go env GOTOOLCHAIN) 'restored global Go toolchain policy'
-    $RestoredFlutter = ConvertFrom-FlutterMachineOutput @(& flutter --version --machine) 'restored global Flutter'
-    if ($RestoredFlutter.frameworkVersion -ne $GlobalFlutterVersion) {
-        throw 'restored global Flutter returned an unexpected version'
+    if (-not $SkipFlutterRuntime) {
+        $RestoredFlutter = ConvertFrom-FlutterMachineOutput @(& flutter --version --machine) 'restored global Flutter'
+        if ($RestoredFlutter.frameworkVersion -ne $GlobalFlutterVersion) {
+            throw 'restored global Flutter returned an unexpected version'
+        }
+        if (((& dart --version 2>&1) | Out-String).Trim() -notmatch "Dart SDK version: $([regex]::Escape($GlobalDartVersion))") {
+            throw 'restored global Dart returned an unexpected version'
+        }
     }
-    if (((& dart --version 2>&1) | Out-String).Trim() -notmatch "Dart SDK version: $([regex]::Escape($GlobalDartVersion))") {
-        throw 'restored global Dart returned an unexpected version'
+    if ($SkipFlutterRuntime) {
+        Write-Host 'Windows real Node, pnpm, Bun and Go acceptance passed; Flutter runtime download skipped'
     }
-    Write-Host 'Windows real Node, pnpm, Bun, Go and Flutter acceptance passed'
+    else {
+        Write-Host 'Windows real Node, pnpm, Bun, Go and Flutter acceptance passed'
+    }
 }
 finally {
     $env:PATH = $OriginalPath

--- a/scripts/tests/windows_runtime_acceptance.ps1
+++ b/scripts/tests/windows_runtime_acceptance.ps1
@@ -14,6 +14,8 @@ $ProjectPnpmSelector = if ($env:PINSET_PROJECT_PNPM_SELECTOR) { $env:PINSET_PROJ
 $ProjectBunSelector = if ($env:PINSET_PROJECT_BUN_SELECTOR) { $env:PINSET_PROJECT_BUN_SELECTOR } else { '1.2' }
 $GlobalGoSelector = if ($env:PINSET_GLOBAL_GO_SELECTOR) { $env:PINSET_GLOBAL_GO_SELECTOR } else { 'latest' }
 $ProjectGoSelector = if ($env:PINSET_PROJECT_GO_SELECTOR) { $env:PINSET_PROJECT_GO_SELECTOR } else { '1.24' }
+$GlobalFlutterSelector = if ($env:PINSET_GLOBAL_FLUTTER_SELECTOR) { $env:PINSET_GLOBAL_FLUTTER_SELECTOR } else { 'latest' }
+$ProjectFlutterSelector = if ($env:PINSET_PROJECT_FLUTTER_SELECTOR) { $env:PINSET_PROJECT_FLUTTER_SELECTOR } else { '3.44' }
 $VersionPattern = '^\d+\.\d+\.\d+$'
 
 if ($GlobalVersion -notmatch $VersionPattern -or $ProjectVersion -notmatch $VersionPattern -or
@@ -55,6 +57,8 @@ try {
     $env:PINSET_HOME = Join-Path $TestRoot 'pinset-home'
     Remove-Item Env:PINSET_LANG -ErrorAction SilentlyContinue
     Remove-Item Env:GOTOOLCHAIN -ErrorAction SilentlyContinue
+    Remove-Item Env:FLUTTER_ROOT -ErrorAction SilentlyContinue
+    Remove-Item Env:FLUTTER_SUPPRESS_ANALYTICS -ErrorAction SilentlyContinue
     Set-Location $TestRoot
 
     & $Pinset --lang zh-CN | Out-Null
@@ -72,6 +76,18 @@ try {
     if (-not ((& $Pinset list go --available) -match '^go@\d+\.\d+\.\d+$')) {
         throw 'no supported Go release was listed as available'
     }
+    $FlutterReleases = @(& $Pinset list flutter --available)
+    if (-not ($FlutterReleases -match '^flutter@\d+\.\d+\.\d+ dart@\d+\.\d+\.\d+ stable$')) {
+        throw 'no supported Flutter release was listed as available'
+    }
+    $ProjectFlutterMatch = $FlutterReleases |
+        Where-Object { $_ -match "^flutter@$([regex]::Escape($ProjectFlutterSelector))\.(\d+) " } |
+        Select-Object -First 1
+    $ProjectFlutterVersionMatch = [regex]::Match([string]$ProjectFlutterMatch, '^flutter@(\d+\.\d+\.\d+) ')
+    if (-not $ProjectFlutterMatch -or -not $ProjectFlutterVersionMatch.Success) {
+        throw "no Flutter release matched project selector '$ProjectFlutterSelector'"
+    }
+    $ProjectFlutterVersion = $ProjectFlutterVersionMatch.Groups[1].Value
     & $Pinset global "pnpm@$GlobalPnpmSelector"
     $GlobalPnpmVersion = ((& $Pinset exec -- pnpm --version) | Out-String).Trim()
     if ($GlobalPnpmVersion -notmatch '^11\.') {
@@ -85,6 +101,16 @@ try {
         throw "global Go returned an invalid version: '$GlobalGoOutput'"
     }
     $GlobalGoVersion = $GlobalGoMatch.Groups[1].Value
+    & $Pinset global "flutter@$GlobalFlutterSelector"
+    $GlobalFlutterInfo = (((& $Pinset exec -- flutter --version --machine) | Out-String).Trim() | ConvertFrom-Json)
+    $GlobalFlutterVersion = [string]$GlobalFlutterInfo.frameworkVersion
+    $GlobalDartVersion = [string]$GlobalFlutterInfo.dartSdkVersion
+    if ($GlobalFlutterVersion -notmatch $VersionPattern -or $GlobalDartVersion -notmatch $VersionPattern) {
+        throw 'global Flutter returned invalid Flutter or Dart version metadata'
+    }
+    if ($ProjectFlutterVersion -eq $GlobalFlutterVersion) {
+        throw 'project Flutter acceptance version must differ from the global version'
+    }
     Assert-ExactOutput "v$GlobalVersion" (& $Pinset exec -- node --version) 'global pinset exec node'
     Assert-VersionOutput (& $Pinset exec -- npm --version) 'global pinset exec npm'
     Assert-VersionOutput (& $Pinset exec -- npx --version) 'global pinset exec npx'
@@ -99,6 +125,18 @@ try {
     $GlobalGoRoot = ((& $Pinset exec -- go env GOROOT) | Out-String).Trim()
     if ($GlobalGoRoot -notlike "$(Join-Path $env:PINSET_HOME "installs\go\$GlobalGoVersion")*") {
         throw "global Go reported an unmanaged GOROOT: '$GlobalGoRoot'"
+    }
+    $GlobalFlutterPath = ((& $Pinset which flutter) | Out-String).Trim()
+    $GlobalDartPath = ((& $Pinset which dart) | Out-String).Trim()
+    if ((Split-Path -Parent $GlobalFlutterPath) -ne (Split-Path -Parent $GlobalDartPath)) {
+        throw 'global Flutter and Dart resolved from different SDK directories'
+    }
+    $GlobalFlutterRoot = Split-Path -Parent (Split-Path -Parent $GlobalFlutterPath)
+    $FlutterEnvironmentScript = Join-Path $TestRoot 'verify_flutter_env.dart'
+    Set-Content -LiteralPath $FlutterEnvironmentScript -Value "import 'dart:io'; void main() => print(Platform.environment['FLUTTER_ROOT']);" -NoNewline
+    Assert-ExactOutput $GlobalFlutterRoot (& $Pinset exec -- dart $FlutterEnvironmentScript) 'global Flutter root'
+    if (((& $Pinset exec -- dart --version 2>&1) | Out-String).Trim() -notmatch "Dart SDK version: $([regex]::Escape($GlobalDartVersion))") {
+        throw 'global bundled Dart returned an unexpected version'
     }
 
     $ShimDirectory = ((& $Pinset shim path) | Out-String).Trim()
@@ -117,6 +155,20 @@ try {
         throw 'global direct Go returned an unexpected version'
     }
     Assert-ExactOutput 'local' (& go env GOTOOLCHAIN) 'global direct Go toolchain policy'
+    $DirectGlobalFlutter = (((& flutter --version --machine) | Out-String).Trim() | ConvertFrom-Json)
+    if ($DirectGlobalFlutter.frameworkVersion -ne $GlobalFlutterVersion) {
+        throw 'global direct Flutter returned an unexpected version'
+    }
+    if (((& dart --version 2>&1) | Out-String).Trim() -notmatch "Dart SDK version: $([regex]::Escape($GlobalDartVersion))") {
+        throw 'global direct Dart returned an unexpected version'
+    }
+    foreach ($mutation in @('upgrade', 'downgrade', 'channel')) {
+        $MutationOutput = @(& flutter $mutation 2>&1 | ForEach-Object { $_.ToString() })
+        if ($LASTEXITCODE -eq 0 -or ($MutationOutput -join "`n") -notmatch "refusing to run ``flutter $mutation`` against a Pinset-managed Flutter SDK") {
+            throw "managed flutter $mutation was not blocked"
+        }
+    }
+    & $Pinset cache clean
 
     $Project = Join-Path $TestRoot 'project'
     New-Item -ItemType Directory -Path $Project | Out-Null
@@ -142,6 +194,14 @@ try {
         throw "project Go selector resolved to unexpected version '$ProjectGoOutput'"
     }
     $ProjectGoVersion = $ProjectGoMatch.Groups[1].Value
+    Set-Content -LiteralPath (Join-Path $Project '.fvmrc') -Value "{`"flutter`":`"$ProjectFlutterVersion`"}" -NoNewline
+    & $Pinset import --apply --from fvm --no-install
+    & $Pinset install --locked
+    $ProjectFlutterInfo = (((& flutter --version --machine) | Out-String).Trim() | ConvertFrom-Json)
+    if ($ProjectFlutterInfo.frameworkVersion -ne $ProjectFlutterVersion) {
+        throw "project Flutter returned unexpected version '$($ProjectFlutterInfo.frameworkVersion)'"
+    }
+    $ProjectDartVersion = [string]$ProjectFlutterInfo.dartSdkVersion
     Assert-ExactOutput "v$ProjectVersion" (& node --version) 'project direct node'
     Assert-VersionOutput (& npm --version) 'project direct npm'
     Assert-VersionOutput (& npx --version) 'project direct npx'
@@ -152,6 +212,21 @@ try {
     $ProjectGoRoot = ((& go env GOROOT) | Out-String).Trim()
     if ($ProjectGoRoot -notlike "$(Join-Path $env:PINSET_HOME "installs\go\$ProjectGoVersion")*") {
         throw "project Go reported an unmanaged GOROOT: '$ProjectGoRoot'"
+    }
+    $ProjectFlutterPath = ((& $Pinset which flutter) | Out-String).Trim()
+    $ProjectDartPath = ((& $Pinset which dart) | Out-String).Trim()
+    if ((Split-Path -Parent $ProjectFlutterPath) -ne (Split-Path -Parent $ProjectDartPath)) {
+        throw 'project Flutter and Dart resolved from different SDK directories'
+    }
+    $ProjectFlutterRoot = Split-Path -Parent (Split-Path -Parent $ProjectFlutterPath)
+    Assert-ExactOutput $ProjectFlutterRoot (& dart $FlutterEnvironmentScript) 'project Flutter root'
+    if (((& dart --version 2>&1) | Out-String).Trim() -notmatch "Dart SDK version: $([regex]::Escape($ProjectDartVersion))") {
+        throw 'project bundled Dart returned an unexpected version'
+    }
+    & $Pinset cache clean
+    $LockedReuse = ((& $Pinset install --locked) | Out-String)
+    if ($LockedReuse -notmatch "flutter@$([regex]::Escape($ProjectFlutterVersion)) is already installed") {
+        throw 'locked Flutter install did not reuse the completed SDK'
     }
     $PnpmChildNodeOutput = @(& pnpm exec node --version 2>&1 | ForEach-Object { $_.ToString() })
     $PnpmChildNodeStatus = $LASTEXITCODE
@@ -174,7 +249,14 @@ try {
         throw 'restored global direct Go returned an unexpected version'
     }
     Assert-ExactOutput 'local' (& go env GOTOOLCHAIN) 'restored global Go toolchain policy'
-    Write-Host 'Windows real Node, pnpm, Bun and Go acceptance passed'
+    $RestoredFlutter = (((& flutter --version --machine) | Out-String).Trim() | ConvertFrom-Json)
+    if ($RestoredFlutter.frameworkVersion -ne $GlobalFlutterVersion) {
+        throw 'restored global Flutter returned an unexpected version'
+    }
+    if (((& dart --version 2>&1) | Out-String).Trim() -notmatch "Dart SDK version: $([regex]::Escape($GlobalDartVersion))") {
+        throw 'restored global Dart returned an unexpected version'
+    }
+    Write-Host 'Windows real Node, pnpm, Bun, Go and Flutter acceptance passed'
 }
 finally {
     $env:PATH = $OriginalPath

--- a/scripts/tests/windows_runtime_acceptance.ps1
+++ b/scripts/tests/windows_runtime_acceptance.ps1
@@ -52,6 +52,28 @@ function Assert-VersionOutput {
     }
 }
 
+function ConvertFrom-FlutterMachineOutput {
+    param(
+        [Parameter(Mandatory = $true)][object[]]$Output,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    $Value = (($Output | ForEach-Object { $_.ToString() }) -join "`n").Trim()
+    $JsonStart = $Value.IndexOf('{')
+    $JsonEnd = $Value.LastIndexOf('}')
+    if ($JsonStart -lt 0 -or $JsonEnd -lt $JsonStart) {
+        throw "$Label did not return Flutter machine JSON: '$Value'"
+    }
+
+    $Json = $Value.Substring($JsonStart, $JsonEnd - $JsonStart + 1)
+    try {
+        return $Json | ConvertFrom-Json
+    }
+    catch {
+        throw "$Label returned invalid Flutter machine JSON: $($_.Exception.Message)"
+    }
+}
+
 try {
     New-Item -ItemType Directory -Path $TestRoot | Out-Null
     $env:PINSET_HOME = Join-Path $TestRoot 'pinset-home'
@@ -102,7 +124,7 @@ try {
     }
     $GlobalGoVersion = $GlobalGoMatch.Groups[1].Value
     & $Pinset global "flutter@$GlobalFlutterSelector"
-    $GlobalFlutterInfo = (((& $Pinset exec -- flutter --version --machine) | Out-String).Trim() | ConvertFrom-Json)
+    $GlobalFlutterInfo = ConvertFrom-FlutterMachineOutput @(& $Pinset exec -- flutter --version --machine) 'global Flutter'
     $GlobalFlutterVersion = [string]$GlobalFlutterInfo.frameworkVersion
     $GlobalDartVersion = [string]$GlobalFlutterInfo.dartSdkVersion
     if ($GlobalFlutterVersion -notmatch $VersionPattern -or $GlobalDartVersion -notmatch $VersionPattern) {
@@ -155,7 +177,7 @@ try {
         throw 'global direct Go returned an unexpected version'
     }
     Assert-ExactOutput 'local' (& go env GOTOOLCHAIN) 'global direct Go toolchain policy'
-    $DirectGlobalFlutter = (((& flutter --version --machine) | Out-String).Trim() | ConvertFrom-Json)
+    $DirectGlobalFlutter = ConvertFrom-FlutterMachineOutput @(& flutter --version --machine) 'global direct Flutter'
     if ($DirectGlobalFlutter.frameworkVersion -ne $GlobalFlutterVersion) {
         throw 'global direct Flutter returned an unexpected version'
     }
@@ -197,7 +219,7 @@ try {
     Set-Content -LiteralPath (Join-Path $Project '.fvmrc') -Value "{`"flutter`":`"$ProjectFlutterVersion`"}" -NoNewline
     & $Pinset import --apply --from fvm --no-install
     & $Pinset install --locked
-    $ProjectFlutterInfo = (((& flutter --version --machine) | Out-String).Trim() | ConvertFrom-Json)
+    $ProjectFlutterInfo = ConvertFrom-FlutterMachineOutput @(& flutter --version --machine) 'project Flutter'
     if ($ProjectFlutterInfo.frameworkVersion -ne $ProjectFlutterVersion) {
         throw "project Flutter returned unexpected version '$($ProjectFlutterInfo.frameworkVersion)'"
     }
@@ -249,7 +271,7 @@ try {
         throw 'restored global direct Go returned an unexpected version'
     }
     Assert-ExactOutput 'local' (& go env GOTOOLCHAIN) 'restored global Go toolchain policy'
-    $RestoredFlutter = (((& flutter --version --machine) | Out-String).Trim() | ConvertFrom-Json)
+    $RestoredFlutter = ConvertFrom-FlutterMachineOutput @(& flutter --version --machine) 'restored global Flutter'
     if ($RestoredFlutter.frameworkVersion -ne $GlobalFlutterVersion) {
         throw 'restored global Flutter returned an unexpected version'
     }

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -108,7 +108,7 @@ if (Test-Path -LiteralPath $PinsetHome) {
 
 $cliPath = Join-Path $InstallDir 'pinset.exe'
 $routerPath = Join-Path $InstallDir 'pinset-shim.exe'
-$routeCommands = @('node', 'npm', 'npx', 'corepack', 'pnpm', 'bun', 'bunx', 'go', 'gofmt')
+$routeCommands = @('node', 'npm', 'npx', 'corepack', 'pnpm', 'bun', 'bunx', 'go', 'gofmt', 'flutter', 'dart')
 
 function Test-ManagedRoute([string]$Path) {
     if ((Paths-Equal $Path $cliPath) -or (Paths-Equal $Path $routerPath)) {

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -9,7 +9,7 @@ SHIM_BINARY="${PINSET_SHIM_BINARY:-}"
 ASSUME_YES=0
 DRY_RUN=0
 ALLOW_NONSTANDARD_HOME=0
-ROUTE_COMMANDS="node npm npx corepack pnpm bun bunx go gofmt"
+ROUTE_COMMANDS="node npm npx corepack pnpm bun bunx go gofmt flutter dart"
 
 usage() {
     cat <<'EOF'


### PR DESCRIPTION
## Summary
- add Flutter stable SDK metadata, selectors, locking, verified installation, and bundled Dart routing
- add managed Flutter environment policy, FVM import, mutation protection, large-archive limits, and safe macOS ZIP symlink extraction
- extend documentation, uninstallers, and GitHub Actions real-runtime acceptance to Flutter/Dart on Ubuntu, Windows, and macOS

## Verification
- local: cargo fmt only, git diff checks, and PowerShell AST parsing
- intentionally not run locally: cargo build/check/test, Pinset execution, runtime installation, or WSL validation
- required: workflow_dispatch CI build and real-runtime acceptance on all three GitHub-hosted platforms before merge