### PR TITLE
fix: statically link liblzma on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,14 @@ jobs:
       - name: Build release binaries
         run: cargo build --release --locked -p pinset-cli -p pinset-shim
 
+      - name: Verify macOS release dependencies
+        if: runner.os == 'macOS'
+        shell: bash
+        run: >-
+          sh scripts/tests/macos_release_dependencies.sh
+          target/release/pinset
+          target/release/pinset-shim
+
       - name: Run real Node, pnpm, Bun and Go acceptance on macOS
         if: runner.os == 'macOS'
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,14 @@ jobs:
       - name: Build release binaries
         run: cargo build --release --locked -p pinset-cli -p pinset-shim
 
+      - name: Verify macOS release dependencies
+        if: runner.os == 'macOS'
+        shell: bash
+        run: >-
+          sh scripts/tests/macos_release_dependencies.sh
+          target/release/pinset
+          target/release/pinset-shim
+
       - name: Run real Node, pnpm, Bun and Go acceptance on Linux and macOS
         if: runner.os != 'Windows'
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,7 +1181,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "pinset-core",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "atomic-write-file",
  "base64",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.85"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Future Element"]
 
 [workspace.dependencies]
@@ -33,5 +33,5 @@ thiserror = "2"
 toml = "0.9"
 unicode-width = "0.2.2"
 url = "2.5"
-xz2 = "0.1"
+xz2 = { version = "0.1", features = ["static"] }
 zip = { version = "6.0.0", default-features = false, features = ["deflate"] }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Pinset 是一个本地优先的多语言运行时版本管理 CLI。目标是用
 
 `v0.4.0` 新增 Flutter stable SDK Provider，并将 SDK 内置 Dart 作为同一个锁定与路由单元。
 
+`v0.4.1` 将 XZ 解压依赖静态链接进 macOS 发布二进制，不要求用户安装 Homebrew `xz`。
+
 - 全局 Node 默认版本、项目级 Node 覆盖，以及离开项目后恢复全局版本；
 - `node@24.0.0`、`node@24`、`node@24.12`、`node@lts`、`node@current`；
 - pnpm 10/11 与 Bun 1.x 的精确、主版本、主次版本、`latest`/`current` 选择器；
@@ -45,10 +47,10 @@ pinset --version
 
 长期使用可自行把 `export PATH=...` 写入 `~/.bashrc` 或 `~/.zshrc`。Pinset 不会擅自修改这些文件。
 
-固定安装最新已发布的 `v0.4.0`：
+固定安装最新已发布的 `v0.4.1`：
 
 ```bash
-curl -fsSL https://github.com/Future-Element/pinset/releases/download/v0.4.0/install.sh | sh
+curl -fsSL https://github.com/Future-Element/pinset/releases/download/v0.4.1/install.sh | sh
 ```
 
 自定义安装目录：

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -4,9 +4,9 @@
 
 当前发布候选：无
 
-最新已发布版本：`v0.4.0`
+最新已发布版本：`v0.4.1`
 
-更新时间：`2026-08-13`
+更新时间：`2026-08-14`
 
 ## 路线原则
 
@@ -37,6 +37,7 @@ Pinset 将继续保持“一个工具统一选择、安装、锁定和路由开�
 | `v0.2.1` | 已发布 | pnpm、Bun 项目版本切换和安装路径修复 |
 | `v0.3.0` | 已发布 | Go Provider、Native Provider 通用化 |
 | `v0.4.0` | 已发布 | Flutter SDK Provider、内置 Dart 路由 |
+| `v0.4.1` | 已发布 | macOS liblzma 静态链接与发布依赖门禁 |
 | `v0.5.0` | 规划中 | CPython Provider |
 | `v0.6.0` | 规划中 | Eclipse Temurin JDK Provider |
 | `v0.7.0` | 规划中 | rustup 委托式 Rust Provider |

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Pinset Release Notes
 
+## v0.4.1
+
+- 发布日期：`2026-08-14`
+- 阶段：macOS 发布包可移植性修复
+- GitHub Release：[v0.4.1](https://github.com/Future-Element/pinset/releases/tag/v0.4.1)
+- 修复 macOS Apple Silicon 发布二进制动态依赖构建机 Homebrew `liblzma`、导致未安装 `xz` 的用户无法启动 Pinset 的问题；
+- 将 `xz2/lzma-sys` 静态链接进 Pinset，用户无需安装 Homebrew 或系统级 `xz`；
+- 在 CI 和 Release 的 macOS 构建后使用 `otool -L` 检查动态依赖，只允许 macOS 系统库与系统 Framework，阻止构建机包管理器路径进入发布归档。
+
 ## v0.4.0
 
 - 发布日期：`2026-08-13`

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="0.4.0"
+DEFAULT_VERSION="0.4.1"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -18,7 +18,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 0.4.0.
+  --version VERSION       Install an exact release, for example 0.4.1.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.

--- a/scripts/tests/macos_release_dependencies.sh
+++ b/scripts/tests/macos_release_dependencies.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <macOS release binary>..." >&2
+  exit 2
+fi
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "macOS release dependency verification requires Darwin" >&2
+  exit 2
+fi
+
+if ! command -v otool >/dev/null 2>&1; then
+  echo "otool is required to verify macOS release dependencies" >&2
+  exit 2
+fi
+
+for binary in "$@"; do
+  if [ ! -x "$binary" ]; then
+    echo "macOS release binary is not executable: $binary" >&2
+    exit 1
+  fi
+
+  dependencies="$(otool -L "$binary")"
+  printf '%s\n' "$dependencies"
+  unexpected="$(
+    printf '%s\n' "$dependencies" |
+      tail -n +2 |
+      awk '$1 !~ "^/usr/lib/" && $1 !~ "^/System/Library/" { print }'
+  )"
+  if [ -n "$unexpected" ]; then
+    echo "macOS release binary has non-system dynamic dependencies: $binary" >&2
+    printf '%s\n' "$unexpected" >&2
+    exit 1
+  fi
+done
+
+echo "macOS release binaries only depend on system libraries"


### PR DESCRIPTION
## Summary
- statically link xz2/lzma-sys so macOS users do not need Homebrew xz
- reject non-system macOS dynamic dependencies with an otool release gate
- bump the patch release to v0.4.1 and update release documentation

## Verification
- local: static diff, text, and version-consistency checks only
- intentionally not run locally or in WSL: cargo build/check/test, Pinset execution, or runtime installation
- required before merge: GitHub Actions Quality and workflow_dispatch three-platform build, including the macOS dependency gate
- Flutter SDK downloads remain skipped in Actions