### PR TITLE
fix: retry interrupted runtime downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,7 +1181,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "clap",
  "pinset-core",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "atomic-write-file",
  "base64",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.85"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Future Element"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Pinset 是一个本地优先的多语言运行时版本管理 CLI。目标是用
 
 `v0.4.1` 将 XZ 解压依赖静态链接进 macOS 发布二进制，不要求用户安装 Homebrew `xz`。
 
+`v0.4.2` 为中断的大型运行时下载增加同源自动重试和断点续传；短暂网络中断时会在同一条命令内继续下载 Flutter SDK。
+
 - 全局 Node 默认版本、项目级 Node 覆盖，以及离开项目后恢复全局版本；
 - `node@24.0.0`、`node@24`、`node@24.12`、`node@lts`、`node@current`；
 - pnpm 10/11 与 Bun 1.x 的精确、主版本、主次版本、`latest`/`current` 选择器；
@@ -47,10 +49,10 @@ pinset --version
 
 长期使用可自行把 `export PATH=...` 写入 `~/.bashrc` 或 `~/.zshrc`。Pinset 不会擅自修改这些文件。
 
-固定安装最新已发布的 `v0.4.1`：
+固定安装 `v0.4.2`：
 
 ```bash
-curl -fsSL https://github.com/Future-Element/pinset/releases/download/v0.4.1/install.sh | sh
+curl -fsSL https://github.com/Future-Element/pinset/releases/download/v0.4.2/install.sh | sh
 ```
 
 自定义安装目录：

--- a/crates/pinset-core/src/installer.rs
+++ b/crates/pinset-core/src/installer.rs
@@ -24,6 +24,9 @@ use crate::download_cache::{
 };
 use crate::{ArtifactIntegrity, Error, Result};
 
+const DOWNLOAD_ATTEMPTS_PER_SOURCE: usize = 3;
+const DOWNLOAD_RETRY_BASE_DELAY: Duration = Duration::from_millis(250);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ArtifactFormat {
     Zip,
@@ -484,11 +487,24 @@ impl Installer {
         expected_integrity: &ArtifactIntegrity,
         destination: &Path,
     ) -> Result<(u64, String)> {
-        let result = self.download_verified_inner(url, expected_integrity, destination);
-        if result.is_err() {
-            self.report_progress(DownloadProgressEvent::Failed);
+        for attempt in 1..=DOWNLOAD_ATTEMPTS_PER_SOURCE {
+            match self.download_verified_inner(url, expected_integrity, destination) {
+                Ok(result) => return Ok(result),
+                Err(error)
+                    if attempt < DOWNLOAD_ATTEMPTS_PER_SOURCE
+                        && is_retryable_source_error(&error) =>
+                {
+                    std::thread::sleep(
+                        DOWNLOAD_RETRY_BASE_DELAY.saturating_mul(attempt as u32),
+                    );
+                }
+                Err(error) => {
+                    self.report_progress(DownloadProgressEvent::Failed);
+                    return Err(error);
+                }
+            }
         }
-        result
+        unreachable!("the bounded download attempt loop always returns")
     }
 
     fn download_verified_inner(
@@ -1719,6 +1735,33 @@ mod tests {
     }
 
     #[test]
+    fn retries_an_interrupted_download_and_resumes_with_an_http_range_request() {
+        let root = tempdir().expect("temp root");
+        let archive = zip_bytes(&[(
+            "bin/node.exe",
+            b"fake node with enough bytes for an interrupted transfer",
+        )]);
+        let split = archive.len() / 2;
+        let hash = sha256_hex(&archive);
+        let (url, server) = serve_interrupted_then_range(archive.clone(), split);
+        let request = request(root.path(), url, hash.clone());
+
+        let outcome = test_installer()
+            .install(&request)
+            .expect("retried install");
+        server.join().expect("interrupted range server");
+
+        assert_eq!(outcome.bytes_downloaded, archive.len() as u64);
+        assert!(outcome.install_dir.join("bin/node.exe").is_file());
+        assert!(download_cache_path(root.path(), &hash)
+            .expect("download cache path")
+            .is_file());
+        assert!(!download_partial_path(root.path(), &hash)
+            .expect("partial path")
+            .exists());
+    }
+
+    #[test]
     fn installs_tar_xz_with_stripped_root_and_executable_permissions() {
         let archive = tar_xz_bytes(&[
             ("node-v24.0.0-linux-x64/bin/node", b"fake node", 0o755),
@@ -2361,6 +2404,61 @@ mod tests {
             .expect("range response headers");
             stream.write_all(&body).expect("range response body");
             stream.flush().expect("flush range response");
+        });
+        (format!("http://{address}/artifact.zip"), handle)
+    }
+
+    fn serve_interrupted_then_range(
+        body: Vec<u8>,
+        split: usize,
+    ) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind interrupted server");
+        let address = listener.local_addr().expect("interrupted server address");
+        let handle = thread::spawn(move || {
+            {
+                let (mut stream, _) = listener.accept().expect("accept initial request");
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(5)))
+                    .expect("initial read timeout");
+                let mut request = [0_u8; 4096];
+                let length = stream.read(&mut request).expect("read initial request");
+                let request = String::from_utf8_lossy(&request[..length]).to_ascii_lowercase();
+                assert!(!request.contains("range:"), "unexpected Range header");
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                )
+                .expect("initial response headers");
+                stream
+                    .write_all(&body[..split])
+                    .expect("interrupted response body");
+                stream.flush().expect("flush interrupted response");
+            }
+
+            let (mut stream, _) = listener.accept().expect("accept resumed request");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .expect("resumed read timeout");
+            let mut request = [0_u8; 4096];
+            let length = stream.read(&mut request).expect("read resumed request");
+            let request = String::from_utf8_lossy(&request[..length]).to_ascii_lowercase();
+            assert!(
+                request.contains(&format!("range: bytes={split}-")),
+                "missing expected Range header in {request:?}"
+            );
+            write!(
+                stream,
+                "HTTP/1.1 206 Partial Content\r\nContent-Length: {}\r\nContent-Range: bytes {split}-{}/{}\r\nConnection: close\r\n\r\n",
+                body.len() - split,
+                body.len() - 1,
+                body.len()
+            )
+            .expect("resumed response headers");
+            stream
+                .write_all(&body[split..])
+                .expect("resumed response body");
+            stream.flush().expect("flush resumed response");
         });
         (format!("http://{address}/artifact.zip"), handle)
     }

--- a/crates/pinset-core/src/installer.rs
+++ b/crates/pinset-core/src/installer.rs
@@ -494,9 +494,7 @@ impl Installer {
                     if attempt < DOWNLOAD_ATTEMPTS_PER_SOURCE
                         && is_retryable_source_error(&error) =>
                 {
-                    std::thread::sleep(
-                        DOWNLOAD_RETRY_BASE_DELAY.saturating_mul(attempt as u32),
-                    );
+                    std::thread::sleep(DOWNLOAD_RETRY_BASE_DELAY.saturating_mul(attempt as u32));
                 }
                 Err(error) => {
                     self.report_progress(DownloadProgressEvent::Failed);
@@ -1746,19 +1744,21 @@ mod tests {
         let (url, server) = serve_interrupted_then_range(archive.clone(), split);
         let request = request(root.path(), url, hash.clone());
 
-        let outcome = test_installer()
-            .install(&request)
-            .expect("retried install");
+        let outcome = test_installer().install(&request).expect("retried install");
         server.join().expect("interrupted range server");
 
         assert_eq!(outcome.bytes_downloaded, archive.len() as u64);
         assert!(outcome.install_dir.join("bin/node.exe").is_file());
-        assert!(download_cache_path(root.path(), &hash)
-            .expect("download cache path")
-            .is_file());
-        assert!(!download_partial_path(root.path(), &hash)
-            .expect("partial path")
-            .exists());
+        assert!(
+            download_cache_path(root.path(), &hash)
+                .expect("download cache path")
+                .is_file()
+        );
+        assert!(
+            !download_partial_path(root.path(), &hash)
+                .expect("partial path")
+                .exists()
+        );
     }
 
     #[test]

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -4,7 +4,7 @@
 
 当前发布候选：无
 
-最新已发布版本：`v0.4.1`
+最新已发布版本：`v0.4.2`
 
 更新时间：`2026-08-14`
 
@@ -38,6 +38,7 @@ Pinset 将继续保持“一个工具统一选择、安装、锁定和路由开�
 | `v0.3.0` | 已发布 | Go Provider、Native Provider 通用化 |
 | `v0.4.0` | 已发布 | Flutter SDK Provider、内置 Dart 路由 |
 | `v0.4.1` | 已发布 | macOS liblzma 静态链接与发布依赖门禁 |
+| `v0.4.2` | 已发布 | 大型运行时下载自动重试与断点续传 |
 | `v0.5.0` | 规划中 | CPython Provider |
 | `v0.6.0` | 规划中 | Eclipse Temurin JDK Provider |
 | `v0.7.0` | 规划中 | rustup 委托式 Rust Provider |

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Pinset Release Notes
 
+## v0.4.2
+
+- 发布日期：`2026-08-14`
+- 阶段：大型运行时下载可靠性补丁
+- GitHub Release：[v0.4.2](https://github.com/Future-Element/pinset/releases/tag/v0.4.2)
+- 同一下载源遇到请求或响应体读取中断时自动进行最多 3 次下载尝试；
+- 重试复用按完整性摘要隔离的 `.part` 文件，并使用经过 `Content-Range` 校验的 HTTP Range 请求续传，避免重新下载完整 Flutter SDK；
+- 校验和不匹配、超限和不安全缓存条目仍然立即失败，不会作为网络抖动重试；
+- 自动化测试使用小型本地 HTTP 故障注入归档，不在 GitHub Actions 下载 Flutter 大包。
+
 ## v0.4.1
 
 - 发布日期：`2026-08-14`

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="0.4.1"
+DEFAULT_VERSION="0.4.2"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -18,7 +18,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 0.4.1.
+  --version VERSION       Install an exact release, for example 0.4.2.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.


### PR DESCRIPTION
## Summary
- retry transient artifact request and response-body failures up to three attempts per source
- resume interrupted downloads from the integrity-scoped partial file with validated HTTP Range responses
- add a small fault-injection regression test without downloading the Flutter SDK in Actions
- bump the patch release to v0.4.2 and update release documentation

## Verification
- local: static diff, UTF-8 text, and version-consistency checks only
- intentionally not run locally or in WSL: cargo build/check/test, Pinset execution, or runtime installation
- required before merge: GitHub Actions Quality and workflow_dispatch three-platform build/runtime acceptance
- Flutter SDK downloads remain skipped in Actions