### PR TITLE
fix: release v0.6.1 with PATH precedence diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,7 +1181,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "clap",
  "pinset-core",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "atomic-write-file",
  "base64",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.85"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Future Element"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Pinset 是一个本地优先、完全独立的多语言运行时版本管理 CLI
 
 `v0.6.0` 新增 Eclipse Temurin JDK Provider，并修复 Python Provider 缺少 `pip`/`pip3` 直接路由的问题；Java 首期仅支持 JDK/HotSpot/GA，锁定精确 build、四平台归档和 SHA-256，并为受管进程设置 `JAVA_HOME`。
 
+`v0.6.1` 修复 macOS 等系统中 Pinset 路由目录虽然已在 PATH、却被更早的 `/usr/bin/java` 等系统命令遮挡时未给出提示的问题。Provider 注册会检查真正生效的命令路径，并按当前 Shell 输出可直接执行的激活命令。
+
 - 全局 Node 默认版本、项目级 Node 覆盖，以及离开项目后恢复全局版本；
 - `node@24.0.0`、`node@24`、`node@24.12`、`node@lts`、`node@current`；
 - pnpm 10/11 与 Bun 1.x 的精确、主版本、主次版本、`latest`/`current` 选择器；
@@ -46,19 +48,26 @@ curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.
 
 这条命令只安装 `pinset` 和通用路由器 `pinset-shim` 到 `$HOME/.local/bin`，不会自动安装 Node，也不会修改 shell profile。安装脚本会根据平台下载对应 Release 归档，并强制校验同一 Release 中的 `SHA256SUMS`。
 
-将 Pinset 加入当前终端的 PATH：
+将 Pinset 加入当前终端的 PATH，并确保它位于 `/usr/bin`、Homebrew 和其他运行时管理器之前：
 
 ```bash
 export PATH="$HOME/.local/bin:$PATH"
 pinset --version
 ```
 
-长期使用可自行把 `export PATH=...` 写入 `~/.bashrc` 或 `~/.zshrc`。Pinset 不会擅自修改这些文件。
-
-固定安装 `v0.5.0`：
+也可以只为当前 Shell 激活路由：
 
 ```bash
-curl -fsSL https://github.com/Future-Element/pinset/releases/download/v0.5.0/install.sh | sh
+eval "$(pinset activate zsh)"   # macOS 默认 Zsh
+eval "$(pinset activate bash)"  # Bash / WSL
+```
+
+长期使用可自行把 `export PATH=...` 写入 `~/.bashrc` 或 `~/.zshrc`。Pinset 不会擅自修改这些文件。
+
+固定安装 `v0.6.1`：
+
+```bash
+curl -fsSL https://github.com/Future-Element/pinset/releases/download/v0.6.1/install.sh | sh
 ```
 
 自定义安装目录：

--- a/crates/pinset/src/i18n.rs
+++ b/crates/pinset/src/i18n.rs
@@ -891,6 +891,8 @@ impl Catalog {
         installed: &[&str],
         preserved: &[&str],
         active: bool,
+        shadowed: &[String],
+        activation_command: &str,
     ) -> String {
         let installed = if installed.is_empty() {
             "-".to_owned()
@@ -905,9 +907,14 @@ impl Catalog {
         match self.language {
             Language::English => {
                 let activation = if active {
-                    ""
+                    String::new()
+                } else if shadowed.is_empty() {
+                    format!("; run `{activation_command}` in the current shell")
                 } else {
-                    "; run `eval \"$(pinset activate bash)\"` for the current Bash shell"
+                    format!(
+                        "; warning: earlier PATH entries shadow {}; run `{activation_command}` in the current shell",
+                        shadowed.join(",")
+                    )
                 };
                 format!(
                     "{provider} command routing ready: {} (created={installed}; managed-existing={preserved}){activation}",
@@ -916,9 +923,14 @@ impl Catalog {
             }
             Language::SimplifiedChinese => {
                 let activation = if active {
-                    ""
+                    String::new()
+                } else if shadowed.is_empty() {
+                    format!("；当前 Shell 请执行 `{activation_command}`")
                 } else {
-                    "；当前 Bash 请执行 `eval \"$(pinset activate bash)\"`"
+                    format!(
+                        "；警告：更早的 PATH 命令遮挡了 {}；当前 Shell 请执行 `{activation_command}`",
+                        shadowed.join(",")
+                    )
                 };
                 format!(
                     "{provider} 命令路由已就绪：{}（已创建={installed}；已有受管命令={preserved}）{activation}",

--- a/crates/pinset/src/i18n.rs
+++ b/crates/pinset/src/i18n.rs
@@ -890,10 +890,12 @@ impl Catalog {
         directory: &Path,
         installed: &[&str],
         preserved: &[&str],
-        active: bool,
-        shadowed: &[String],
-        activation_command: &str,
+        routing: Option<(&[String], &str)>,
     ) -> String {
+        let (active, shadowed, activation_command) = match routing {
+            Some((shadowed, activation_command)) => (false, shadowed, activation_command),
+            None => (true, &[] as &[String], ""),
+        };
         let installed = if installed.is_empty() {
             "-".to_owned()
         } else {

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -2730,17 +2730,14 @@ fn register_provider_commands(
     Ok(())
 }
 
-fn provider_command_routing_status(
-    shim_binary: &Path,
-    commands: &[String],
-) -> (bool, Vec<String>) {
+fn provider_command_routing_status(shim_binary: &Path, commands: &[String]) -> (bool, Vec<String>) {
     let mut active = true;
     let mut shadowed = Vec::new();
     for command in commands {
         let effective = path_command_candidates(command).into_iter().next();
         match effective {
-            Some(path)
-                if is_managed_command_shim(shim_binary, &path, command).unwrap_or(false) => {}
+            Some(path) if is_managed_command_shim(shim_binary, &path, command).unwrap_or(false) => {
+            }
             Some(path) => {
                 active = false;
                 shadowed.push(format!("{command}={}", path.display()));

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -2715,6 +2715,7 @@ fn register_provider_commands(
         .collect::<Vec<_>>();
     let (active, shadowed) = provider_command_routing_status(&shim_binary, &commands);
     let activation_command = current_shell_activation_command();
+    let routing = (!active).then_some((shadowed.as_slice(), activation_command));
     println!(
         "{}",
         catalog.provider_commands_registered(
@@ -2722,9 +2723,7 @@ fn register_provider_commands(
             &directory,
             &installed,
             &preserved,
-            active,
-            &shadowed,
-            activation_command,
+            routing,
         )
     );
     Ok(())

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -2701,7 +2701,8 @@ fn register_provider_commands(
         .map(|command| (*command).to_owned())
         .collect::<Vec<_>>();
     let directory = command_routing_directory(home)?;
-    let results = ensure_shims(&default_shim_binary()?, &directory, &commands)?;
+    let shim_binary = default_shim_binary()?;
+    let results = ensure_shims(&shim_binary, &directory, &commands)?;
     let installed = results
         .iter()
         .filter(|result| result.method != ShimInstallMethod::Existing)
@@ -2712,12 +2713,64 @@ fn register_provider_commands(
         .filter(|result| result.method == ShimInstallMethod::Existing)
         .map(|result| result.command.as_str())
         .collect::<Vec<_>>();
-    let active = directory_on_path(&directory);
+    let (active, shadowed) = provider_command_routing_status(&shim_binary, &commands);
+    let activation_command = current_shell_activation_command();
     println!(
         "{}",
-        catalog.provider_commands_registered(tool, &directory, &installed, &preserved, active)
+        catalog.provider_commands_registered(
+            tool,
+            &directory,
+            &installed,
+            &preserved,
+            active,
+            &shadowed,
+            activation_command,
+        )
     );
     Ok(())
+}
+
+fn provider_command_routing_status(
+    shim_binary: &Path,
+    commands: &[String],
+) -> (bool, Vec<String>) {
+    let mut active = true;
+    let mut shadowed = Vec::new();
+    for command in commands {
+        let effective = path_command_candidates(command).into_iter().next();
+        match effective {
+            Some(path)
+                if is_managed_command_shim(shim_binary, &path, command).unwrap_or(false) => {}
+            Some(path) => {
+                active = false;
+                shadowed.push(format!("{command}={}", path.display()));
+            }
+            None => active = false,
+        }
+    }
+    (active, shadowed)
+}
+
+fn current_shell_activation_command() -> &'static str {
+    activation_command_for_shell(env::var_os("SHELL").as_deref())
+}
+
+fn activation_command_for_shell(shell: Option<&std::ffi::OsStr>) -> &'static str {
+    let name = shell
+        .map(Path::new)
+        .and_then(Path::file_stem)
+        .and_then(std::ffi::OsStr::to_str)
+        .map(str::to_ascii_lowercase);
+    match name.as_deref() {
+        Some("zsh") => "eval \"$(pinset activate zsh)\"",
+        Some("fish") => "pinset activate fish | source",
+        Some("powershell" | "pwsh") => {
+            "pinset activate powershell | Out-String | Invoke-Expression"
+        }
+        Some("bash") => "eval \"$(pinset activate bash)\"",
+        _ if cfg!(windows) => "pinset activate powershell | Out-String | Invoke-Expression",
+        _ => "eval \"$(pinset activate bash)\"",
+    }
 }
 
 fn migrate_provider_shims(
@@ -2919,6 +2972,22 @@ mod tests {
         assert!(powershell.contains("$env:PATH"));
         assert!(powershell.contains("PathSeparator"));
         assert!(!powershell.contains("node"));
+    }
+
+    #[test]
+    fn recommends_activation_for_the_current_shell() {
+        assert_eq!(
+            activation_command_for_shell(Some(std::ffi::OsStr::new("/bin/zsh"))),
+            "eval \"$(pinset activate zsh)\""
+        );
+        assert_eq!(
+            activation_command_for_shell(Some(std::ffi::OsStr::new("/usr/bin/fish"))),
+            "pinset activate fish | source"
+        );
+        assert_eq!(
+            activation_command_for_shell(Some(std::ffi::OsStr::new("pwsh.exe"))),
+            "pinset activate powershell | Out-String | Invoke-Expression"
+        );
     }
 
     #[test]

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -2718,13 +2718,7 @@ fn register_provider_commands(
     let routing = (!active).then_some((shadowed.as_slice(), activation_command));
     println!(
         "{}",
-        catalog.provider_commands_registered(
-            tool,
-            &directory,
-            &installed,
-            &preserved,
-            routing,
-        )
+        catalog.provider_commands_registered(tool, &directory, &installed, &preserved, routing,)
     );
     Ok(())
 }

--- a/crates/pinset/tests/mvp_cli.rs
+++ b/crates/pinset/tests/mvp_cli.rs
@@ -354,6 +354,25 @@ fn locked_install_registers_provider_commands_without_downloading_a_runtime() {
         &["install", "--locked"],
     );
     assert_success_contains(&repeated, "managed-existing=node,npm,npx,corepack");
+
+    let system_bin = root.path().join("system-bin");
+    fs::create_dir(&system_bin).expect("system bin");
+    let system_node = system_bin.join(if cfg!(windows) {
+        "node.exe"
+    } else {
+        "node"
+    });
+    fs::write(&system_node, b"system node").expect("system node");
+    let shadowed = pinset_with_router_and_path(
+        &project,
+        &home,
+        &fake_shim,
+        &routing,
+        &[&system_bin, &routing],
+        &["install", "--locked"],
+    );
+    assert_success_contains(&shadowed, "earlier PATH entries shadow node=");
+    assert_success_contains(&shadowed, "pinset activate");
 }
 
 #[test]

--- a/crates/pinset/tests/mvp_cli.rs
+++ b/crates/pinset/tests/mvp_cli.rs
@@ -357,11 +357,7 @@ fn locked_install_registers_provider_commands_without_downloading_a_runtime() {
 
     let system_bin = root.path().join("system-bin");
     fs::create_dir(&system_bin).expect("system bin");
-    let system_node = system_bin.join(if cfg!(windows) {
-        "node.exe"
-    } else {
-        "node"
-    });
+    let system_node = system_bin.join(if cfg!(windows) { "node.exe" } else { "node" });
     fs::write(&system_node, b"system node").expect("system node");
     let shadowed = pinset_with_router_and_path(
         &project,

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -4,7 +4,7 @@
 
 当前发布候选：无
 
-最新已发布版本：`v0.6.0`
+最新已发布版本：`v0.6.1`
 
 更新时间：`2026-08-14`
 
@@ -41,6 +41,7 @@ Pinset 将继续保持“一个工具统一选择、安装、锁定和路由开�
 | `v0.4.2` | 已发布 | 大型运行时下载自动重试与断点续传 |
 | `v0.5.0` | 已发布 | CPython Provider、项目 `.venv` 与无激活路由 |
 | `v0.6.0` | 已发布 | Eclipse Temurin JDK Provider、Python pip/pip3 路由修复 |
+| `v0.6.1` | 已发布 | 检测 PATH 中被系统命令遮挡的 Provider 路由并给出当前 Shell 激活命令 |
 | `v0.7.0` | 规划中 | 原生 Rust Provider |
 
 ## v0.3.0 — Go Provider 与 Native Provider 通用化

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,14 +1,14 @@
 # Pinset PRD
 
-文档版本：`v0.6.0`
-产品阶段：`Eclipse Temurin JDK Provider development`
+文档版本：`v0.6.1`
+产品阶段：`Java command routing precedence patch`
 更新时间：`2026-08-14`
 
 ## 1. 产品简介
 
 Pinset 是一个本地优先、跨平台、完全独立的运行时版本管理 CLI。它只读取自己的配置和锁文件，用一致的命令完成版本选择、锁定、安装、执行、镜像、缓存和诊断。
 
-`v0.6.0` 在已发布的 Node.js、pnpm、Bun、Go、Flutter 和 CPython Provider 基础上新增 Eclipse Temurin JDK Provider。首期仅管理 JDK/HotSpot/GA 正式版本，Rust 暂不纳入本版本。
+`v0.6.0` 在已发布的 Node.js、pnpm、Bun、Go、Flutter 和 CPython Provider 基础上新增 Eclipse Temurin JDK Provider。`v0.6.1` 修复路由目录已在 PATH 但被更早系统命令遮挡时的生效状态误判与 Shell 激活提示。Rust 暂不纳入本补丁版本。
 
 ### 1.1 目标
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Pinset Release Notes
 
+## v0.6.1
+
+- 发布日期：`2026-08-14`
+- GitHub Release：[v0.6.1](https://github.com/Future-Element/pinset/releases/tag/v0.6.1)
+- 阶段：Provider 命令路由优先级补丁；
+- 修复路由目录已存在于 PATH、但 `java` 等命令被更早的系统路径遮挡时仍显示为已生效的问题；
+- Provider 注册后检查每个受管命令真正命中的首个 PATH 文件，并明确列出 `java=/usr/bin/java` 一类遮挡来源；
+- 根据当前 zsh、bash、fish 或 PowerShell 输出可直接执行的 `pinset activate` 命令；
+- 安装脚本在安装目录已位于 PATH 但不是首项时提示将其前置，仍不自动修改 shell profile。
+
 ## v0.6.0
 
 - 发布日期：`2026-08-14`

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="0.6.0"
+DEFAULT_VERSION="0.6.1"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -18,7 +18,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 0.6.0.
+  --version VERSION       Install an exact release, for example 0.6.1.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.
@@ -221,10 +221,18 @@ printf 'Installed %s\n' "$INSTALL_DIR/pinset"
 printf 'Installed %s\n' "$INSTALL_DIR/pinset-shim"
 "$INSTALL_DIR/pinset" --version
 
-case ":${PATH:-}:" in
-    *":$INSTALL_DIR:"*) ;;
+case "${PATH:-}" in
+    "$INSTALL_DIR"|"$INSTALL_DIR:"*) ;;
     *)
-        printf '\nAdd Pinset to the current shell:\n'
+        case ":${PATH:-}:" in
+            *":$INSTALL_DIR:"*)
+                printf '\nPinset is on PATH but may be shadowed by earlier system commands.\n'
+                printf 'Move Pinset to the front for the current shell:\n'
+                ;;
+            *)
+                printf '\nAdd Pinset to the current shell:\n'
+                ;;
+        esac
         printf '  export PATH="%s:$PATH"\n' "$INSTALL_DIR"
         ;;
 esac

--- a/scripts/tests/install_sh_test.sh
+++ b/scripts/tests/install_sh_test.sh
@@ -48,9 +48,13 @@ else
 fi
 printf '%s  %s\n' "$HASH" "$ARCHIVE" > "$RELEASE_DIR/SHA256SUMS"
 
-PINSET_INSTALL_TEST_MODE=1 \
-PINSET_TEST_RELEASE_BASE_URL="file://$RELEASE_DIR" \
-sh "$ROOT/install.sh" --install-dir "$INSTALL_DIR"
+INSTALL_OUTPUT=$(
+    PINSET_INSTALL_TEST_MODE=1 \
+    PINSET_TEST_RELEASE_BASE_URL="file://$RELEASE_DIR" \
+    sh "$ROOT/install.sh" --install-dir "$INSTALL_DIR"
+)
+printf '%s\n' "$INSTALL_OUTPUT" | grep -F 'Add Pinset to the current shell:'
+printf '%s\n' "$INSTALL_OUTPUT" | grep -F "export PATH=\"$INSTALL_DIR:\$PATH\""
 
 [ -x "$INSTALL_DIR/pinset" ]
 [ -x "$INSTALL_DIR/pinset-shim" ]
@@ -60,6 +64,26 @@ INSTALLED_ENTRIES=$(find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 -print | wc -l |
 for runtime_command in node npm npx corepack pnpm bun bunx go gofmt flutter dart python java; do
     [ ! -e "$INSTALL_DIR/$runtime_command" ]
 done
+
+FRONT_OUTPUT=$(
+    PATH="$INSTALL_DIR:/usr/bin:/bin" \
+    PINSET_INSTALL_TEST_MODE=1 \
+    PINSET_TEST_RELEASE_BASE_URL="file://$RELEASE_DIR" \
+    sh "$ROOT/install.sh" --install-dir "$INSTALL_DIR"
+)
+if printf '%s\n' "$FRONT_OUTPUT" | grep -F 'for the current shell:' >/dev/null; then
+    printf 'installer unexpectedly requested PATH activation when already first\n' >&2
+    exit 1
+fi
+
+SHADOWED_OUTPUT=$(
+    PATH="/usr/bin:$INSTALL_DIR:/bin" \
+    PINSET_INSTALL_TEST_MODE=1 \
+    PINSET_TEST_RELEASE_BASE_URL="file://$RELEASE_DIR" \
+    sh "$ROOT/install.sh" --install-dir "$INSTALL_DIR"
+)
+printf '%s\n' "$SHADOWED_OUTPUT" | grep -F 'Pinset is on PATH but may be shadowed by earlier system commands.'
+printf '%s\n' "$SHADOWED_OUTPUT" | grep -F 'Move Pinset to the front for the current shell:'
 
 BAD_RELEASE_DIR="$TEST_ROOT/bad-release"
 BAD_INSTALL_DIR="$TEST_ROOT/bad-install"


### PR DESCRIPTION
## Summary
- detect the effective command resolved from PATH for every managed provider command
- warn when system commands shadow Pinset shims and print shell-specific activation guidance
- cover installer PATH ordering and bump the patch release to v0.6.1

## Validation
- local checks were limited to static diff and version consistency checks
- build, test, install, and runtime acceptance are delegated to GitHub Actions VMs
- Flutter runtime download remains skipped in Actions because of its artifact size and will be verified by the maintainer after release