### PR TITLE
fix: satisfy v0.9.0 release quality

### DIFF
--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -1002,7 +1002,7 @@ fn selected_runtimes_for_outdated(
 ) -> Result<Vec<SelectedRuntime>, Box<dyn std::error::Error>> {
     let mut selected = Vec::new();
     let mut seen = BTreeSet::new();
-    if !global_only && let Some(path) = find_optional_project_config(&cwd)? {
+    if !global_only && let Some(path) = find_optional_project_config(cwd)? {
         for (selected_tool, version) in load_project_config(&path)?.tools {
             if tool.is_some_and(|tool| tool != selected_tool.as_str()) {
                 continue;
@@ -1018,7 +1018,7 @@ fn selected_runtimes_for_outdated(
             }
         }
     }
-    let global_path = global_config_path(&home);
+    let global_path = global_config_path(home);
     if let Some(global) = load_optional_global_config(&global_path)? {
         for (selected_tool, version) in global.tools {
             if tool.is_some_and(|tool| tool != selected_tool.as_str()) {

--- a/crates/pinset/tests/lifecycle_cli.rs
+++ b/crates/pinset/tests/lifecycle_cli.rs
@@ -150,7 +150,7 @@ fn emits_completion_for_each_supported_shell() {
 
 fn create_install(home: &Path, tool: &str, version: &str, command: &str) {
     let target = pinset_core::current_target_for_tool(tool);
-    let root = home.join("installs").join(tool).join(version).join(target);
+    let root = home.join("installs").join(tool).join(version).join(&target);
     let command_directory = pinset_core::runtime_command_directory(tool, &root);
     fs::create_dir_all(&command_directory).expect("command directory");
     fs::write(

--- a/crates/pinset/tests/provider_lifecycle_contract.rs
+++ b/crates/pinset/tests/provider_lifecycle_contract.rs
@@ -84,7 +84,7 @@ fn create_install<'a>(
     commands: impl Iterator<Item = &'a str>,
 ) {
     let target = pinset_core::current_target_for_tool(tool);
-    let root = home.join("installs").join(tool).join(version).join(target);
+    let root = home.join("installs").join(tool).join(version).join(&target);
     let command_directory = pinset_core::runtime_command_directory(tool, &root);
     fs::create_dir_all(&command_directory).expect("command directory");
     fs::write(


### PR DESCRIPTION
## Summary
- borrow the generated target while constructing lifecycle test fixture paths
- remove two needless path borrows reported by Clippy

## Verification
- cargo fmt --all -- --check
- cargo metadata --offline --no-deps --format-version 1
- git diff --check
- no local build, test, runtime installation, or WSL execution