### PR TITLE
fix: satisfy v1.0.0 release formatting

### DIFF
--- a/crates/pinset-core/src/lib.rs
+++ b/crates/pinset-core/src/lib.rs
@@ -45,12 +45,12 @@ mod lockfile;
 mod node_lifecycle;
 #[cfg(feature = "node-metadata")]
 mod node_metadata;
-#[cfg(feature = "node-metadata")]
-mod node_trust;
 #[cfg(feature = "node-provider")]
 mod node_provider;
 #[cfg(all(feature = "installer", feature = "lockfile"))]
 mod node_runtime;
+#[cfg(feature = "node-metadata")]
+mod node_trust;
 #[cfg(feature = "npm-metadata")]
 mod npm_metadata;
 #[cfg(all(feature = "installer", feature = "npm-metadata"))]

--- a/crates/pinset-core/src/lockfile.rs
+++ b/crates/pinset-core/src/lockfile.rs
@@ -499,8 +499,7 @@ fn validate_node_metadata(tool: &LockedTool) -> Result<()> {
     let fingerprint = tool.metadata.get("signature_primary_fingerprint");
     if tool.metadata.len() != expected.len()
         || expected.iter().any(|key| !tool.metadata.contains_key(*key))
-        || tool.metadata.get("signed_manifest").map(String::as_str)
-            != Some("SHASUMS256.txt.asc")
+        || tool.metadata.get("signed_manifest").map(String::as_str) != Some("SHASUMS256.txt.asc")
         || tool
             .metadata
             .get("manifest_source")
@@ -1236,8 +1235,7 @@ mod tests {
             "official".to_owned(),
             artifacts,
         );
-        https_checksums_only.tools[0].artifacts[0].verification =
-            "nodejs-shasums-https".to_owned();
+        https_checksums_only.tools[0].artifacts[0].verification = "nodejs-shasums-https".to_owned();
         let error = validate_lockfile(&https_checksums_only).expect_err("legacy verification");
         assert!(error.to_string().contains("pinset use node@<selector>"));
     }

--- a/crates/pinset-core/src/node_metadata.rs
+++ b/crates/pinset-core/src/node_metadata.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 
 use crate::{
     Error, LockedArtifact, LockedArtifactFormat, Lockfile, MVP_NODE_TARGETS, NodeArchiveFormat,
-    Result, SourceConfig, plan_node_artifact, node_trust::verify_node_manifest,
+    Result, SourceConfig, node_trust::verify_node_manifest, plan_node_artifact,
 };
 
 const OFFICIAL_NODE_DIST_URL: &str = "https://nodejs.org/dist/";
@@ -538,9 +538,11 @@ mod tests {
             node.metadata.get("manifest_source").map(String::as_str),
             Some("mirror")
         );
-        assert!(node.artifacts.iter().all(|artifact| {
-            artifact.verification == "nodejs-openpgp-sha256-source:mirror"
-        }));
+        assert!(
+            node.artifacts
+                .iter()
+                .all(|artifact| { artifact.verification == "nodejs-openpgp-sha256-source:mirror" })
+        );
     }
 
     #[test]

--- a/crates/pinset-core/src/node_trust.rs
+++ b/crates/pinset-core/src/node_trust.rs
@@ -121,11 +121,12 @@ pub(crate) fn verify_node_manifest(armored: &str) -> Result<VerifiedNodeManifest
 }
 
 fn trusted_keys() -> Result<Vec<SignedPublicKey>> {
-    let (keys, _) = SignedPublicKey::from_reader_many(NODE_RELEASE_KEYS.as_bytes()).map_err(
-        |source| Error::NodeTrustStoreInvalid {
-            reason: format!("cannot parse {NODE_RELEASE_KEYS_SOURCE}: {source}"),
-        },
-    )?;
+    let (keys, _) =
+        SignedPublicKey::from_reader_many(NODE_RELEASE_KEYS.as_bytes()).map_err(|source| {
+            Error::NodeTrustStoreInvalid {
+                reason: format!("cannot parse {NODE_RELEASE_KEYS_SOURCE}: {source}"),
+            }
+        })?;
     let allowlist = TRUSTED_PRIMARY_FINGERPRINTS
         .iter()
         .copied()

--- a/crates/pinset-core/src/rust_runtime.rs
+++ b/crates/pinset-core/src/rust_runtime.rs
@@ -81,11 +81,7 @@ pub fn install_locked_rust(
 fn required_rust_paths(target: &str) -> Result<Vec<PathBuf>> {
     if !matches!(
         target,
-        "windows-x86_64"
-            | "linux-x86_64"
-            | "linux-aarch64"
-            | "macos-x86_64"
-            | "macos-aarch64"
+        "windows-x86_64" | "linux-x86_64" | "linux-aarch64" | "macos-x86_64" | "macos-aarch64"
     ) {
         return Err(Error::UnsupportedRustTarget {
             target: target.to_owned(),

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -489,7 +489,10 @@ fn requested_json_command(arguments: &[OsString]) -> Option<String> {
         return Some(values[index].as_ref().to_owned());
     }
     let subcommand = values[index + 1..].iter().find(|value| {
-        matches!(value.as_ref(), "list" | "info" | "verify" | "repair" | "clean")
+        matches!(
+            value.as_ref(),
+            "list" | "info" | "verify" | "repair" | "clean"
+        )
     });
     Some(match subcommand {
         Some(subcommand) => format!("cache.{subcommand}"),

--- a/crates/pinset/tests/lifecycle_cli.rs
+++ b/crates/pinset/tests/lifecycle_cli.rs
@@ -21,7 +21,13 @@ fn lists_all_installed_versions_and_current_rust_as_json() {
     let listed: serde_json::Value = serde_json::from_slice(&listed.stdout).expect("installed JSON");
     assert_eq!(listed["schema"], 1);
     assert_eq!(listed["command"], "list");
-    assert_eq!(listed["data"]["versions"].as_array().expect("installed array").len(), 2);
+    assert_eq!(
+        listed["data"]["versions"]
+            .as_array()
+            .expect("installed array")
+            .len(),
+        2
+    );
 
     let current = pinset(&project, &home, &["current", "rust", "--json"]);
     assert_success(&current);


### PR DESCRIPTION
## Summary
- apply the Rust 1.85 rustfmt output required by the v1.0.0 release gate
- keep the change mechanical with no runtime behavior changes

## Validation
- static diff review and git diff --check completed locally
- no local or WSL build, test, Pinset execution, or Provider download performed
- GitHub Actions will perform the four-platform build validation