### PR TITLE
fix: satisfy v1.0.0 release Clippy gate

### DIFF
--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -2305,25 +2305,23 @@ fn install_tool_from_lock(
                 outcome.install_dir.display()
             );
         }
+    } else if tool == "node" {
+        println!(
+            "{}",
+            catalog.installed(
+                &locked_tool.version,
+                &target,
+                &outcome.source_id,
+                &outcome.install_dir,
+            )
+        );
     } else {
-        if tool == "node" {
-            println!(
-                "{}",
-                catalog.installed(
-                    &locked_tool.version,
-                    &target,
-                    &outcome.source_id,
-                    &outcome.install_dir,
-                )
-            );
-        } else {
-            println!(
-                "installed {tool}@{} for {target} from {} at {}",
-                locked_tool.version,
-                outcome.source_id,
-                outcome.install_dir.display()
-            );
-        }
+        println!(
+            "installed {tool}@{} for {target} from {} at {}",
+            locked_tool.version,
+            outcome.source_id,
+            outcome.install_dir.display()
+        );
     }
     if let Err(error) = register_provider_commands(home, tool, catalog) {
         eprintln!(


### PR DESCRIPTION
## Summary
- collapse the equivalent nested else/if reported by the v1.0.0 Clippy gate
- preserve the existing Node and non-Node install output behavior

## Validation
- static diff review and git diff --check completed locally
- no local or WSL build, test, Clippy, Pinset execution, or Provider download performed
- GitHub Actions will perform the four-platform build validation