### PR TITLE
test: cover Go Linux ARM64 source metadata

### DIFF
--- a/crates/pinset/tests/source_cli.rs
+++ b/crates/pinset/tests/source_cli.rs
@@ -183,6 +183,7 @@ fn tests_a_go_source_read_only_against_its_download_index() {
             {"filename":"go1.25.1.windows-amd64.zip","os":"windows","arch":"amd64","version":"go1.25.1","sha256":hash.clone(),"size":1,"kind":"archive"},
             {"filename":"go1.25.1.darwin-arm64.tar.gz","os":"darwin","arch":"arm64","version":"go1.25.1","sha256":hash.clone(),"size":1,"kind":"archive"},
             {"filename":"go1.25.1.darwin-amd64.tar.gz","os":"darwin","arch":"amd64","version":"go1.25.1","sha256":hash.clone(),"size":1,"kind":"archive"},
+            {"filename":"go1.25.1.linux-arm64.tar.gz","os":"linux","arch":"arm64","version":"go1.25.1","sha256":hash.clone(),"size":1,"kind":"archive"},
             {"filename":"go1.25.1.linux-amd64.tar.gz","os":"linux","arch":"amd64","version":"go1.25.1","sha256":hash,"size":1,"kind":"archive"}
         ]
     }])


### PR DESCRIPTION
Complete the offline Go source fixture for the v1.0.0 Linux ARM64 target.\n\nThe prior release gate showed that all other tests, including the repaired Node source test, pass; this fixture only lacked the required linux-arm64 archive entry.\n\nVerification is delegated to GitHub Actions; no local or WSL build/test/runtime command was run.