### PR TITLE
fix: complete ARM64 metadata target mappings

### DIFF
--- a/crates/pinset-core/src/java_metadata.rs
+++ b/crates/pinset-core/src/java_metadata.rs
@@ -378,6 +378,7 @@ fn binary_matches_target(binary: &ApiBinary, target: &str) -> bool {
     let (os, architecture) = match target {
         "windows-x86_64" => ("windows", "x64"),
         "linux-x86_64" => ("linux", "x64"),
+        "linux-aarch64" => ("linux", "aarch64"),
         "macos-x86_64" => ("mac", "x64"),
         "macos-aarch64" => ("mac", "aarch64"),
         _ => return false,
@@ -530,6 +531,7 @@ mod tests {
             let (os, arch, extension) = match *target {
                 "windows-x86_64" => ("windows", "x64", "zip"),
                 "linux-x86_64" => ("linux", "x64", "tar.gz"),
+                "linux-aarch64" => ("linux", "aarch64", "tar.gz"),
                 "macos-x86_64" => ("mac", "x64", "tar.gz"),
                 "macos-aarch64" => ("mac", "aarch64", "tar.gz"),
                 _ => unreachable!("known Java target"),

--- a/crates/pinset-core/src/lockfile.rs
+++ b/crates/pinset-core/src/lockfile.rs
@@ -1608,6 +1608,7 @@ mod tests {
         let (os, arch, extension) = match target {
             "windows-x86_64" => ("windows", "x64", "zip"),
             "linux-x86_64" => ("linux", "x64", "tar.gz"),
+            "linux-aarch64" => ("linux", "aarch64", "tar.gz"),
             "macos-x86_64" => ("mac", "x64", "tar.gz"),
             "macos-aarch64" => ("mac", "aarch64", "tar.gz"),
             _ => unreachable!("known Java target"),
@@ -1658,6 +1659,7 @@ mod tests {
         let (rid, extension) = match target {
             "windows-x86_64" => ("win-x64", "zip"),
             "linux-x86_64" => ("linux-x64", "tar.gz"),
+            "linux-aarch64" => ("linux-arm64", "tar.gz"),
             "macos-x86_64" => ("osx-x64", "tar.gz"),
             "macos-aarch64" => ("osx-arm64", "tar.gz"),
             _ => unreachable!("known .NET SDK target"),

--- a/crates/pinset-core/src/python_metadata.rs
+++ b/crates/pinset-core/src/python_metadata.rs
@@ -385,6 +385,7 @@ mod tests {
             let platform = match *target {
                 "windows-x86_64" => "x86_64-pc-windows-msvc",
                 "linux-x86_64" => "x86_64-unknown-linux-gnu",
+                "linux-aarch64" => "aarch64-unknown-linux-gnu",
                 "macos-x86_64" => "x86_64-apple-darwin",
                 "macos-aarch64" => "aarch64-apple-darwin",
                 _ => unreachable!("known Python target"),


### PR DESCRIPTION
Complete the remaining Linux ARM64 mappings exposed by the v1.0.0 offline release suite.\n\n- recognize Temurin Linux aarch64 binaries in Java metadata\n- include Linux aarch64 in Java and Python metadata fixtures\n- include Linux ARM64 in Java and .NET lockfile fixtures\n\nThe preceding release run passed every CLI integration test, including Node and Go source validation, before exposing these core fixture gaps. Verification is delegated to GitHub Actions; no local or WSL build/test/runtime command was run.