### PR TITLE
feat: release Pinset v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 1.5.0 - 2026-08-19
+
+This release deliberately changes the project-resolution contract before broad adoption.
+
+- Write schema 3 project/global configuration and lockfiles while retaining schema 1/2 readers.
+- Keep requested selectors in configuration and exact resolved versions in lockfiles.
+- Make projects strict by default, with explicit global inheritance, system fallback, and Git/filesystem boundary policy.
+- Add `pinset current --explain`, `pinset which --explain`, and traditional-source diagnostics in `pinset doctor`.
+- Add constraint-aware `pinset outdated`, lock-only `pinset update`, and explicit `pinset migrate`.
+- Move provider-specific traditional-file declarations into Provider manifests; ordinary runtime routing still does not inspect those files.
+
+Direct downgrade from schema 3 is not supported. Run `pinset migrate --dry-run` before migrating existing state and commit `pinset.toml` together with `pinset.lock`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,7 +2021,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "1.1.0"
+version = "1.5.0"
 dependencies = [
  "clap",
  "hex",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "1.1.0"
+version = "1.5.0"
 dependencies = [
  "atomic-write-file",
  "base64",
@@ -2065,7 +2065,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "1.1.0"
+version = "1.5.0"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.85"
-version = "1.1.0"
+version = "1.5.0"
 authors = ["Future Element"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ It manages Node.js, pnpm, Bun, Go, Python, Java, Rust, .NET, and Flutter/Dart th
 ## Highlights
 
 - One CLI for global defaults and reproducible project selections.
-- Exact versions and per-platform artifacts recorded in `pinset.lock`.
+- Requested selectors stay in `pinset.toml`; exact versions and per-platform artifacts are recorded in `pinset.lock`.
+- Strict project routing by default, with explicit global inheritance and system fallback policies.
+- Explainable resolution through `current --explain`, `which --explain`, and `doctor`.
 - Direct command routing through one small, runtime-independent shim.
 - Node.js release manifests verified with embedded OpenPGP trust roots before checksums are parsed.
 - Provider integrity checks, safe extraction, atomic installs, ownership-aware uninstall, and a content-addressed download cache.
@@ -40,7 +42,7 @@ export PATH="$HOME/.local/bin:$PATH"
 Run the same installer again to upgrade. To install an exact release or another absolute directory:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.1.0
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.5.0
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -127,7 +129,18 @@ pinset install --locked
 pinset exec -- node --version
 ```
 
-Commit `pinset.toml` and `pinset.lock`. Selectors such as `latest`, `lts`, `stable`, or a version prefix are resolved to exact versions in the lockfile.
+Commit `pinset.toml` and `pinset.lock`. Selectors such as `latest`, `lts`, `stable`, or version prefixes remain visible in `pinset.toml`; their exact resolved versions are recorded in the lockfile. `pinset outdated` distinguishes a compatible lock refresh from a selector-changing upgrade, and `pinset update --dry-run` previews compatible lock changes.
+
+Schema 3 projects are strict by default: once `pinset.toml` exists, an undeclared tool does not inherit a global selection or use the system `PATH`. Opt in deliberately when needed:
+
+```toml
+[policy]
+inherit-global = true
+system-fallback = false
+boundary = "git"
+```
+
+Resolution stops at the nearest Git root by default; it crosses that boundary only when the parent configuration itself explicitly sets `boundary = "filesystem"`. Use `pinset current node --explain` or `pinset which node --explain` to inspect every candidate and any traditional files that remain explicit migration inputs only. Existing schema 1/2 state remains readable; preview and perform its schema-only upgrade with `pinset migrate --dry-run` and `pinset migrate`.
 
 To migrate an existing repository, inspect traditional files locally first, then import and install their unambiguous selections:
 
@@ -166,13 +179,15 @@ Flutter does not publish an official Linux ARM64 SDK archive that matches Pinset
 
 See the complete [English command reference](docs/commands.md) or [Chinese command reference](docs/commands.zh-CN.md). It documents every command and subcommand, state changes, JSON support, exit codes, and common failures.
 
+For product positioning and trade-offs, see the sourced [Pinset v1.5 comparison (Chinese)](docs/comparison.zh-CN.md).
+
 ## Future Roadmap
 
 The roadmap describes direction, not promised versions or dates.
 
 | Status | Direction |
 | --- | --- |
-| Planned | v1.x migration and upgrade assistance for future stable protocol changes. |
+| Planned | Expand lock auditing, stable failure reason codes, and compatibility diagnostics. |
 | Exploring | Official distribution through Homebrew, Winget, Scoop, and similar channels. |
 | Exploring | Additional platforms and architectures when upstream runtimes provide suitable artifacts. |
 | Exploring | New Providers or a Provider extension mechanism, guided by real-world demand. |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,7 +13,9 @@ Pinset 是一个行为可预测、理解项目边界的多语言运行时版本�
 ## 核心特性
 
 - 使用一个 CLI 管理全局默认版本与可复现的项目版本。
-- 在 `pinset.lock` 中记录精确版本和各平台制品。
+- `pinset.toml` 保留用户请求的选择器，`pinset.lock` 记录精确版本和各平台制品。
+- 项目内默认严格路由，只有显式策略才允许继承全局版本或回退系统命令。
+- 通过 `current --explain`、`which --explain` 与 `doctor` 解释完整解析过程。
 - 通过一个轻量、与运行时无关的 shim 路由命令。
 - 解析摘要之前，先使用内嵌 OpenPGP 信任根验证 Node.js 发布清单。
 - Provider 完整性校验、安全解压、原子安装、带所有权检查的卸载，以及内容寻址下载缓存。
@@ -40,7 +42,7 @@ export PATH="$HOME/.local/bin:$PATH"
 再次运行同一安装脚本即可升级。也可以安装指定版本或使用其他绝对目录：
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.1.0
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.5.0
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -127,7 +129,18 @@ pinset install --locked
 pinset exec -- node --version
 ```
 
-请提交 `pinset.toml` 和 `pinset.lock`。`latest`、`lts`、`stable` 或版本前缀等选择器会在锁文件中解析为精确版本。
+请提交 `pinset.toml` 和 `pinset.lock`。`latest`、`lts`、`stable` 或版本前缀等选择器会保留在 `pinset.toml`，锁文件则记录其精确解析版本。`pinset outdated` 会区分“兼容选择器内可更新”与“必须修改选择器才能升级”，`pinset update --dry-run` 可预览兼容的锁更新。
+
+schema 3 项目默认严格：只要存在 `pinset.toml`，未声明的工具就不会继承全局选择，也不会使用系统 `PATH`。需要时必须明确选择：
+
+```toml
+[policy]
+inherit-global = true
+system-fallback = false
+boundary = "git"
+```
+
+默认解析边界是最近的 Git 根目录；只有父级配置自身明确设置 `boundary = "filesystem"` 时，才允许跨过 Git 边界。使用 `pinset current node --explain` 或 `pinset which node --explain` 可以查看每个候选，以及那些只作为显式迁移输入的传统配置文件。schema 1/2 状态仍可读取；可通过 `pinset migrate --dry-run` 预览，再运行 `pinset migrate` 完成仅格式层面的升级。
 
 迁移现有仓库时，先在本地检查传统配置，再导入并安装其中无歧义的选择：
 
@@ -166,13 +179,15 @@ Flutter 没有发布符合 Pinset 安装模型的官方 Linux ARM64 SDK 归档�
 
 请查阅完整的[中文命令文档](docs/commands.zh-CN.md)或[英文命令文档](docs/commands.md)。其中记录了每个命令及二级命令、状态修改、JSON 支持、退出码与常见错误。
 
+产品定位与取舍见带官方来源的 [Pinset v1.5 横向对比](docs/comparison.zh-CN.md)。
+
 ## 未来规划
 
 路线图只表达方向，不承诺具体版本或发布日期。
 
 | 状态 | 方向 |
 | --- | --- |
-| Planned | 为 v1.x 后续稳定协议变化提供迁移与升级辅助。 |
+| Planned | 扩展锁审计、失败原因码与兼容性迁移诊断。 |
 | Exploring | 评估通过 Homebrew、Winget、Scoop 等渠道进行官方分发。 |
 | Exploring | 在上游运行时提供合适制品时扩展平台和架构。 |
 | Exploring | 根据真实需求增加 Provider 或 Provider 扩展机制。 |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-Pinset 仍处于预发布阶段，目前只对最新 GitHub Release 提供安全修复。预发布版本可能包含不兼容变更。
+Pinset 只对最新发布的 GitHub Release 提供安全修复。仓库中的版本号不代表对应 Release 已经发布；报告问题时请同时注明实际安装版本和提交。
 
 ## Reporting a vulnerability
 

--- a/crates/pinset-core/src/config.rs
+++ b/crates/pinset-core/src/config.rs
@@ -112,10 +112,10 @@ pub fn find_project_context(start: &Path) -> Result<ProjectContext> {
             let boundary = if config.policy.boundary == ProjectBoundary::Filesystem {
                 filesystem_root(&start)
             } else {
-                default_boundary
+                default_boundary.clone()
             };
             return Ok(ProjectContext {
-                start,
+                start: start.clone(),
                 boundary,
                 config_path: Some(candidate),
             });

--- a/crates/pinset-core/src/config.rs
+++ b/crates/pinset-core/src/config.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::BTreeMap,
+    env,
     fs,
     path::{Path, PathBuf},
 };
@@ -19,9 +20,9 @@ use crate::{Error, Result};
 use crate::{Lockfile, lockfile_path, save_lockfile, validate_lock_matches_tools};
 
 pub const PROJECT_CONFIG_FILENAME: &str = "pinset.toml";
-pub const PROJECT_CONFIG_SCHEMA: u32 = 2;
+pub const PROJECT_CONFIG_SCHEMA: u32 = 3;
 #[cfg(feature = "project-write")]
-const MINIMAL_PROJECT_CONFIG: &[u8] = b"schema = 2\n\n[tools]\n";
+const MINIMAL_PROJECT_CONFIG: &[u8] = b"schema = 3\n\n[policy]\ninherit-global = false\nsystem-fallback = false\nboundary = \"git\"\n\n[tools]\n";
 #[cfg(all(feature = "project-write", feature = "lockfile"))]
 static PROJECT_STATE_WRITE_LOCK: Mutex<()> = Mutex::new(());
 
@@ -30,7 +31,47 @@ static PROJECT_STATE_WRITE_LOCK: Mutex<()> = Mutex::new(());
 pub struct ProjectConfig {
     pub schema: u32,
     #[serde(default)]
+    pub policy: ProjectPolicy,
+    #[serde(default)]
     pub tools: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ProjectBoundary {
+    Git,
+    Filesystem,
+}
+
+impl Default for ProjectBoundary {
+    fn default() -> Self {
+        Self::Git
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct ProjectPolicy {
+    pub inherit_global: bool,
+    pub system_fallback: bool,
+    pub boundary: ProjectBoundary,
+}
+
+impl Default for ProjectPolicy {
+    fn default() -> Self {
+        Self {
+            inherit_global: false,
+            system_fallback: false,
+            boundary: ProjectBoundary::Git,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectContext {
+    pub start: PathBuf,
+    pub boundary: PathBuf,
+    pub config_path: Option<PathBuf>,
 }
 
 impl ProjectConfig {
@@ -40,22 +81,77 @@ impl ProjectConfig {
 }
 
 pub fn find_project_config(start: &Path) -> Result<PathBuf> {
-    find_optional_project_config(start)?.ok_or_else(|| Error::ProjectConfigNotFound {
-        start: normalized_search_start(start).to_path_buf(),
+    let context = find_project_context(start)?;
+    context.config_path.ok_or_else(|| Error::ProjectConfigNotFound {
+        start: context.start,
     })
 }
 
 pub fn find_optional_project_config(start: &Path) -> Result<Option<PathBuf>> {
-    let start = normalized_search_start(start);
+    Ok(find_project_context(start)?.config_path)
+}
 
-    for directory in start.ancestors() {
+pub fn find_project_context(start: &Path) -> Result<ProjectContext> {
+    let start = normalized_search_start(start);
+    let start = if start.is_absolute() {
+        start.to_path_buf()
+    } else {
+        env::current_dir()
+            .map_err(|source| Error::ReadProjectConfig {
+                path: start.to_path_buf(),
+                source,
+            })?
+            .join(start)
+    };
+    let default_boundary = nearest_git_root(&start).unwrap_or_else(|| start.clone());
+
+    for directory in ancestors_through(&start, &default_boundary) {
         let candidate = directory.join(PROJECT_CONFIG_FILENAME);
         if candidate.is_file() {
-            return Ok(Some(candidate));
+            let config = load_project_config(&candidate)?;
+            let boundary = if config.policy.boundary == ProjectBoundary::Filesystem {
+                filesystem_root(&start)
+            } else {
+                default_boundary
+            };
+            return Ok(ProjectContext {
+                start,
+                boundary,
+                config_path: Some(candidate),
+            });
         }
     }
 
-    Ok(None)
+    // A configuration above the normal Git/home boundary is considered only when it explicitly
+    // opts into filesystem-wide discovery. This preserves an escape hatch without allowing an
+    // unrelated parent configuration to silently capture a repository.
+    let mut above_boundary = false;
+    for directory in start.ancestors() {
+        if !above_boundary {
+            if directory == default_boundary {
+                above_boundary = true;
+            }
+            continue;
+        }
+        let candidate = directory.join(PROJECT_CONFIG_FILENAME);
+        if candidate.is_file() {
+            let config = load_project_config(&candidate)?;
+            if config.policy.boundary == ProjectBoundary::Filesystem {
+                return Ok(ProjectContext {
+                    start: start.clone(),
+                    boundary: filesystem_root(&start),
+                    config_path: Some(candidate),
+                });
+            }
+            break;
+        }
+    }
+
+    Ok(ProjectContext {
+        start,
+        boundary: default_boundary,
+        config_path: None,
+    })
 }
 
 fn normalized_search_start(start: &Path) -> &Path {
@@ -64,6 +160,30 @@ fn normalized_search_start(start: &Path) -> &Path {
     } else {
         start
     }
+}
+
+fn nearest_git_root(start: &Path) -> Option<PathBuf> {
+    start
+        .ancestors()
+        .find(|directory| {
+            let marker = directory.join(".git");
+            marker.is_file() || marker.is_dir()
+        })
+        .map(Path::to_path_buf)
+}
+
+fn filesystem_root(start: &Path) -> PathBuf {
+    start
+        .ancestors()
+        .last()
+        .unwrap_or(start)
+        .to_path_buf()
+}
+
+fn ancestors_through<'a>(start: &'a Path, boundary: &'a Path) -> impl Iterator<Item = &'a Path> {
+    start
+        .ancestors()
+        .take_while(move |directory| directory.starts_with(boundary))
 }
 
 pub fn load_project_config(path: &Path) -> Result<ProjectConfig> {
@@ -77,7 +197,7 @@ pub fn load_project_config(path: &Path) -> Result<ProjectConfig> {
             source,
         })?;
 
-    if !matches!(config.schema, 1 | PROJECT_CONFIG_SCHEMA) {
+    if !matches!(config.schema, 1 | 2 | PROJECT_CONFIG_SCHEMA) {
         return Err(Error::UnsupportedSchema {
             actual: config.schema,
         });
@@ -119,7 +239,7 @@ pub fn create_project_config(directory: &Path) -> Result<PathBuf> {
 
 #[cfg(feature = "project-write")]
 pub fn save_project_config(path: &Path, config: &ProjectConfig) -> Result<()> {
-    if !matches!(config.schema, 1 | PROJECT_CONFIG_SCHEMA) {
+    if !matches!(config.schema, 1 | 2 | PROJECT_CONFIG_SCHEMA) {
         return Err(Error::UnsupportedSchema {
             actual: config.schema,
         });
@@ -171,6 +291,7 @@ mod tests {
         let root = tempdir().expect("temp directory");
         let nested = root.path().join("packages").join("web").join("src");
         fs::create_dir_all(&nested).expect("nested directory");
+        fs::create_dir(root.path().join(".git")).expect("git marker");
         fs::write(
             root.path().join("pinset.toml"),
             "schema = 1\n[tools]\nnode = \"20.0.0\"\n",
@@ -191,6 +312,43 @@ mod tests {
     }
 
     #[test]
+    fn git_boundary_prevents_parent_project_capture() {
+        let root = tempdir().expect("temp directory");
+        let repository = root.path().join("repo");
+        let nested = repository.join("packages").join("app");
+        fs::create_dir_all(repository.join(".git")).expect("git marker");
+        fs::create_dir_all(&nested).expect("nested directory");
+        fs::write(
+            root.path().join(PROJECT_CONFIG_FILENAME),
+            "schema = 3\n[tools]\nnode = \"24\"\n",
+        )
+        .expect("parent config");
+
+        let context = find_project_context(&nested).expect("project context");
+        assert_eq!(context.boundary, repository);
+        assert_eq!(context.config_path, None);
+    }
+
+    #[test]
+    fn filesystem_policy_can_cross_the_git_boundary() {
+        let root = tempdir().expect("temp directory");
+        let repository = root.path().join("repo");
+        let nested = repository.join("packages").join("app");
+        fs::create_dir_all(repository.join(".git")).expect("git marker");
+        fs::create_dir_all(&nested).expect("nested directory");
+        let parent_config = root.path().join(PROJECT_CONFIG_FILENAME);
+        fs::write(
+            &parent_config,
+            "schema = 3\n[policy]\nboundary = \"filesystem\"\n[tools]\n",
+        )
+        .expect("parent config");
+
+        let context = find_project_context(&nested).expect("project context");
+        assert_eq!(context.config_path, Some(parent_config));
+        assert_eq!(context.boundary, filesystem_root(&nested));
+    }
+
+    #[test]
     fn rejects_executable_or_unknown_config_fields() {
         let root = tempdir().expect("temp directory");
         let config_path = root.path().join("pinset.toml");
@@ -208,10 +366,10 @@ mod tests {
     fn rejects_unknown_schema() {
         let root = tempdir().expect("temp directory");
         let config_path = root.path().join("pinset.toml");
-        fs::write(&config_path, "schema = 3\n[tools]\nnode = \"20\"\n").expect("config");
+        fs::write(&config_path, "schema = 4\n[tools]\nnode = \"20\"\n").expect("config");
 
         let error = load_project_config(&config_path).expect_err("schema must fail");
-        assert!(matches!(error, Error::UnsupportedSchema { actual: 3 }));
+        assert!(matches!(error, Error::UnsupportedSchema { actual: 4 }));
     }
 
     #[cfg(feature = "project-write")]
@@ -225,12 +383,13 @@ mod tests {
             load_project_config(&path).expect("load created config"),
             ProjectConfig {
                 schema: PROJECT_CONFIG_SCHEMA,
+                policy: ProjectPolicy::default(),
                 tools: BTreeMap::new(),
             }
         );
         assert_eq!(
             fs::read_to_string(path).expect("created config"),
-            "schema = 2\n\n[tools]\n"
+            "schema = 3\n\n[policy]\ninherit-global = false\nsystem-fallback = false\nboundary = \"git\"\n\n[tools]\n"
         );
     }
 
@@ -314,6 +473,7 @@ mod tests {
         let config_path = root.path().join(PROJECT_CONFIG_FILENAME);
         let config = ProjectConfig {
             schema: PROJECT_CONFIG_SCHEMA,
+            policy: ProjectPolicy::default(),
             tools: BTreeMap::new(),
         };
         let lockfile = Lockfile {

--- a/crates/pinset-core/src/error.rs
+++ b/crates/pinset-core/src/error.rs
@@ -19,7 +19,7 @@ pub enum Error {
         source: toml::de::Error,
     },
 
-    #[error("unsupported pinset.toml schema {actual}; this version supports schemas 1 and 2")]
+    #[error("unsupported pinset.toml schema {actual}; this version supports schemas 1, 2 and 3")]
     UnsupportedSchema { actual: u32 },
 
     #[error("global config does not exist: {path}")]
@@ -39,7 +39,7 @@ pub enum Error {
         source: toml::de::Error,
     },
 
-    #[error("unsupported global.toml schema {actual}; this version supports schema 1")]
+    #[error("unsupported global.toml schema {actual}; this version supports schemas 1, 2 and 3")]
     UnsupportedGlobalConfigSchema { actual: u32 },
 
     #[error("failed to read user settings {path}: {source}")]
@@ -122,7 +122,7 @@ pub enum Error {
     },
 
     #[cfg(feature = "lockfile")]
-    #[error("unsupported pinset.lock schema {actual}; this version supports schemas 1 and 2")]
+    #[error("unsupported pinset.lock schema {actual}; this version supports schemas 1, 2 and 3")]
     UnsupportedLockfileSchema { actual: u32 },
 
     #[cfg(feature = "lockfile")]
@@ -187,6 +187,11 @@ pub enum Error {
 
     #[error("tool \"{tool}\" is not declared in {config_path}")]
     ToolNotConfigured { tool: String, config_path: PathBuf },
+
+    #[error(
+        "tool \"{tool}\" is not declared in strict project {config_path}; add it with `pinset use {tool}@<selector>` or explicitly enable project fallback"
+    )]
+    ProjectToolSelectionRequired { tool: String, config_path: PathBuf },
 
     #[error(
         "no version selected for tool \"{tool}\"; checked project ancestors from {start} and global config {global_config_path}"

--- a/crates/pinset-core/src/global_state.rs
+++ b/crates/pinset-core/src/global_state.rs
@@ -16,7 +16,7 @@ use crate::{Error, Result};
 #[cfg(all(feature = "state-write", feature = "lockfile"))]
 use crate::{Lockfile, save_lockfile, validate_lock_matches_tools};
 
-pub const GLOBAL_STATE_SCHEMA: u32 = 2;
+pub const GLOBAL_STATE_SCHEMA: u32 = 3;
 pub const GLOBAL_CONFIG_FILENAME: &str = "global.toml";
 pub const GLOBAL_LOCKFILE_FILENAME: &str = "global.lock";
 
@@ -89,7 +89,7 @@ pub fn load_optional_global_config(path: &Path) -> Result<Option<GlobalConfig>> 
 }
 
 fn validate_global_config(config: &GlobalConfig) -> Result<()> {
-    if !matches!(config.schema, 1 | GLOBAL_STATE_SCHEMA) {
+    if !matches!(config.schema, 1 | 2 | GLOBAL_STATE_SCHEMA) {
         return Err(Error::UnsupportedGlobalConfigSchema {
             actual: config.schema,
         });
@@ -197,10 +197,10 @@ mod tests {
             Err(Error::ParseGlobalConfig { .. })
         ));
 
-        fs::write(&path, "schema = 3\n[tools]\n").expect("unsupported config");
+        fs::write(&path, "schema = 4\n[tools]\n").expect("unsupported config");
         assert!(matches!(
             load_global_config(&path),
-            Err(Error::UnsupportedGlobalConfigSchema { actual: 3 })
+            Err(Error::UnsupportedGlobalConfigSchema { actual: 4 })
         ));
     }
 

--- a/crates/pinset-core/src/lib.rs
+++ b/crates/pinset-core/src/lib.rs
@@ -86,8 +86,9 @@ mod user_settings;
 #[cfg(all(feature = "project-write", feature = "lockfile"))]
 pub use config::save_project_state;
 pub use config::{
-    PROJECT_CONFIG_FILENAME, PROJECT_CONFIG_SCHEMA, ProjectConfig, find_optional_project_config,
-    find_project_config, load_project_config,
+    PROJECT_CONFIG_FILENAME, PROJECT_CONFIG_SCHEMA, ProjectBoundary, ProjectConfig, ProjectContext,
+    ProjectPolicy, find_optional_project_config, find_project_config, find_project_context,
+    load_project_config,
 };
 #[cfg(feature = "project-write")]
 pub use config::{create_project_config, save_project_config};
@@ -224,8 +225,9 @@ pub use runtime_lifecycle::{
     uninstall_tool_version,
 };
 pub use runtime_provider::{
-    RuntimeCommandLayout, RuntimeEnvironmentKind, RuntimeInstallKind, RuntimeMetadataKind,
-    RuntimeProvider, runtime_provider, runtime_provider_for_command, runtime_providers,
+    RuntimeCommandLayout, RuntimeDiscoveryKind, RuntimeDiscoveryRule, RuntimeEnvironmentKind,
+    RuntimeInstallKind, RuntimeMetadataKind, RuntimeProvider, runtime_provider,
+    runtime_provider_for_command, runtime_providers,
 };
 #[cfg(feature = "rust-metadata")]
 pub use rust_metadata::{RustMetadataClient, RustRelease};

--- a/crates/pinset-core/src/lockfile.rs
+++ b/crates/pinset-core/src/lockfile.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 pub const LOCKFILE_FILENAME: &str = "pinset.lock";
-pub const LOCKFILE_SCHEMA: u32 = 2;
+pub const LOCKFILE_SCHEMA: u32 = 3;
 pub const MVP_NODE_TARGETS: [&str; 5] = [
     "windows-x86_64",
     "macos-aarch64",
@@ -230,18 +230,18 @@ pub fn validate_lock_matches_project<'a>(
 
 pub fn validate_lock_matches_selection<'a>(
     lockfile: &'a Lockfile,
-    selected_node_version: &str,
+    selected_node_selector: &str,
     selection_path: &Path,
 ) -> Result<&'a LockedTool> {
     let tool = lockfile.tool("node").ok_or(Error::LockedToolMissing {
         tool: "node".to_owned(),
     })?;
-    if tool.requested != selected_node_version || tool.version != selected_node_version {
+    if tool.requested != selected_node_selector {
         return Err(Error::LockfileMismatch {
             selection_path: selection_path.to_path_buf(),
             tool: "node".to_owned(),
-            configured: selected_node_version.to_owned(),
-            locked: tool.version.clone(),
+            configured: selected_node_selector.to_owned(),
+            locked: format!("{} -> {}", tool.requested, tool.version),
         });
     }
     Ok(tool)
@@ -250,7 +250,7 @@ pub fn validate_lock_matches_selection<'a>(
 pub fn validate_lock_matches_tool<'a>(
     lockfile: &'a Lockfile,
     tool_name: &str,
-    selected_version: &str,
+    selected_selector: &str,
     selection_path: &Path,
 ) -> Result<&'a LockedTool> {
     let tool = lockfile
@@ -258,12 +258,12 @@ pub fn validate_lock_matches_tool<'a>(
         .ok_or_else(|| Error::LockedToolMissing {
             tool: tool_name.to_owned(),
         })?;
-    if tool.requested != selected_version || tool.version != selected_version {
+    if tool.requested != selected_selector {
         return Err(Error::LockfileMismatch {
             selection_path: selection_path.to_path_buf(),
             tool: tool_name.to_owned(),
-            configured: selected_version.to_owned(),
-            locked: tool.version.clone(),
+            configured: selected_selector.to_owned(),
+            locked: format!("{} -> {}", tool.requested, tool.version),
         });
     }
     Ok(tool)
@@ -289,7 +289,7 @@ pub fn validate_lock_matches_tools(
 }
 
 fn validate_lockfile(lockfile: &Lockfile) -> Result<()> {
-    if !matches!(lockfile.schema, 1 | LOCKFILE_SCHEMA) {
+    if !matches!(lockfile.schema, 1 | 2 | LOCKFILE_SCHEMA) {
         return Err(Error::UnsupportedLockfileSchema {
             actual: lockfile.schema,
         });
@@ -307,6 +307,14 @@ fn validate_lockfile(lockfile: &Lockfile) -> Result<()> {
             });
         }
         validate_locked_tool(tool)?;
+        if lockfile.schema < LOCKFILE_SCHEMA && tool.requested != tool.version {
+            return Err(Error::InvalidLockfile {
+                reason: format!(
+                    "schema {} requires {} requested and resolved versions to match",
+                    lockfile.schema, tool.name
+                ),
+            });
+        }
     }
     if lockfile.schema == 1 && lockfile.tools.iter().any(|tool| tool.name != "node") {
         return Err(Error::InvalidLockfile {
@@ -337,12 +345,9 @@ fn validate_locked_tool(tool: &LockedTool) -> Result<()> {
             ),
         });
     }
-    if tool.requested != tool.version {
+    if tool.requested.trim().is_empty() {
         return Err(Error::InvalidLockfile {
-            reason: format!(
-                "{} requires requested and version to be the same exact version",
-                tool.name
-            ),
+            reason: format!("{} requested selector cannot be empty", tool.name),
         });
     }
     if tool.name != "node"
@@ -1177,6 +1182,36 @@ mod tests {
                 "windows-x86_64",
             ]
         );
+    }
+
+    #[test]
+    fn schema_three_separates_requested_selector_from_resolved_version() {
+        let artifacts = MVP_NODE_TARGETS
+            .into_iter()
+            .map(locked_artifact)
+            .collect::<Vec<_>>();
+        let mut lockfile = Lockfile::new_node(
+            "pinset 1.5.0".to_owned(),
+            "24.0.0".to_owned(),
+            "5BE8A3F6C8A5C01D106C0AD820B1A390B168D356".to_owned(),
+            "official".to_owned(),
+            artifacts,
+        );
+        lockfile.tools[0].requested = "24".to_owned();
+
+        validate_lockfile(&lockfile).expect("schema 3 accepts a selector");
+        assert_eq!(
+            validate_lock_matches_selection(&lockfile, "24", Path::new("pinset.toml"))
+                .expect("selector matches")
+                .version,
+            "24.0.0"
+        );
+
+        lockfile.schema = 2;
+        assert!(matches!(
+            validate_lockfile(&lockfile),
+            Err(Error::InvalidLockfile { .. })
+        ));
     }
 
     #[test]

--- a/crates/pinset-core/src/node_lifecycle.rs
+++ b/crates/pinset-core/src/node_lifecycle.rs
@@ -4,11 +4,11 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{
-    Error, Result, find_optional_project_config, global_config_path, load_optional_global_config,
-    load_project_config, validate_exact_node_version,
-};
 use serde::Deserialize;
+
+use crate::{Error, Result, find_tool_version_references, validate_exact_node_version};
+#[cfg(test)]
+use crate::global_config_path;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstalledNodeVersion {
@@ -81,34 +81,15 @@ pub fn find_node_version_references(
     version: &str,
 ) -> Result<Vec<NodeVersionReference>> {
     validate_exact_node_version(version)?;
-    let mut references = Vec::new();
-    if let Some(path) = find_optional_project_config(cwd)? {
-        let config = load_project_config(&path)?;
-        if config
-            .tools
-            .get("node")
-            .is_some_and(|selected| selected == version)
-        {
-            references.push(NodeVersionReference {
-                scope: "project",
-                path,
-            });
-        }
-    }
-    let path = global_config_path(pinset_home);
-    if let Some(config) = load_optional_global_config(&path)? {
-        if config
-            .tools
-            .get("node")
-            .is_some_and(|selected| selected == version)
-        {
-            references.push(NodeVersionReference {
-                scope: "global",
-                path,
-            });
-        }
-    }
-    Ok(references)
+    find_tool_version_references(pinset_home, cwd, "node", version).map(|references| {
+        references
+            .into_iter()
+            .map(|reference| NodeVersionReference {
+                scope: reference.scope,
+                path: reference.path,
+            })
+            .collect()
+    })
 }
 
 pub fn uninstall_node_version(

--- a/crates/pinset-core/src/project_discovery.rs
+++ b/crates/pinset-core/src/project_discovery.rs
@@ -7,7 +7,9 @@ use std::{
 
 use serde::Serialize;
 
-use crate::{PROJECT_CONFIG_FILENAME, runtime_provider};
+use crate::{
+    PROJECT_CONFIG_FILENAME, RuntimeDiscoveryKind, runtime_provider, runtime_providers,
+};
 
 const MAX_SOURCE_BYTES: u64 = 1024 * 1024;
 
@@ -92,39 +94,10 @@ pub fn scan_project_sources(start: &Path) -> io::Result<DiscoveryReport> {
 
     let mut scanner = Scanner::new(boundary.clone());
     for directory in &directories {
-        scanner.scan_simple("nvmrc", &directory.join(".nvmrc"), "node", normalize_node);
-        scanner.scan_simple(
-            "node-version",
-            &directory.join(".node-version"),
-            "node",
-            normalize_node,
-        );
-        scanner.scan_simple(
-            "bun-version",
-            &directory.join(".bun-version"),
-            "bun",
-            normalize_bun,
-        );
-        scanner.scan_simple(
-            "go-version",
-            &directory.join(".go-version"),
-            "go",
-            normalize_go,
-        );
-        scanner.scan_python_version(directory);
-        scanner.scan_simple(
-            "java-version",
-            &directory.join(".java-version"),
-            "java",
-            normalize_java,
-        );
+        scanner.scan_provider_sources(directory);
         scanner.scan_package_json(directory);
         scanner.scan_go_file(directory, "go.mod");
         scanner.scan_go_file(directory, "go.work");
-        scanner.scan_fvm(directory);
-        scanner.scan_sdkman(directory);
-        scanner.scan_rust(directory);
-        scanner.scan_global_json(directory);
         scanner.scan_tool_versions(directory);
         scanner.scan_mise(directory);
         scanner.scan_pyproject(directory);
@@ -214,6 +187,26 @@ impl Scanner {
         })
     }
 
+    fn scan_provider_sources(&mut self, directory: &Path) {
+        for provider in runtime_providers() {
+            for rule in provider.discovery {
+                match rule.kind {
+                    RuntimeDiscoveryKind::SimpleFile { filename } => self.scan_simple(
+                        rule.source,
+                        &directory.join(filename),
+                        provider.tool,
+                        |raw| normalize_tool(provider.tool, raw),
+                    ),
+                    RuntimeDiscoveryKind::PythonVersion => self.scan_python_version(directory),
+                    RuntimeDiscoveryKind::Fvm => self.scan_fvm(directory),
+                    RuntimeDiscoveryKind::Sdkman => self.scan_sdkman(directory),
+                    RuntimeDiscoveryKind::RustToolchain => self.scan_rust(directory),
+                    RuntimeDiscoveryKind::DotnetGlobalJson => self.scan_global_json(directory),
+                }
+            }
+        }
+    }
+
     fn load(&mut self, group: &'static str, path: &Path, tool: &str) -> Option<String> {
         if self.seen.contains(group) {
             return None;
@@ -249,7 +242,7 @@ impl Scanner {
         group: &'static str,
         path: &Path,
         tool: &str,
-        normalize: fn(&str) -> Result<String, String>,
+        normalize: impl FnOnce(&str) -> Result<String, String>,
     ) {
         let Some(content) = self.load(group, path, tool) else {
             return;

--- a/crates/pinset-core/src/resolver.rs
+++ b/crates/pinset-core/src/resolver.rs
@@ -15,10 +15,14 @@ use std::{
 use crate::current_target;
 use crate::{
     Error, Result, RuntimeCommandLayout, RuntimeEnvironmentKind, current_target_for_tool,
-    find_optional_project_config, global_config_path, is_managed_command_shim,
+    find_project_context, global_config_path, is_managed_command_shim,
     load_optional_global_config, load_project_config, load_project_python_environment,
     project_python_command_candidates, runtime_provider, runtime_provider_for_command,
     runtime_providers,
+};
+#[cfg(feature = "lockfile")]
+use crate::{
+    global_lockfile_path, load_optional_lockfile, lockfile_path, validate_lock_matches_tool,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -41,6 +45,7 @@ impl SelectionSource {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolSelection {
     pub tool: String,
+    pub requested: String,
     pub version: String,
     pub source: SelectionSource,
     pub config_path: PathBuf,
@@ -50,6 +55,7 @@ pub struct ToolSelection {
 pub struct CommandResolution {
     pub command: String,
     pub tool: String,
+    pub requested: Option<String>,
     pub version: String,
     pub source: SelectionSource,
     pub selection_path: Option<PathBuf>,
@@ -141,6 +147,7 @@ pub fn resolve_command_with_path(
             return Ok(CommandResolution {
                 command: command.to_owned(),
                 tool: tool.to_owned(),
+                requested: None,
                 version: "unknown".to_owned(),
                 source: SelectionSource::System,
                 selection_path: None,
@@ -173,6 +180,7 @@ pub fn resolve_command_with_path(
         return Ok(CommandResolution {
             command: command.to_owned(),
             tool: tool.to_owned(),
+            requested: Some(selection.requested.clone()),
             version,
             source: selection.source,
             selection_path: Some(selection.config_path),
@@ -204,6 +212,7 @@ pub fn resolve_command_with_path(
     Ok(CommandResolution {
         command: command.to_owned(),
         tool: tool.to_owned(),
+        requested: Some(selection.requested.clone()),
         version,
         source: selection.source,
         selection_path: Some(selection.config_path),
@@ -243,6 +252,7 @@ pub fn resolve_project_python_command(
     Ok(CommandResolution {
         command: command.to_owned(),
         tool: "python".to_owned(),
+        requested: Some(selection.requested),
         version: selection.version,
         source: SelectionSource::Project,
         selection_path: Some(selection.config_path),
@@ -251,35 +261,148 @@ pub fn resolve_project_python_command(
 }
 
 pub fn resolve_tool_selection(tool: &str, cwd: &Path, pinset_home: &Path) -> Result<ToolSelection> {
-    let project_path = find_optional_project_config(cwd)?;
-    if let Some(config_path) = project_path.as_ref() {
+    let context = find_project_context(cwd)?;
+    if let Some(config_path) = context.config_path.as_ref() {
         let config = load_project_config(config_path)?;
-        if let Some(version) = config.tools.get(tool) {
-            return Ok(ToolSelection {
+        if let Some(requested) = config.tools.get(tool) {
+            return selection_from_config(
+                tool,
+                requested,
+                config.schema,
+                SelectionSource::Project,
+                config_path,
+                lockfile_for_project(config_path),
+            );
+        }
+        if !config.policy.inherit_global {
+            if config.policy.system_fallback {
+                return Err(selection_not_found(tool, cwd, pinset_home));
+            }
+            return Err(Error::ProjectToolSelectionRequired {
                 tool: tool.to_owned(),
-                version: version.clone(),
-                source: SelectionSource::Project,
                 config_path: config_path.clone(),
             });
         }
+
+        let global_path = global_config_path(pinset_home);
+        if let Some(global) = load_optional_global_config(&global_path)? {
+            if let Some(requested) = global.tools.get(tool) {
+                return selection_from_config(
+                    tool,
+                    requested,
+                    global.schema,
+                    SelectionSource::Global,
+                    &global_path,
+                    lockfile_for_global(pinset_home),
+                );
+            }
+        }
+        if config.policy.system_fallback {
+            return Err(selection_not_found(tool, cwd, pinset_home));
+        }
+        return Err(Error::ProjectToolSelectionRequired {
+            tool: tool.to_owned(),
+            config_path: config_path.clone(),
+        });
     }
 
     let global_path = global_config_path(pinset_home);
     if let Some(config) = load_optional_global_config(&global_path)? {
-        if let Some(version) = config.tools.get(tool) {
-            return Ok(ToolSelection {
-                tool: tool.to_owned(),
-                version: version.clone(),
-                source: SelectionSource::Global,
-                config_path: global_path,
-            });
+        if let Some(requested) = config.tools.get(tool) {
+            return selection_from_config(
+                tool,
+                requested,
+                config.schema,
+                SelectionSource::Global,
+                &global_path,
+                lockfile_for_global(pinset_home),
+            );
         }
     }
 
-    Err(Error::ToolSelectionNotFound {
+    Err(selection_not_found(tool, cwd, pinset_home))
+}
+
+fn selection_not_found(tool: &str, cwd: &Path, pinset_home: &Path) -> Error {
+    Error::ToolSelectionNotFound {
         tool: tool.to_owned(),
         start: cwd.to_path_buf(),
-        global_config_path: global_path,
+        global_config_path: global_config_path(pinset_home),
+    }
+}
+
+#[cfg(feature = "lockfile")]
+fn lockfile_for_project(config_path: &Path) -> Result<Option<crate::Lockfile>> {
+    load_optional_lockfile(&lockfile_path(config_path))
+}
+
+#[cfg(not(feature = "lockfile"))]
+fn lockfile_for_project(_config_path: &Path) {}
+
+#[cfg(feature = "lockfile")]
+fn lockfile_for_global(pinset_home: &Path) -> Result<Option<crate::Lockfile>> {
+    load_optional_lockfile(&global_lockfile_path(pinset_home))
+}
+
+#[cfg(not(feature = "lockfile"))]
+fn lockfile_for_global(_pinset_home: &Path) {}
+
+#[cfg(feature = "lockfile")]
+fn selection_from_config(
+    tool: &str,
+    requested: &str,
+    config_schema: u32,
+    source: SelectionSource,
+    config_path: &Path,
+    lockfile: Result<Option<crate::Lockfile>>,
+) -> Result<ToolSelection> {
+    let lockfile = lockfile?;
+    let version = if let Some(lockfile) = lockfile {
+        validate_lock_matches_tool(&lockfile, tool, requested, config_path)?
+            .version
+            .clone()
+    } else if config_schema < crate::PROJECT_CONFIG_SCHEMA {
+        requested.to_owned()
+    } else {
+        return Err(Error::ReadLockfile {
+            path: if source == SelectionSource::Project {
+                lockfile_path(config_path)
+            } else {
+                config_path
+                    .parent()
+                    .unwrap_or(config_path)
+                    .join(crate::GLOBAL_LOCKFILE_FILENAME)
+            },
+            source: std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "schema 3 selections require a lockfile",
+            ),
+        });
+    };
+    Ok(ToolSelection {
+        tool: tool.to_owned(),
+        requested: requested.to_owned(),
+        version,
+        source,
+        config_path: config_path.to_path_buf(),
+    })
+}
+
+#[cfg(not(feature = "lockfile"))]
+fn selection_from_config(
+    tool: &str,
+    requested: &str,
+    _config_schema: u32,
+    source: SelectionSource,
+    config_path: &Path,
+    _lockfile: (),
+) -> Result<ToolSelection> {
+    Ok(ToolSelection {
+        tool: tool.to_owned(),
+        requested: requested.to_owned(),
+        version: requested.to_owned(),
+        source,
+        config_path: config_path.to_path_buf(),
     })
 }
 
@@ -659,6 +782,7 @@ mod tests {
         let nested = project.join("src").join("feature");
         let home = root.path().join("home");
         fs::create_dir_all(&nested).expect("nested directory");
+        fs::create_dir(project.join(".git")).expect("git marker");
         fs::write(
             project.join("pinset.toml"),
             "schema = 1\n[tools]\nnode = \"20.0.0\"\n",
@@ -804,12 +928,16 @@ mod tests {
     }
 
     #[test]
-    fn project_without_tool_falls_back_to_global_selection() {
+    fn project_can_explicitly_inherit_global_selection() {
         let root = tempdir().expect("temp directory");
         let project = root.path().join("project");
         let home = root.path().join("home");
         fs::create_dir_all(&project).expect("project");
-        fs::write(project.join("pinset.toml"), "schema = 1\n[tools]\n").expect("project config");
+        fs::write(
+            project.join("pinset.toml"),
+            "schema = 2\n[policy]\ninherit-global = true\n[tools]\n",
+        )
+        .expect("project config");
         let global_path = global_config_path(&home);
         fs::create_dir_all(global_path.parent().expect("state directory")).expect("state");
         fs::write(&global_path, "schema = 1\n[tools]\nnode = \"24.0.0\"\n").expect("global config");
@@ -818,6 +946,47 @@ mod tests {
         assert_eq!(selection.version, "24.0.0");
         assert_eq!(selection.source, SelectionSource::Global);
         assert_eq!(selection.config_path, global_path);
+    }
+
+    #[test]
+    fn project_without_tool_is_strict_by_default() {
+        let root = tempdir().expect("temp directory");
+        let project = root.path().join("project");
+        let home = root.path().join("home");
+        fs::create_dir_all(&project).expect("project");
+        fs::write(project.join("pinset.toml"), "schema = 2\n[tools]\n")
+            .expect("project config");
+        let global_path = global_config_path(&home);
+        fs::create_dir_all(global_path.parent().expect("state directory")).expect("state");
+        fs::write(global_path, "schema = 1\n[tools]\nnode = \"24.0.0\"\n")
+            .expect("global config");
+
+        assert!(matches!(
+            resolve_tool_selection("node", &project, &home),
+            Err(Error::ProjectToolSelectionRequired { .. })
+        ));
+    }
+
+    #[test]
+    fn project_can_explicitly_fall_back_to_system_path() {
+        let root = tempdir().expect("temp directory");
+        let project = root.path().join("project");
+        let home = root.path().join("home");
+        let system_bin = root.path().join("system-bin");
+        fs::create_dir_all(&project).expect("project");
+        fs::write(
+            project.join("pinset.toml"),
+            "schema = 2\n[policy]\nsystem-fallback = true\n[tools]\n",
+        )
+        .expect("project config");
+        let executable = create_fake_command(&system_bin, "node");
+        let path = env::join_paths([&system_bin]).expect("system PATH");
+
+        let resolution =
+            resolve_command_with_path("node", &project, &home, Some(path.as_os_str()), &[])
+                .expect("system resolution");
+        assert_eq!(resolution.source, SelectionSource::System);
+        assert_eq!(resolution.executable, executable);
     }
 
     #[test]

--- a/crates/pinset-core/src/runtime_lifecycle.rs
+++ b/crates/pinset-core/src/runtime_lifecycle.rs
@@ -14,8 +14,14 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    Error, Result, find_optional_project_config, global_config_path, load_optional_global_config,
-    load_project_config, runtime_provider, runtime_providers,
+    Error, GlobalConfig, ProjectConfig, Result, find_optional_project_config, global_config_path,
+    load_optional_global_config, load_project_config, runtime_provider, runtime_providers,
+};
+
+#[cfg(feature = "lockfile")]
+use crate::{
+    GLOBAL_STATE_SCHEMA, PROJECT_CONFIG_SCHEMA, global_lockfile_path, load_lockfile,
+    load_optional_lockfile, lockfile_path, validate_lock_matches_tool,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -129,6 +135,78 @@ pub fn list_all_installed_tool_versions(pinset_home: &Path) -> Result<Vec<Instal
     Ok(installed)
 }
 
+fn project_config_selects_version(
+    config_path: &Path,
+    config: &ProjectConfig,
+    tool: &str,
+    version: &str,
+) -> Result<bool> {
+    let Some(requested) = config.tools.get(tool) else {
+        return Ok(false);
+    };
+    #[cfg(feature = "lockfile")]
+    {
+        locked_config_selects_version(
+            config_path,
+            &lockfile_path(config_path),
+            config.schema < PROJECT_CONFIG_SCHEMA,
+            tool,
+            requested,
+            version,
+        )
+    }
+    #[cfg(not(feature = "lockfile"))]
+    {
+        let _ = config_path;
+        Ok(requested == version)
+    }
+}
+
+fn global_config_selects_version(
+    pinset_home: &Path,
+    config_path: &Path,
+    config: &GlobalConfig,
+    tool: &str,
+    version: &str,
+) -> Result<bool> {
+    let Some(requested) = config.tools.get(tool) else {
+        return Ok(false);
+    };
+    #[cfg(feature = "lockfile")]
+    {
+        locked_config_selects_version(
+            config_path,
+            &global_lockfile_path(pinset_home),
+            config.schema < GLOBAL_STATE_SCHEMA,
+            tool,
+            requested,
+            version,
+        )
+    }
+    #[cfg(not(feature = "lockfile"))]
+    {
+        let _ = (pinset_home, config_path);
+        Ok(requested == version)
+    }
+}
+
+#[cfg(feature = "lockfile")]
+fn locked_config_selects_version(
+    config_path: &Path,
+    lock_path: &Path,
+    legacy_without_lock: bool,
+    tool: &str,
+    requested: &str,
+    version: &str,
+) -> Result<bool> {
+    let lockfile = match load_optional_lockfile(lock_path)? {
+        Some(lockfile) => lockfile,
+        None if legacy_without_lock => return Ok(requested == version),
+        None => load_lockfile(lock_path)?,
+    };
+    Ok(validate_lock_matches_tool(&lockfile, tool, requested, config_path)?.version == version)
+}
+
 pub fn find_tool_version_references(
     pinset_home: &Path,
     cwd: &Path,
@@ -139,11 +217,7 @@ pub fn find_tool_version_references(
     let mut references = Vec::new();
     if let Some(path) = find_optional_project_config(cwd)? {
         let config = load_project_config(&path)?;
-        if config
-            .tools
-            .get(tool)
-            .is_some_and(|selected| selected == version)
-        {
+        if project_config_selects_version(&path, &config, tool, version)? {
             references.push(ToolVersionReference {
                 scope: "project",
                 path,
@@ -152,11 +226,7 @@ pub fn find_tool_version_references(
     }
     let path = global_config_path(pinset_home);
     if let Some(config) = load_optional_global_config(&path)? {
-        if config
-            .tools
-            .get(tool)
-            .is_some_and(|selected| selected == version)
-        {
+        if global_config_selects_version(pinset_home, &path, &config, tool, version)? {
             references.push(ToolVersionReference {
                 scope: "global",
                 path,
@@ -183,11 +253,7 @@ pub fn find_tool_version_references_in_projects(
             continue;
         }
         let config = load_project_config(&path)?;
-        if config
-            .tools
-            .get(tool)
-            .is_some_and(|selected| selected == version)
-        {
+        if project_config_selects_version(&path, &config, tool, version)? {
             references.push(ToolVersionReference {
                 scope: "project",
                 path,
@@ -196,11 +262,7 @@ pub fn find_tool_version_references_in_projects(
     }
     let path = global_config_path(pinset_home);
     if let Some(config) = load_optional_global_config(&path)? {
-        if config
-            .tools
-            .get(tool)
-            .is_some_and(|selected| selected == version)
-        {
+        if global_config_selects_version(pinset_home, &path, &config, tool, version)? {
             references.push(ToolVersionReference {
                 scope: "global",
                 path,

--- a/crates/pinset-core/src/runtime_provider.rs
+++ b/crates/pinset-core/src/runtime_provider.rs
@@ -6,6 +6,23 @@ pub struct RuntimeProvider {
     pub metadata: RuntimeMetadataKind,
     pub installer: RuntimeInstallKind,
     pub environment: RuntimeEnvironmentKind,
+    pub discovery: &'static [RuntimeDiscoveryRule],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RuntimeDiscoveryRule {
+    pub source: &'static str,
+    pub kind: RuntimeDiscoveryKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeDiscoveryKind {
+    SimpleFile { filename: &'static str },
+    PythonVersion,
+    Fvm,
+    Sdkman,
+    RustToolchain,
+    DotnetGlobalJson,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -52,6 +69,58 @@ pub enum RuntimeEnvironmentKind {
 }
 
 const NODE_COMMANDS: &[&str] = &["node", "npm", "npx", "corepack"];
+const NODE_DISCOVERY: &[RuntimeDiscoveryRule] = &[
+    RuntimeDiscoveryRule {
+        source: "nvmrc",
+        kind: RuntimeDiscoveryKind::SimpleFile { filename: ".nvmrc" },
+    },
+    RuntimeDiscoveryRule {
+        source: "node-version",
+        kind: RuntimeDiscoveryKind::SimpleFile {
+            filename: ".node-version",
+        },
+    },
+];
+const BUN_DISCOVERY: &[RuntimeDiscoveryRule] = &[RuntimeDiscoveryRule {
+    source: "bun-version",
+    kind: RuntimeDiscoveryKind::SimpleFile {
+        filename: ".bun-version",
+    },
+}];
+const GO_DISCOVERY: &[RuntimeDiscoveryRule] = &[RuntimeDiscoveryRule {
+    source: "go-version",
+    kind: RuntimeDiscoveryKind::SimpleFile {
+        filename: ".go-version",
+    },
+}];
+const FLUTTER_DISCOVERY: &[RuntimeDiscoveryRule] = &[RuntimeDiscoveryRule {
+    source: "fvm",
+    kind: RuntimeDiscoveryKind::Fvm,
+}];
+const PYTHON_DISCOVERY: &[RuntimeDiscoveryRule] = &[RuntimeDiscoveryRule {
+    source: "python-version",
+    kind: RuntimeDiscoveryKind::PythonVersion,
+}];
+const JAVA_DISCOVERY: &[RuntimeDiscoveryRule] = &[
+    RuntimeDiscoveryRule {
+        source: "java-version",
+        kind: RuntimeDiscoveryKind::SimpleFile {
+            filename: ".java-version",
+        },
+    },
+    RuntimeDiscoveryRule {
+        source: "sdkmanrc",
+        kind: RuntimeDiscoveryKind::Sdkman,
+    },
+];
+const RUST_DISCOVERY: &[RuntimeDiscoveryRule] = &[RuntimeDiscoveryRule {
+    source: "rust-toolchain",
+    kind: RuntimeDiscoveryKind::RustToolchain,
+}];
+const DOTNET_DISCOVERY: &[RuntimeDiscoveryRule] = &[RuntimeDiscoveryRule {
+    source: "global-json",
+    kind: RuntimeDiscoveryKind::DotnetGlobalJson,
+}];
 const NODE_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "node",
     commands: NODE_COMMANDS,
@@ -59,6 +128,7 @@ const NODE_PROVIDER: RuntimeProvider = RuntimeProvider {
     metadata: RuntimeMetadataKind::Node,
     installer: RuntimeInstallKind::Node,
     environment: RuntimeEnvironmentKind::None,
+    discovery: NODE_DISCOVERY,
 };
 const PNPM_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "pnpm",
@@ -67,6 +137,7 @@ const PNPM_PROVIDER: RuntimeProvider = RuntimeProvider {
     metadata: RuntimeMetadataKind::Npm,
     installer: RuntimeInstallKind::Npm,
     environment: RuntimeEnvironmentKind::None,
+    discovery: &[],
 };
 const BUN_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "bun",
@@ -75,6 +146,7 @@ const BUN_PROVIDER: RuntimeProvider = RuntimeProvider {
     metadata: RuntimeMetadataKind::Npm,
     installer: RuntimeInstallKind::Npm,
     environment: RuntimeEnvironmentKind::None,
+    discovery: BUN_DISCOVERY,
 };
 const GO_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "go",
@@ -83,6 +155,7 @@ const GO_PROVIDER: RuntimeProvider = RuntimeProvider {
     metadata: RuntimeMetadataKind::Go,
     installer: RuntimeInstallKind::Go,
     environment: RuntimeEnvironmentKind::Go,
+    discovery: GO_DISCOVERY,
 };
 const FLUTTER_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "flutter",
@@ -91,6 +164,7 @@ const FLUTTER_PROVIDER: RuntimeProvider = RuntimeProvider {
     metadata: RuntimeMetadataKind::Flutter,
     installer: RuntimeInstallKind::Flutter,
     environment: RuntimeEnvironmentKind::Flutter,
+    discovery: FLUTTER_DISCOVERY,
 };
 const PYTHON_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "python",
@@ -99,6 +173,7 @@ const PYTHON_PROVIDER: RuntimeProvider = RuntimeProvider {
     metadata: RuntimeMetadataKind::Python,
     installer: RuntimeInstallKind::Python,
     environment: RuntimeEnvironmentKind::Python,
+    discovery: PYTHON_DISCOVERY,
 };
 const JAVA_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "java",
@@ -109,6 +184,7 @@ const JAVA_PROVIDER: RuntimeProvider = RuntimeProvider {
     metadata: RuntimeMetadataKind::Java,
     installer: RuntimeInstallKind::Java,
     environment: RuntimeEnvironmentKind::Java,
+    discovery: JAVA_DISCOVERY,
 };
 const RUST_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "rust",
@@ -125,6 +201,7 @@ const RUST_PROVIDER: RuntimeProvider = RuntimeProvider {
     metadata: RuntimeMetadataKind::Rust,
     installer: RuntimeInstallKind::Rust,
     environment: RuntimeEnvironmentKind::None,
+    discovery: RUST_DISCOVERY,
 };
 const DOTNET_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "dotnet",
@@ -133,6 +210,7 @@ const DOTNET_PROVIDER: RuntimeProvider = RuntimeProvider {
     metadata: RuntimeMetadataKind::Dotnet,
     installer: RuntimeInstallKind::Dotnet,
     environment: RuntimeEnvironmentKind::Dotnet,
+    discovery: DOTNET_DISCOVERY,
 };
 const PROVIDERS: &[RuntimeProvider] = &[
     NODE_PROVIDER,
@@ -279,5 +357,21 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn provider_specific_discovery_is_declared_in_provider_manifests() {
+        assert_eq!(
+            runtime_provider("node").expect("node").discovery,
+            NODE_DISCOVERY
+        );
+        assert_eq!(
+            runtime_provider("python").expect("python").discovery,
+            PYTHON_DISCOVERY
+        );
+        assert_eq!(
+            runtime_provider("dotnet").expect("dotnet").discovery,
+            DOTNET_DISCOVERY
+        );
     }
 }

--- a/crates/pinset-shim/Cargo.toml
+++ b/crates/pinset-shim/Cargo.toml
@@ -7,7 +7,7 @@ authors.workspace = true
 publish = false
 
 [dependencies]
-pinset-core = { path = "../pinset-core" }
+pinset-core = { path = "../pinset-core", features = ["lockfile"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/pinset-shim/tests/routing.rs
+++ b/crates/pinset-shim/tests/routing.rs
@@ -14,6 +14,7 @@ fn executes_fake_node_selected_by_nearest_project_config() {
     let nested = project.join("packages").join("app").join("src");
     let home = root.path().join("home");
     fs::create_dir_all(&nested).expect("nested directory");
+    fs::create_dir(project.join(".git")).expect("git marker");
     fs::write(
         project.join("pinset.toml"),
         "schema = 1\n[tools]\nnode = \"20.0.0\"\n",

--- a/crates/pinset/src/i18n.rs
+++ b/crates/pinset/src/i18n.rs
@@ -77,7 +77,7 @@ impl Catalog {
                 format!("错误：项目配置 {} 格式无效：{source}", path.display())
             }
             Error::UnsupportedSchema { actual } => {
-                format!("错误：不支持 pinset.toml schema {actual}，当前支持 schema 1 和 2")
+                format!("错误：不支持 pinset.toml schema {actual}，当前支持 schema 1、2 和 3")
             }
             Error::GlobalConfigNotFound { path } => {
                 format!("错误：全局配置不存在：{}", path.display())
@@ -89,7 +89,7 @@ impl Catalog {
                 format!("错误：全局配置 {} 格式无效：{source}", path.display())
             }
             Error::UnsupportedGlobalConfigSchema { actual } => {
-                format!("错误：不支持 global.toml schema {actual}，当前仅支持 schema 1")
+                format!("错误：不支持 global.toml schema {actual}，当前支持 schema 1、2 和 3")
             }
             Error::ReadUserSettings { path, source } => {
                 format!("错误：无法读取用户设置 {}：{source}", path.display())
@@ -106,6 +106,10 @@ impl Catalog {
             Error::ToolNotConfigured { tool, config_path } => {
                 format!("错误：工具 {tool:?} 未在 {} 中声明", config_path.display())
             }
+            Error::ProjectToolSelectionRequired { tool, config_path } => format!(
+                "错误：严格项目 {} 未声明工具 {tool:?}；请运行 `pinset use {tool}@<选择器>`，或在项目策略中显式启用回退",
+                config_path.display()
+            ),
             Error::ToolSelectionNotFound {
                 tool,
                 start,

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -24,7 +24,8 @@ use pinset_core::{
     RuntimeInstallKind, RuntimeMetadataKind, RustMetadataClient, SUPPORTED_SOURCE_PROVIDERS,
     ShimInstallMethod, SourceView, clean_download_cache, command_tool, create_project_config,
     create_project_python_environment, current_target_for_tool, download_cache_info, ensure_shims,
-    find_optional_project_config, find_project_config, global_config_path, global_lockfile_path,
+    find_optional_project_config, find_project_config, find_project_context, global_config_path,
+    global_lockfile_path,
     import_download_cache, import_download_cache_with_integrity, install_locked_dotnet,
     install_locked_flutter, install_locked_go, install_locked_java, install_locked_node,
     install_locked_npm_tool, install_locked_python, install_locked_rust, is_managed_command_shim,
@@ -138,6 +139,9 @@ enum Commands {
         command: String,
         #[arg(long)]
         cwd: Option<PathBuf>,
+        /// Explain the project/global/system candidate chain.
+        #[arg(long)]
+        explain: bool,
         /// Emit a stable machine-readable result.
         #[arg(long)]
         json: bool,
@@ -148,6 +152,9 @@ enum Commands {
         tool: Option<String>,
         #[arg(long)]
         cwd: Option<PathBuf>,
+        /// Explain the project/global/system candidate chain.
+        #[arg(long)]
+        explain: bool,
         /// Emit a stable machine-readable result.
         #[arg(long)]
         json: bool,
@@ -173,6 +180,38 @@ enum Commands {
         /// Project directory whose nearest Pinset configuration is checked.
         #[arg(long, conflicts_with = "global")]
         cwd: Option<PathBuf>,
+        /// Emit a stable machine-readable result.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Re-resolve configured selectors and update exact lock records without installing.
+    Update {
+        /// Limit the update to one runtime provider.
+        tool: Option<String>,
+        /// Update only global selections.
+        #[arg(long, conflicts_with = "cwd")]
+        global: bool,
+        /// Project directory whose nearest Pinset configuration is updated.
+        #[arg(long, conflicts_with = "global")]
+        cwd: Option<PathBuf>,
+        /// Report the proposed lock changes without writing them.
+        #[arg(long)]
+        dry_run: bool,
+        /// Emit a stable machine-readable result.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Upgrade project or global configuration and lock data to schema 3.
+    Migrate {
+        /// Migrate the global selection state instead of a project.
+        #[arg(long, conflicts_with = "cwd")]
+        global: bool,
+        /// Project directory whose nearest Pinset state is migrated.
+        #[arg(long, conflicts_with = "global")]
+        cwd: Option<PathBuf>,
+        /// Report the schema change without writing it.
+        #[arg(long)]
+        dry_run: bool,
         /// Emit a stable machine-readable result.
         #[arg(long)]
         json: bool,
@@ -407,6 +446,8 @@ impl Commands {
             Self::Current { json: true, .. } => Some("current"),
             Self::List { json: true, .. } => Some("list"),
             Self::Outdated { json: true, .. } => Some("outdated"),
+            Self::Update { json: true, .. } => Some("update"),
+            Self::Migrate { json: true, .. } => Some("migrate"),
             Self::Uninstall { json: true, .. } => Some("uninstall"),
             Self::Prune { json: true, .. } => Some("prune"),
             Self::Doctor { json: true, .. } => Some("doctor"),
@@ -507,6 +548,8 @@ fn requested_json_command(arguments: &[OsString]) -> Option<String> {
                 | "current"
                 | "list"
                 | "outdated"
+                | "update"
+                | "migrate"
                 | "uninstall"
                 | "prune"
                 | "doctor"
@@ -575,6 +618,7 @@ fn json_error(error: &(dyn std::error::Error + 'static)) -> (&'static str, serde
         | Error::ToolSelectionNotFound { .. }
         | Error::CommandSelectionNotFound { .. }
         | Error::ToolNotConfigured { .. }
+        | Error::ProjectToolSelectionRequired { .. }
         | Error::LockedToolMissing { .. }
         | Error::LockedArtifactMissing { .. } => "selection_missing",
         Error::ReadProjectConfig { .. }
@@ -862,32 +906,62 @@ fn run(cli: Cli, catalog: Catalog) -> Result<i32, Box<dyn std::error::Error>> {
                 install_project(&effective_cwd(cwd)?, catalog)?;
             }
         }
-        Commands::Which { command, cwd, json } => {
+        Commands::Which {
+            command,
+            cwd,
+            explain,
+            json,
+        } => {
             let cwd = effective_cwd(cwd)?;
-            let resolution = resolve_command(&command, &cwd, &pinset_home()?)?;
+            let resolution = match resolve_command(&command, &cwd, &pinset_home()?) {
+                Ok(resolution) => resolution,
+                Err(error) => {
+                    if explain && !json {
+                        if let Some(tool) = command_tool(&command) {
+                            if let Ok(explanation) = resolution_explanation(&cwd, tool, "none") {
+                                print_resolution_explanation(&explanation);
+                            }
+                        }
+                    }
+                    return Err(error.into());
+                }
+            };
+            let explanation = explain
+                .then(|| resolution_explanation(&cwd, &resolution.tool, resolution.source.as_str()))
+                .transpose()?;
             if json {
                 print_json_success(
                     "which",
                     WhichReport {
                         command,
                         tool: resolution.tool,
+                        requested: resolution.requested,
                         version: resolution.version,
                         source: resolution.source.as_str(),
                         executable: resolution.executable,
                         config: resolution.selection_path,
+                        explanation,
                     },
                 )?;
             } else {
+                if let Some(explanation) = explanation.as_ref() {
+                    print_resolution_explanation(explanation);
+                }
                 println!("{}", resolution.executable.display());
             }
         }
-        Commands::Current { tool, cwd, json } => {
+        Commands::Current {
+            tool,
+            cwd,
+            explain,
+            json,
+        } => {
             let cwd = effective_cwd(cwd)?;
             let tool = tool.as_deref().unwrap_or("node");
             if json {
-                print_json_success("current", current_report(&cwd, tool)?)?;
+                print_json_success("current", current_report(&cwd, tool, explain)?)?;
             } else {
-                print_current(&cwd, tool, catalog)?;
+                print_current(&cwd, tool, explain, catalog)?;
             }
         }
         Commands::List {
@@ -901,6 +975,19 @@ fn run(cli: Cli, catalog: Catalog) -> Result<i32, Box<dyn std::error::Error>> {
             cwd,
             json,
         } => run_outdated(tool.as_deref(), global, cwd, json)?,
+        Commands::Update {
+            tool,
+            global,
+            cwd,
+            dry_run,
+            json,
+        } => run_update(tool.as_deref(), global, cwd, dry_run, json)?,
+        Commands::Migrate {
+            global,
+            cwd,
+            dry_run,
+            json,
+        } => run_migrate(global, cwd, dry_run, json)?,
         Commands::Uninstall {
             selection,
             force,
@@ -990,22 +1077,52 @@ fn run(cli: Cli, catalog: Catalog) -> Result<i32, Box<dyn std::error::Error>> {
 struct WhichReport {
     command: String,
     tool: String,
+    requested: Option<String>,
     version: String,
     source: &'static str,
     executable: PathBuf,
     config: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    explanation: Option<ResolutionExplanation>,
 }
 
 #[derive(Debug, Serialize)]
 struct CurrentReport {
     command: String,
     tool: String,
+    requested: Option<String>,
     version: String,
     source: &'static str,
     installed: bool,
     executable: Option<PathBuf>,
     expected_directory: Option<PathBuf>,
     config: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    explanation: Option<ResolutionExplanation>,
+}
+
+#[derive(Debug, Serialize)]
+struct ResolutionExplanation {
+    start: PathBuf,
+    boundary: PathBuf,
+    project_config: Option<PathBuf>,
+    project_strict: bool,
+    global_eligible: bool,
+    system_eligible: bool,
+    selected_source: String,
+    fallback_used: bool,
+    candidates: Vec<ResolutionCandidate>,
+    traditional_sources: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ResolutionCandidate {
+    source: &'static str,
+    config: Option<PathBuf>,
+    requested: Option<String>,
+    resolved: Option<String>,
+    status: &'static str,
+    reason: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -1021,9 +1138,12 @@ struct OutdatedReport {
     scope: &'static str,
     config: PathBuf,
     tool: String,
+    requested: String,
     current: String,
+    latest_compatible: String,
     latest: String,
-    outdated: bool,
+    update_available: bool,
+    upgrade_available: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1031,7 +1151,31 @@ struct SelectedRuntime {
     scope: &'static str,
     config: PathBuf,
     tool: String,
+    requested: String,
     version: String,
+}
+
+#[derive(Debug, Serialize)]
+struct UpdateReport {
+    scope: &'static str,
+    config: PathBuf,
+    tool: String,
+    requested: String,
+    previous: String,
+    resolved: String,
+    changed: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct MigrationReport {
+    scope: &'static str,
+    config: PathBuf,
+    lockfile: PathBuf,
+    from_config_schema: u32,
+    from_lock_schema: u32,
+    to_schema: u32,
+    changed: bool,
+    dry_run: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -1061,6 +1205,7 @@ struct CacheMutationReport {
 fn current_report(
     cwd: &Path,
     requested: &str,
+    explain: bool,
 ) -> Result<CurrentReport, Box<dyn std::error::Error>> {
     let home = pinset_home()?;
     let provider = runtime_provider(requested)
@@ -1080,16 +1225,23 @@ fn current_report(
             })?
     };
     match resolve_command(command, cwd, &home) {
-        Ok(resolution) => Ok(CurrentReport {
-            command: command.to_owned(),
-            tool: resolution.tool,
-            version: resolution.version,
-            source: resolution.source.as_str(),
-            installed: true,
-            executable: Some(resolution.executable),
-            expected_directory: None,
-            config: resolution.selection_path,
-        }),
+        Ok(resolution) => {
+            let explanation = explain
+                .then(|| resolution_explanation(cwd, provider.tool, resolution.source.as_str()))
+                .transpose()?;
+            Ok(CurrentReport {
+                command: command.to_owned(),
+                tool: resolution.tool,
+                requested: resolution.requested,
+                version: resolution.version,
+                source: resolution.source.as_str(),
+                installed: true,
+                executable: Some(resolution.executable),
+                expected_directory: None,
+                config: resolution.selection_path,
+                explanation,
+            })
+        }
         Err(Error::RuntimeCommandNotFound { .. }) => {
             let selection = resolve_tool_selection(provider.tool, cwd, &home)?;
             let install_dir = home
@@ -1100,15 +1252,206 @@ fn current_report(
             Ok(CurrentReport {
                 command: command.to_owned(),
                 tool: provider.tool.to_owned(),
+                requested: Some(selection.requested),
                 version: selection.version,
                 source: selection.source.as_str(),
                 installed: false,
                 executable: None,
                 expected_directory: Some(runtime_command_directory(provider.tool, &install_dir)),
                 config: Some(selection.config_path),
+                explanation: explain
+                    .then(|| resolution_explanation(cwd, provider.tool, selection.source.as_str()))
+                    .transpose()?,
             })
         }
         Err(error) => Err(error.into()),
+    }
+}
+
+fn resolution_explanation(
+    cwd: &Path,
+    tool: &str,
+    selected_source: &str,
+) -> Result<ResolutionExplanation, Box<dyn std::error::Error>> {
+    let home = pinset_home()?;
+    let context = find_project_context(cwd)?;
+    let mut candidates = Vec::new();
+    let mut project_strict = false;
+    let mut global_eligible = true;
+    let mut system_eligible = true;
+    if let Some(config_path) = context.config_path.as_ref() {
+        let config = load_project_config(config_path)?;
+        project_strict = !config.policy.inherit_global && !config.policy.system_fallback;
+        global_eligible = config.policy.inherit_global;
+        system_eligible = config.policy.system_fallback;
+        if let Some(requested) = config.tools.get(tool) {
+            let resolved = selected_version_from_lock(
+                tool,
+                requested,
+                config.schema,
+                config_path,
+                &lockfile_path(config_path),
+            )?;
+            candidates.push(ResolutionCandidate {
+                source: "project",
+                config: Some(config_path.clone()),
+                requested: Some(requested.clone()),
+                resolved: Some(resolved),
+                status: if selected_source == "project" {
+                    "selected"
+                } else {
+                    "available"
+                },
+                reason: "nearest project selection".to_owned(),
+            });
+        } else {
+            candidates.push(ResolutionCandidate {
+                source: "project",
+                config: Some(config_path.clone()),
+                requested: None,
+                resolved: None,
+                status: "missing",
+                reason: if project_strict {
+                    "strict project does not declare this tool"
+                } else if config.policy.inherit_global {
+                    "project allows global inheritance"
+                } else {
+                    "project allows system fallback"
+                }
+                .to_owned(),
+            });
+        }
+    } else {
+        candidates.push(ResolutionCandidate {
+            source: "project",
+            config: None,
+            requested: None,
+            resolved: None,
+            status: "not-found",
+            reason: "no Pinset project exists inside the effective boundary".to_owned(),
+        });
+    }
+
+    let global_path = global_config_path(&home);
+    if let Some(global) = load_optional_global_config(&global_path)? {
+        if let Some(requested) = global.tools.get(tool) {
+            let resolved = selected_version_from_lock(
+                tool,
+                requested,
+                global.schema,
+                &global_path,
+                &global_lockfile_path(&home),
+            )?;
+            candidates.push(ResolutionCandidate {
+                source: "global",
+                config: Some(global_path.clone()),
+                requested: Some(requested.clone()),
+                resolved: Some(resolved),
+                status: if selected_source == "global" {
+                    "selected"
+                } else if !global_eligible {
+                    "suppressed"
+                } else {
+                    "not-selected"
+                },
+                reason: if context.config_path.is_some() && !global_eligible {
+                    "project policy does not allow global inheritance"
+                } else {
+                    "global selection is eligible"
+                }
+                .to_owned(),
+            });
+        } else {
+            candidates.push(ResolutionCandidate {
+                source: "global",
+                config: Some(global_path.clone()),
+                requested: None,
+                resolved: None,
+                status: "missing",
+                reason: "global configuration does not declare this tool".to_owned(),
+            });
+        }
+    } else {
+        candidates.push(ResolutionCandidate {
+            source: "global",
+            config: Some(global_path),
+            requested: None,
+            resolved: None,
+            status: "not-found",
+            reason: "global configuration does not exist".to_owned(),
+        });
+    }
+    candidates.push(ResolutionCandidate {
+        source: "system",
+        config: None,
+        requested: None,
+        resolved: None,
+        status: if selected_source == "system" {
+            "selected"
+        } else if !system_eligible {
+            "suppressed"
+        } else {
+            "not-selected"
+        },
+        reason: if context.config_path.is_some() && !system_eligible {
+            "project policy does not allow system fallback"
+        } else {
+            "system PATH is the final eligible fallback"
+        }
+        .to_owned(),
+    });
+
+    let traditional_sources = scan_project_sources(cwd)?
+        .findings
+        .into_iter()
+        .map(|finding| {
+            format!(
+                "{}:{}:{}",
+                finding.tool,
+                finding.source,
+                discovery_status_name(finding.status, Language::English)
+            )
+        })
+        .collect();
+    Ok(ResolutionExplanation {
+        start: context.start,
+        boundary: context.boundary,
+        project_config: context.config_path,
+        project_strict,
+        global_eligible,
+        system_eligible,
+        selected_source: selected_source.to_owned(),
+        fallback_used: selected_source != "project",
+        candidates,
+        traditional_sources,
+    })
+}
+
+fn print_resolution_explanation(explanation: &ResolutionExplanation) {
+    println!("resolution start={}", explanation.start.display());
+    println!("resolution boundary={}", explanation.boundary.display());
+    println!(
+        "resolution policy project-strict={} global-eligible={} system-eligible={}",
+        explanation.project_strict,
+        explanation.global_eligible,
+        explanation.system_eligible
+    );
+    for candidate in &explanation.candidates {
+        println!(
+            "candidate source={} status={} requested={} resolved={} config={} reason={}",
+            candidate.source,
+            candidate.status,
+            candidate.requested.as_deref().unwrap_or("-"),
+            candidate.resolved.as_deref().unwrap_or("-"),
+            candidate
+                .config
+                .as_deref()
+                .map_or_else(|| "-".to_owned(), |path| path.display().to_string()),
+            candidate.reason
+        );
+    }
+    for source in &explanation.traditional_sources {
+        println!("traditional-source {source} (explicit detect/import only)");
     }
 }
 
@@ -1317,6 +1660,7 @@ fn run_outdated(
     let mut reports = Vec::new();
     let mut latest_versions: BTreeMap<String, String> = BTreeMap::new();
     for selection in selected {
+        let latest_compatible = resolve_locked_tool(&selection.tool, &selection.requested)?.version;
         let latest = if let Some(latest) = latest_versions.get(&selection.tool) {
             latest.clone()
         } else {
@@ -1330,8 +1674,11 @@ fn run_outdated(
             scope: selection.scope,
             config: selection.config,
             tool: selection.tool,
-            outdated: selection.version != latest,
+            requested: selection.requested,
+            update_available: selection.version != latest_compatible,
+            upgrade_available: latest_compatible != latest,
             current: selection.version,
+            latest_compatible,
             latest,
         });
     }
@@ -1339,13 +1686,17 @@ fn run_outdated(
         print_json_success("outdated", serde_json::json!({ "runtimes": reports }))?;
     } else {
         let mut count = 0;
-        for report in reports.iter().filter(|report| report.outdated) {
+        for report in reports
+            .iter()
+            .filter(|report| report.update_available || report.upgrade_available)
+        {
             count += 1;
             println!(
-                "{}@{} -> {}@{} scope={} config={}",
+                "{}@{} requested={} compatible={} latest={} scope={} config={}",
                 report.tool,
                 report.current,
-                report.tool,
+                report.requested,
+                report.latest_compatible,
                 report.latest,
                 report.scope,
                 report.config.display()
@@ -1368,16 +1719,26 @@ fn selected_runtimes_for_outdated(
     let mut seen = BTreeSet::new();
     if !global_only {
         if let Some(path) = find_optional_project_config(cwd)? {
-            for (selected_tool, version) in load_project_config(&path)?.tools {
+            let config = load_project_config(&path)?;
+            let lock_path = lockfile_path(&path);
+            for (selected_tool, requested) in config.tools {
                 if tool.is_some_and(|tool| tool != selected_tool.as_str()) {
                     continue;
                 }
                 require_provider(&selected_tool)?;
+                let version = selected_version_from_lock(
+                    &selected_tool,
+                    &requested,
+                    config.schema,
+                    &path,
+                    &lock_path,
+                )?;
                 if seen.insert(("project", selected_tool.clone(), path.clone())) {
                     selected.push(SelectedRuntime {
                         scope: "project",
                         config: path.clone(),
                         tool: selected_tool,
+                        requested,
                         version,
                     });
                 }
@@ -1386,22 +1747,50 @@ fn selected_runtimes_for_outdated(
     }
     let global_path = global_config_path(home);
     if let Some(global) = load_optional_global_config(&global_path)? {
-        for (selected_tool, version) in global.tools {
+        let lock_path = global_lockfile_path(home);
+        for (selected_tool, requested) in global.tools {
             if tool.is_some_and(|tool| tool != selected_tool.as_str()) {
                 continue;
             }
             require_provider(&selected_tool)?;
+            let version = selected_version_from_lock(
+                &selected_tool,
+                &requested,
+                global.schema,
+                &global_path,
+                &lock_path,
+            )?;
             if seen.insert(("global", selected_tool.clone(), global_path.clone())) {
                 selected.push(SelectedRuntime {
                     scope: "global",
                     config: global_path.clone(),
                     tool: selected_tool,
+                    requested,
                     version,
                 });
             }
         }
     }
     Ok(selected)
+}
+
+fn selected_version_from_lock(
+    tool: &str,
+    requested: &str,
+    config_schema: u32,
+    config_path: &Path,
+    lock_path: &Path,
+) -> Result<String, Box<dyn std::error::Error>> {
+    if let Some(lockfile) = load_optional_lockfile(lock_path)? {
+        return Ok(validate_lock_matches_tool(&lockfile, tool, requested, config_path)?
+            .version
+            .clone());
+    }
+    if config_schema < PROJECT_CONFIG_SCHEMA {
+        return Ok(requested.to_owned());
+    }
+    load_lockfile(lock_path)?;
+    unreachable!("loading a missing schema 3 lock always returns an error")
 }
 
 fn latest_stable_selector(tool: &str) -> &'static str {
@@ -1696,7 +2085,7 @@ fn run_cache(command: CacheCommands, catalog: Catalog) -> Result<(), Box<dyn std
     Ok(())
 }
 
-const COMPLETION_COMMANDS: &str = "init detect import global use unset install which current list outdated uninstall prune cache exec doctor venv shim activate completions source";
+const COMPLETION_COMMANDS: &str = "init detect import global use unset install which current list outdated update migrate uninstall prune cache exec doctor venv shim activate completions source";
 const COMPLETION_SHELLS: &str = "bash zsh fish powershell";
 const COMPLETION_CACHE_COMMANDS: &str = "list info verify repair clean import";
 const COMPLETION_VENV_COMMANDS: &str = "create status recreate";
@@ -1737,10 +2126,12 @@ fn completion_script(shell: ActivationShell) -> String {
             uninstall) values="__SELECTIONS__ --force --cwd --dry-run --json --lang --help" ;;
             unset) values="__PROVIDERS__ --global --cwd --lang --help" ;;
             list) values="__PROVIDERS__ --available --json --lang --help" ;;
-            current) values="__PROVIDERS__ --cwd --json --lang --help" ;;
+            current) values="__PROVIDERS__ --cwd --explain --json --lang --help" ;;
             outdated) values="__PROVIDERS__ --global --cwd --json --lang --help" ;;
+            update) values="__PROVIDERS__ --global --cwd --dry-run --json --lang --help" ;;
+            migrate) values="--global --cwd --dry-run --json --lang --help" ;;
             prune) values="--cwd --project --dry-run --json --lang --help" ;;
-            which) values="--cwd --json --lang --help" ;;
+            which) values="--cwd --explain --json --lang --help" ;;
             doctor) values="--cwd --json --lang --help" ;;
             cache) values="__CACHE_COMMANDS__ --lang --help" ;;
             venv) values="__VENV_COMMANDS__ --lang --help" ;;
@@ -1771,10 +2162,12 @@ _pinset_completion() {
             uninstall) values="__SELECTIONS__ --force --cwd --dry-run --json --lang --help" ;;
             unset) values="__PROVIDERS__ --global --cwd --lang --help" ;;
             list) values="__PROVIDERS__ --available --json --lang --help" ;;
-            current) values="__PROVIDERS__ --cwd --json --lang --help" ;;
+            current) values="__PROVIDERS__ --cwd --explain --json --lang --help" ;;
             outdated) values="__PROVIDERS__ --global --cwd --json --lang --help" ;;
+            update) values="__PROVIDERS__ --global --cwd --dry-run --json --lang --help" ;;
+            migrate) values="--global --cwd --dry-run --json --lang --help" ;;
             prune) values="--cwd --project --dry-run --json --lang --help" ;;
-            which) values="--cwd --json --lang --help" ;;
+            which) values="--cwd --explain --json --lang --help" ;;
             doctor) values="--cwd --json --lang --help" ;;
             cache) values="__CACHE_COMMANDS__ --lang --help" ;;
             venv) values="__VENV_COMMANDS__ --lang --help" ;;
@@ -1791,16 +2184,18 @@ compdef _pinset_completion pinset"#
         ActivationShell::Fish => {
             r#"complete -c pinset -f -n '__fish_use_subcommand' -a '__COMMANDS__'
 complete -c pinset -f -n '__fish_seen_subcommand_from global use install uninstall' -a '__SELECTIONS__'
-complete -c pinset -f -n '__fish_seen_subcommand_from unset list current outdated' -a '__PROVIDERS__'
+complete -c pinset -f -n '__fish_seen_subcommand_from unset list current outdated update' -a '__PROVIDERS__'
 complete -c pinset -f -n '__fish_seen_subcommand_from cache' -a '__CACHE_COMMANDS__'
 complete -c pinset -f -n '__fish_seen_subcommand_from venv' -a '__VENV_COMMANDS__'
 complete -c pinset -f -n '__fish_seen_subcommand_from shim' -a '__SHIM_COMMANDS__ __PROVIDERS__'
 complete -c pinset -f -n '__fish_seen_subcommand_from activate completions' -a '__SHELLS__'
 complete -c pinset -f -n '__fish_seen_subcommand_from source' -a '__SOURCE_COMMANDS__ __SOURCE_PROVIDERS__'
-complete -c pinset -f -n '__fish_seen_subcommand_from detect which current list outdated uninstall prune doctor cache' -a '--json'
-complete -c pinset -f -n '__fish_seen_subcommand_from detect import' -a '--cwd'
+complete -c pinset -f -n '__fish_seen_subcommand_from detect which current list outdated update migrate uninstall prune doctor cache' -a '--json'
+complete -c pinset -f -n '__fish_seen_subcommand_from which current' -a '--explain'
+complete -c pinset -f -n '__fish_seen_subcommand_from detect import install which current outdated update migrate uninstall prune doctor' -a '--cwd'
 complete -c pinset -f -n '__fish_seen_subcommand_from import' -a '--force --no-install'
-complete -c pinset -f -n '__fish_seen_subcommand_from uninstall prune cache' -a '--dry-run'
+complete -c pinset -f -n '__fish_seen_subcommand_from use unset install outdated update migrate' -a '--global'
+complete -c pinset -f -n '__fish_seen_subcommand_from update migrate uninstall prune cache' -a '--dry-run'
 complete -c pinset -f -a '--help --lang'"#
         }
         ActivationShell::Powershell => {
@@ -1817,10 +2212,12 @@ complete -c pinset -f -a '--help --lang'"#
         'uninstall' { '__SELECTIONS__ --force --cwd --dry-run --json --lang --help' -split ' ' }
         'unset' { '__PROVIDERS__ --global --cwd --lang --help' -split ' ' }
         'list' { '__PROVIDERS__ --available --json --lang --help' -split ' ' }
-        'current' { '__PROVIDERS__ --cwd --json --lang --help' -split ' ' }
+        'current' { '__PROVIDERS__ --cwd --explain --json --lang --help' -split ' ' }
         'outdated' { '__PROVIDERS__ --global --cwd --json --lang --help' -split ' ' }
+        'update' { '__PROVIDERS__ --global --cwd --dry-run --json --lang --help' -split ' ' }
+        'migrate' { '--global --cwd --dry-run --json --lang --help' -split ' ' }
         'prune' { '--cwd --project --dry-run --json --lang --help' -split ' ' }
-        'which' { '--cwd --json --lang --help' -split ' ' }
+        'which' { '--cwd --explain --json --lang --help' -split ' ' }
         'doctor' { '--cwd --json --lang --help' -split ' ' }
         'cache' { '__CACHE_COMMANDS__ --lang --help' -split ' ' }
         'venv' { '__VENV_COMMANDS__ --lang --help' -split ' ' }
@@ -1902,33 +2299,33 @@ fn resolve_locked_tool(
     selector: &str,
 ) -> Result<LockedTool, Box<dyn std::error::Error>> {
     let provider = runtime_provider(tool).expect("validated provider");
-    match provider.metadata {
+    let mut locked = match provider.metadata {
         RuntimeMetadataKind::Node => {
             let lockfile = node_metadata_client(&pinset_home()?)?
                 .resolve_lock(selector, &format!("pinset {}", env!("CARGO_PKG_VERSION")))?;
-            Ok(lockfile
+            lockfile
                 .tool("node")
                 .expect("generated Node lock contains node")
-                .clone())
+                .clone()
         }
         RuntimeMetadataKind::Npm => {
             let client = NpmMetadataClient::official()?;
             let version = client.resolve_version_selector(tool, selector)?;
-            Ok(client.resolve_tool(tool, &version)?)
+            client.resolve_tool(tool, &version)?
         }
-        RuntimeMetadataKind::Go => Ok(go_metadata_client(&pinset_home()?)?.resolve_tool(selector)?),
+        RuntimeMetadataKind::Go => go_metadata_client(&pinset_home()?)?.resolve_tool(selector)?,
         RuntimeMetadataKind::Flutter => {
-            Ok(flutter_metadata_client(&pinset_home()?)?.resolve_tool(selector)?)
+            flutter_metadata_client(&pinset_home()?)?.resolve_tool(selector)?
         }
-        RuntimeMetadataKind::Python => {
-            Ok(PythonMetadataClient::official()?.resolve_tool(selector)?)
-        }
-        RuntimeMetadataKind::Java => Ok(JavaMetadataClient::official()?.resolve_tool(selector)?),
-        RuntimeMetadataKind::Rust => Ok(RustMetadataClient::official()?.resolve_tool(selector)?),
+        RuntimeMetadataKind::Python => PythonMetadataClient::official()?.resolve_tool(selector)?,
+        RuntimeMetadataKind::Java => JavaMetadataClient::official()?.resolve_tool(selector)?,
+        RuntimeMetadataKind::Rust => RustMetadataClient::official()?.resolve_tool(selector)?,
         RuntimeMetadataKind::Dotnet => {
-            Ok(DotnetMetadataClient::official()?.resolve_tool(selector)?)
+            DotnetMetadataClient::official()?.resolve_tool(selector)?
         }
-    }
+    };
+    locked.requested = selector.to_owned();
+    Ok(locked)
 }
 
 fn new_lockfile() -> Lockfile {
@@ -1961,7 +2358,7 @@ fn select_tool(
         let mut lockfile = load_optional_lockfile(&lock_path)?.unwrap_or_else(new_lockfile);
         lockfile.generated_by = format!("pinset {}", env!("CARGO_PKG_VERSION"));
         lockfile.upsert_tool(locked_tool.clone());
-        config.set_tool(&tool, &version);
+        config.set_tool(&tool, &selector);
         validate_lock_matches_tools(&lockfile, &config.tools, &config_path)?;
         save_global_state(&home, &config, &lockfile)?;
         ("global", lock_path)
@@ -1976,7 +2373,7 @@ fn select_tool(
         let mut lockfile = load_optional_lockfile(&lock_path)?.unwrap_or_else(new_lockfile);
         lockfile.generated_by = format!("pinset {}", env!("CARGO_PKG_VERSION"));
         lockfile.upsert_tool(locked_tool.clone());
-        project.set_tool(&tool, &version);
+        project.set_tool(&tool, &selector);
         save_project_state(&config_path, &project, &lockfile)?;
         ("project", lock_path)
     };
@@ -2189,6 +2586,7 @@ fn run_project_import(
     } else {
         ProjectConfig {
             schema: PROJECT_CONFIG_SCHEMA,
+            policy: Default::default(),
             tools: BTreeMap::new(),
         }
     };
@@ -2272,7 +2670,7 @@ fn run_project_import(
                 locked_tool.version
             );
         }
-        project.set_tool(tool, &locked_tool.version);
+        project.set_tool(tool, selector);
         lockfile.upsert_tool(locked_tool.clone());
     }
     save_project_state(&config_path, &project, &lockfile)?;
@@ -2329,12 +2727,175 @@ fn import_replacement_conflict(
     project: &ProjectConfig,
     resolved: &[(String, String, LockedTool)],
 ) -> Option<(String, String, String)> {
-    resolved.iter().find_map(|(tool, _, locked_tool)| {
+    resolved.iter().find_map(|(tool, selector, _)| {
         project.tools.get(tool).and_then(|existing| {
-            (existing != &locked_tool.version)
-                .then(|| (tool.clone(), existing.clone(), locked_tool.version.clone()))
+            (existing != selector)
+                .then(|| (tool.clone(), existing.clone(), selector.clone()))
         })
     })
+}
+
+fn run_update(
+    tool: Option<&str>,
+    global: bool,
+    cwd: Option<PathBuf>,
+    dry_run: bool,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(tool) = tool {
+        require_provider(tool)?;
+    }
+    let home = pinset_home()?;
+    let cwd = effective_cwd(cwd)?;
+    let (scope, config_path, tools, mut lockfile) = if global {
+        let config_path = global_config_path(&home);
+        let config = load_global_config(&config_path)?;
+        let lockfile = load_lockfile(&global_lockfile_path(&home))?;
+        validate_lock_matches_tools(&lockfile, &config.tools, &config_path)?;
+        ("global", config_path, config.tools, lockfile)
+    } else {
+        let config_path = find_project_config(&cwd)?;
+        let config = load_project_config(&config_path)?;
+        let lockfile = load_lockfile(&lockfile_path(&config_path))?;
+        validate_lock_matches_tools(&lockfile, &config.tools, &config_path)?;
+        ("project", config_path, config.tools, lockfile)
+    };
+
+    let mut reports = Vec::new();
+    for (selected_tool, requested) in &tools {
+        if tool.is_some_and(|tool| tool != selected_tool) {
+            continue;
+        }
+        let previous = lockfile
+            .tool(selected_tool)
+            .expect("validated lock contains configured tool")
+            .version
+            .clone();
+        let resolved = resolve_locked_tool(selected_tool, requested)?;
+        let report = UpdateReport {
+            scope,
+            config: config_path.clone(),
+            tool: selected_tool.clone(),
+            requested: requested.clone(),
+            changed: previous != resolved.version,
+            previous,
+            resolved: resolved.version.clone(),
+        };
+        lockfile.upsert_tool(resolved);
+        reports.push(report);
+    }
+    if tool.is_some() && reports.is_empty() {
+        return Err(format!(
+            "{} does not declare runtime provider {:?}",
+            config_path.display(),
+            tool.expect("checked")
+        )
+        .into());
+    }
+
+    if !dry_run {
+        lockfile.generated_by = format!("pinset {}", env!("CARGO_PKG_VERSION"));
+        if global {
+            let config = load_global_config(&config_path)?;
+            save_global_state(&home, &config, &lockfile)?;
+        } else {
+            let config = load_project_config(&config_path)?;
+            save_project_state(&config_path, &config, &lockfile)?;
+        }
+    }
+
+    if json {
+        print_json_success(
+            "update",
+            serde_json::json!({ "dry_run": dry_run, "runtimes": reports }),
+        )?;
+    } else if reports.iter().all(|report| !report.changed) {
+        println!("all selected runtimes already match their configured selectors");
+    } else {
+        for report in reports.iter().filter(|report| report.changed) {
+            println!(
+                "{}@{} -> {} requested={} scope={} lock-only",
+                report.tool, report.previous, report.resolved, report.requested, report.scope
+            );
+        }
+        if dry_run {
+            println!("dry-run: lockfile was not changed");
+        } else {
+            println!("lock updated; run `pinset install --locked` to install resolved runtimes");
+        }
+    }
+    Ok(())
+}
+
+fn run_migrate(
+    global: bool,
+    cwd: Option<PathBuf>,
+    dry_run: bool,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let cwd = effective_cwd(cwd)?;
+    let (scope, config_path, lock_path, config_schema, lock_schema) = if global {
+        let home = pinset_home()?;
+        let config_path = global_config_path(&home);
+        let lock_path = global_lockfile_path(&home);
+        let config = load_global_config(&config_path)?;
+        let lockfile = load_lockfile(&lock_path)?;
+        validate_lock_matches_tools(&lockfile, &config.tools, &config_path)?;
+        let report = (
+            "global",
+            config_path.clone(),
+            lock_path.clone(),
+            config.schema,
+            lockfile.schema,
+        );
+        if !dry_run {
+            save_global_state(&home, &config, &lockfile)?;
+        }
+        report
+    } else {
+        let config_path = find_project_config(&cwd)?;
+        let lock_path = lockfile_path(&config_path);
+        let config = load_project_config(&config_path)?;
+        let lockfile = load_lockfile(&lock_path)?;
+        validate_lock_matches_tools(&lockfile, &config.tools, &config_path)?;
+        let report = (
+            "project",
+            config_path.clone(),
+            lock_path.clone(),
+            config.schema,
+            lockfile.schema,
+        );
+        if !dry_run {
+            save_project_state(&config_path, &config, &lockfile)?;
+        }
+        report
+    };
+    let report = MigrationReport {
+        scope,
+        config: config_path,
+        lockfile: lock_path,
+        from_config_schema: config_schema,
+        from_lock_schema: lock_schema,
+        to_schema: PROJECT_CONFIG_SCHEMA,
+        changed: config_schema != PROJECT_CONFIG_SCHEMA
+            || lock_schema != pinset_core::LOCKFILE_SCHEMA,
+        dry_run,
+    };
+    if json {
+        print_json_success("migrate", report)?;
+    } else if report.changed {
+        println!(
+            "{} config-schema={} lock-schema={} -> schema={}{}",
+            report.scope,
+            report.from_config_schema,
+            report.from_lock_schema,
+            report.to_schema,
+            if dry_run { " dry-run" } else { "" }
+        );
+    } else {
+        println!("{} state already uses schema 3", report.scope);
+    }
+    Ok(())
 }
 
 fn install_tool_selection(
@@ -2469,7 +3030,7 @@ fn requested_help_command(arguments: &[OsString]) -> Option<Option<&str>> {
 }
 
 fn command_from_arguments(arguments: &[OsString]) -> Option<&str> {
-    const COMMANDS: [&str; 21] = [
+    const COMMANDS: [&str; 23] = [
         "init",
         "detect",
         "import",
@@ -2480,6 +3041,8 @@ fn command_from_arguments(arguments: &[OsString]) -> Option<&str> {
         "which",
         "current",
         "outdated",
+        "update",
+        "migrate",
         "exec",
         "doctor",
         "shim",
@@ -2531,8 +3094,15 @@ fn install_project_with_venv(
     let lock_path = lockfile_path(&config_path);
     let home = pinset_home()?;
     install_locked_selection(&home, &project.tools, &config_path, &lock_path, catalog)?;
-    if let Some(distribution) = project.tools.get("python") {
-        ensure_project_python_environment(&home, &config_path, distribution, recreate_venv)?;
+    if let Some(requested) = project.tools.get("python") {
+        let distribution = selected_version_from_lock(
+            "python",
+            requested,
+            project.schema,
+            &config_path,
+            &lock_path,
+        )?;
+        ensure_project_python_environment(&home, &config_path, &distribution, recreate_venv)?;
     }
     Ok(())
 }
@@ -2548,16 +3118,23 @@ fn run_venv_command(
     };
     let config_path = find_project_config(&cwd)?;
     let project = load_project_config(&config_path)?;
-    let distribution =
+    let requested =
         project
             .tools
             .get("python")
             .ok_or_else(|| Error::PythonEnvironmentSelectionMissing {
                 path: config_path.clone(),
             })?;
+    let distribution = selected_version_from_lock(
+        "python",
+        requested,
+        project.schema,
+        &config_path,
+        &lockfile_path(&config_path),
+    )?;
     if action == "status" {
         let target = current_target_for_tool("python");
-        let environment = load_project_python_environment(&config_path, distribution, &target)?;
+        let environment = load_project_python_environment(&config_path, &distribution, &target)?;
         println!(
             "python@{} project environment {}",
             environment.distribution,
@@ -2986,8 +3563,24 @@ fn print_global_current(catalog: Catalog) -> Result<(), Box<dyn std::error::Erro
         println!("{}", catalog.global_not_selected(&config_path));
         return Ok(());
     }
-    for (tool, version) in &config.tools {
-        print_declared_tool(&home, tool, version, "global", &config_path, catalog)?;
+    let lock_path = global_lockfile_path(&home);
+    for (tool, requested) in &config.tools {
+        let version = selected_version_from_lock(
+            tool,
+            requested,
+            config.schema,
+            &config_path,
+            &lock_path,
+        )?;
+        print_declared_tool(
+            &home,
+            tool,
+            requested,
+            &version,
+            "global",
+            &config_path,
+            catalog,
+        )?;
     }
     Ok(())
 }
@@ -3021,11 +3614,15 @@ fn print_project_override(
 fn print_declared_tool(
     home: &Path,
     tool: &str,
+    requested: &str,
     version: &str,
     source: &str,
     config_path: &Path,
     catalog: Catalog,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    if requested != version {
+        println!("{tool}@{requested} resolved to {tool}@{version}");
+    }
     let install_dir = home
         .join("installs")
         .join(tool)
@@ -3055,9 +3652,37 @@ fn print_declared_tool(
 fn print_current(
     cwd: &Path,
     tool: &str,
+    explain: bool,
     catalog: Catalog,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let report = current_report(cwd, tool)?;
+    let report = match current_report(cwd, tool, explain) {
+        Ok(report) => report,
+        Err(error) => {
+            if explain {
+                let provider = runtime_provider(tool)
+                    .or_else(|| command_tool(tool).and_then(runtime_provider));
+                if let Some(provider) = provider {
+                    if let Ok(explanation) = resolution_explanation(cwd, provider.tool, "none") {
+                        print_resolution_explanation(&explanation);
+                    }
+                }
+            }
+            return Err(error);
+        }
+    };
+    if let Some(explanation) = report.explanation.as_ref() {
+        print_resolution_explanation(explanation);
+    }
+    if let Some(requested) = report
+        .requested
+        .as_deref()
+        .filter(|value| *value != report.version.as_str())
+    {
+        println!(
+            "{}@{} resolved to {}@{}",
+            report.tool, requested, report.tool, report.version
+        );
+    }
     if let Some(executable) = report.executable.as_deref() {
         println!(
             "{}",
@@ -3235,6 +3860,7 @@ fn command_for_runtime(executable: &Path) -> Command {
 struct DoctorReport {
     cwd: String,
     pinset_home: String,
+    boundary: String,
     project_config: DoctorItem,
     global_config: DoctorItem,
     selection: Option<DoctorSelection>,
@@ -3245,6 +3871,7 @@ struct DoctorReport {
     legacy_shim_path: DoctorItem,
     path_candidates: Vec<DoctorPathCandidate>,
     routing_issues: Vec<DoctorRoutingIssue>,
+    traditional_sources: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -3257,6 +3884,7 @@ struct DoctorItem {
 #[derive(Debug, Serialize)]
 struct DoctorSelection {
     tool: String,
+    requested: String,
     version: String,
     source: String,
     config_path: Option<String>,
@@ -3282,7 +3910,8 @@ struct DoctorRoutingIssue {
 
 fn doctor_report(cwd: &Path) -> Result<DoctorReport, Box<dyn std::error::Error>> {
     let home = pinset_home()?;
-    let project_path = find_optional_project_config(cwd)?;
+    let context = find_project_context(cwd)?;
+    let project_path = context.config_path.clone();
     let global_path = global_config_path(&home);
     let project_config = DoctorItem {
         status: if project_path.is_some() {
@@ -3305,11 +3934,14 @@ fn doctor_report(cwd: &Path) -> Result<DoctorReport, Box<dyn std::error::Error>>
 
     let selected = match resolve_tool_selection("node", cwd, &home) {
         Ok(selection) => Some(selection),
-        Err(Error::ToolSelectionNotFound { .. }) => None,
+        Err(Error::ToolSelectionNotFound { .. } | Error::ProjectToolSelectionRequired { .. }) => {
+            None
+        }
         Err(error) => return Err(error.into()),
     };
     let selection = selected.as_ref().map(|selection| DoctorSelection {
         tool: selection.tool.clone(),
+        requested: selection.requested.clone(),
         version: selection.version.clone(),
         source: selection.source.as_str().to_owned(),
         config_path: Some(selection.config_path.display().to_string()),
@@ -3321,7 +3953,7 @@ fn doctor_report(cwd: &Path) -> Result<DoctorReport, Box<dyn std::error::Error>>
             pinset_core::SelectionSource::System => unreachable!("declared selection"),
         };
         let lockfile = load_lockfile(&path)?;
-        validate_lock_matches_selection(&lockfile, &selection.version, &selection.config_path)?;
+        validate_lock_matches_selection(&lockfile, &selection.requested, &selection.config_path)?;
         DoctorItem {
             status: "ok",
             path: Some(path.display().to_string()),
@@ -3356,6 +3988,11 @@ fn doctor_report(cwd: &Path) -> Result<DoctorReport, Box<dyn std::error::Error>>
             path: None,
             detail: Some(format!("searched={searched}")),
         },
+        Err(Error::ProjectToolSelectionRequired { config_path, .. }) => DoctorItem {
+            status: "blocked",
+            path: Some(config_path.display().to_string()),
+            detail: Some("strict project does not declare node".to_owned()),
+        },
         Err(error) => return Err(error.into()),
     };
     let python_environment = doctor_python_environment(cwd, &home)?;
@@ -3388,9 +4025,22 @@ fn doctor_report(cwd: &Path) -> Result<DoctorReport, Box<dyn std::error::Error>>
         routing_issues.push(issue);
     }
     routing_issues.extend(java_environment_issues(cwd, &home));
+    let traditional_sources = scan_project_sources(cwd)?
+        .findings
+        .into_iter()
+        .map(|finding| {
+            format!(
+                "{}:{}:{}",
+                finding.tool,
+                finding.source,
+                discovery_status_name(finding.status, Language::English)
+            )
+        })
+        .collect();
     Ok(DoctorReport {
         cwd: cwd.display().to_string(),
         pinset_home: home.display().to_string(),
+        boundary: context.boundary.display().to_string(),
         project_config,
         global_config,
         selection,
@@ -3419,6 +4069,7 @@ fn doctor_report(cwd: &Path) -> Result<DoctorReport, Box<dyn std::error::Error>>
         },
         path_candidates,
         routing_issues,
+        traditional_sources,
     })
 }
 
@@ -3428,7 +4079,7 @@ fn doctor_python_environment(
 ) -> Result<DoctorItem, Box<dyn std::error::Error>> {
     let selection = match resolve_tool_selection("python", cwd, home) {
         Ok(selection) => selection,
-        Err(Error::ToolSelectionNotFound { .. }) => {
+        Err(Error::ToolSelectionNotFound { .. } | Error::ProjectToolSelectionRequired { .. }) => {
             return Ok(DoctorItem {
                 status: "not-applicable",
                 path: None,
@@ -3680,7 +4331,7 @@ fn run_doctor(cwd: &Path, catalog: Catalog) -> Result<(), Box<dyn std::error::Er
                 validate_lock_matches_tool(
                     &lockfile,
                     provider.tool,
-                    &selection.version,
+                    &selection.requested,
                     &selection.config_path,
                 )?;
                 println!(
@@ -3697,6 +4348,14 @@ fn run_doctor(cwd: &Path, catalog: Catalog) -> Result<(), Box<dyn std::error::Er
                 );
             }
             Err(Error::ToolSelectionNotFound { .. }) => {}
+            Err(Error::ProjectToolSelectionRequired { config_path, .. }) => println!(
+                "{}",
+                catalog.doctor_line(
+                    &format!("{}_selection", provider.tool),
+                    config_path.display(),
+                    "strict-missing",
+                )
+            ),
             Err(error) => return Err(error.into()),
         }
 
@@ -3753,6 +4412,7 @@ fn run_doctor(cwd: &Path, catalog: Catalog) -> Result<(), Box<dyn std::error::Er
                 println!("{}", catalog.no_selection())
             }
             Err(Error::CommandSelectionNotFound { .. }) => {}
+            Err(Error::ProjectToolSelectionRequired { .. }) => {}
             Err(error) => return Err(error.into()),
         }
     }
@@ -3820,6 +4480,14 @@ fn run_doctor(cwd: &Path, catalog: Catalog) -> Result<(), Box<dyn std::error::Er
                 issue.path.as_deref(),
                 issue.action,
             )
+        );
+    }
+    for finding in scan_project_sources(cwd)?.findings {
+        println!(
+            "traditional_source tool={} source={} status={} action=pinset-detect-or-import",
+            finding.tool,
+            finding.source,
+            discovery_status_name(finding.status, Language::English)
         );
     }
     Ok(())
@@ -4536,6 +5204,7 @@ mod tests {
     fn import_replacement_check_is_limited_to_discovered_tools() {
         let project = ProjectConfig {
             schema: PROJECT_CONFIG_SCHEMA,
+            policy: Default::default(),
             tools: BTreeMap::from([
                 ("go".to_owned(), "1.24.0".to_owned()),
                 ("node".to_owned(), "22.0.0".to_owned()),
@@ -4586,6 +5255,49 @@ mod tests {
                 global: false,
                 ..
             }) if selection == "node@24"
+        ));
+    }
+
+    #[test]
+    fn parses_v15_explain_update_and_migrate_options() {
+        let which = Cli::try_parse_from(["pinset", "which", "node", "--explain", "--json"])
+            .expect("which explain");
+        assert!(matches!(
+            which.command,
+            Some(Commands::Which {
+                explain: true,
+                json: true,
+                ..
+            })
+        ));
+
+        let update = Cli::try_parse_from([
+            "pinset",
+            "update",
+            "node",
+            "--dry-run",
+            "--json",
+        ])
+        .expect("update");
+        assert!(matches!(
+            update.command,
+            Some(Commands::Update {
+                tool: Some(tool),
+                dry_run: true,
+                json: true,
+                ..
+            }) if tool == "node"
+        ));
+
+        let migrate = Cli::try_parse_from(["pinset", "migrate", "--global", "--dry-run"])
+            .expect("migrate");
+        assert!(matches!(
+            migrate.command,
+            Some(Commands::Migrate {
+                global: true,
+                dry_run: true,
+                ..
+            })
         ));
     }
 

--- a/crates/pinset/tests/init_cli.rs
+++ b/crates/pinset/tests/init_cli.rs
@@ -19,7 +19,7 @@ fn init_creates_a_minimal_config_without_runtime_side_effects() {
     let config_path = project.join("pinset.toml");
     assert_eq!(
         fs::read_to_string(&config_path).expect("created config"),
-        "schema = 2\n\n[tools]\n"
+        "schema = 3\n\n[policy]\ninherit-global = false\nsystem-fallback = false\nboundary = \"git\"\n\n[tools]\n"
     );
     assert!(String::from_utf8_lossy(&output.stdout).contains(&config_path.display().to_string()));
     assert!(!isolated_home.exists());

--- a/crates/pinset/tests/mvp_cli.rs
+++ b/crates/pinset/tests/mvp_cli.rs
@@ -53,6 +53,56 @@ fn current_which_exec_and_doctor_share_the_locked_fake_runtime() {
 }
 
 #[test]
+fn current_keeps_requested_selector_separate_from_locked_version() {
+    let root = tempdir().expect("temporary root");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    fs::create_dir(&project).expect("project");
+    let config_path = project.join("pinset.toml");
+    let config = ProjectConfig {
+        schema: 3,
+        policy: Default::default(),
+        tools: BTreeMap::from([("node".to_owned(), "24".to_owned())]),
+    };
+    save_project_config(&config_path, &config).expect("project config");
+    let mut lockfile = test_lockfile("24.0.0");
+    lockfile.tools[0].requested = "24".to_owned();
+    save_lockfile(&project.join("pinset.lock"), &lockfile).expect("lockfile");
+    create_fake_node(&home, "24.0.0");
+    create_complete_install_receipt(&home, "24.0.0");
+
+    let current = pinset(&project, &home, &["current", "--json"]);
+    assert!(
+        current.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&current.stderr)
+    );
+    let report: serde_json::Value =
+        serde_json::from_slice(&current.stdout).expect("current JSON");
+    assert_eq!(report["data"]["requested"], "24");
+    assert_eq!(report["data"]["version"], "24.0.0");
+
+    let global_config = GlobalConfig {
+        schema: 3,
+        tools: BTreeMap::from([("node".to_owned(), "24".to_owned())]),
+    };
+    let mut global_lock = test_lockfile("24.0.0");
+    global_lock.tools[0].requested = "24".to_owned();
+    save_global_state(&home, &global_config, &global_lock).expect("global selector state");
+    let global = pinset(&project, &home, &["global"]);
+    assert_success_contains(&global, "node@24 resolved to node@24.0.0");
+    assert_success_contains(&global, "node 24.0.0 installed");
+
+    let uninstall = pinset(&project, &home, &["uninstall", "node@24.0.0"]);
+    assert!(!uninstall.status.success());
+    assert!(
+        String::from_utf8_lossy(&uninstall.stderr).contains("it is selected"),
+        "stderr: {}",
+        String::from_utf8_lossy(&uninstall.stderr)
+    );
+}
+
+#[test]
 fn which_and_exec_use_the_global_fake_runtime_without_a_project() {
     let root = tempdir().expect("temporary root");
     let workspace = root.path().join("workspace");
@@ -484,8 +534,12 @@ fn unset_clears_project_then_global_selection_without_uninstalling_runtimes() {
             .contains("[tools]")
     );
     let current = pinset(&project, &home, &["current"]);
-    assert_success_contains(&current, "node 24.0.0 installed");
-    assert_success_contains(&current, "source=global");
+    assert!(!current.status.success());
+    assert!(
+        String::from_utf8_lossy(&current.stderr).contains("strict project"),
+        "stderr: {}",
+        String::from_utf8_lossy(&current.stderr)
+    );
     assert!(
         project_runtime.is_file(),
         "project runtime must be preserved"
@@ -619,14 +673,71 @@ fn doctor_json_is_machine_readable_and_has_no_manager_migration_report() {
     assert!(report["data"].get("legacy_node_configs").is_none());
     assert_eq!(
         fs::read_to_string(project.join("pinset.toml")).expect("project config"),
-        "schema = 2\n\n[tools]\nnode = \"24.0.0\"\n"
+        "schema = 3\n\n[policy]\ninherit-global = false\nsystem-fallback = false\nboundary = \"git\"\n\n[tools]\nnode = \"24.0.0\"\n"
     );
+}
+
+#[test]
+fn migrate_previews_and_upgrades_schema_two_without_resolving_versions() {
+    let root = tempdir().expect("temporary root");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    fs::create_dir(&project).expect("project");
+    let config_path = project.join("pinset.toml");
+    let lock_path = project.join("pinset.lock");
+    fs::write(
+        &config_path,
+        "schema = 2\n\n[tools]\nnode = \"24.0.0\"\n",
+    )
+    .expect("legacy config");
+    let artifacts = MVP_NODE_TARGETS
+        .into_iter()
+        .map(|target| locked_artifact("24.0.0", target))
+        .collect();
+    let mut lockfile = Lockfile::new_node(
+        "pinset integration test".to_owned(),
+        "24.0.0".to_owned(),
+        "5BE8A3F6C8A5C01D106C0AD820B1A390B168D356".to_owned(),
+        "official".to_owned(),
+        artifacts,
+    );
+    lockfile.schema = 2;
+    fs::write(
+        &lock_path,
+        toml::to_string_pretty(&lockfile).expect("legacy lock TOML"),
+    )
+    .expect("legacy lock");
+
+    let preview = pinset(&project, &home, &["migrate", "--dry-run", "--json"]);
+    assert!(preview.status.success());
+    let preview: serde_json::Value =
+        serde_json::from_slice(&preview.stdout).expect("migration preview JSON");
+    assert_eq!(preview["data"]["from_config_schema"], 2);
+    assert_eq!(preview["data"]["from_lock_schema"], 2);
+    assert_eq!(preview["data"]["to_schema"], 3);
+    assert!(fs::read_to_string(&config_path)
+        .expect("unchanged config")
+        .starts_with("schema = 2"));
+
+    let migrated = pinset(&project, &home, &["migrate"]);
+    assert!(
+        migrated.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&migrated.stderr)
+    );
+    let config = fs::read_to_string(config_path).expect("migrated config");
+    assert!(config.starts_with("schema = 3"));
+    assert!(config.contains("inherit-global = false"));
+    assert!(fs::read_to_string(lock_path)
+        .expect("migrated lock")
+        .starts_with("schema = 3"));
 }
 
 fn write_project(project: &Path, configured_version: &str, locked_version: &str) {
     let config_path = project.join("pinset.toml");
     let config = ProjectConfig {
         schema: 1,
+        policy: Default::default(),
         tools: BTreeMap::from([("node".to_owned(), configured_version.to_owned())]),
     };
     save_project_config(&config_path, &config).expect("project config");

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2,15 +2,15 @@
 
 [English](commands.md) | [简体中文](commands.zh-CN.md) · [README](../README.md)
 
-This document describes the Pinset v1.1 command-line contract. Run `pinset <command> --help` for the exact parser help shipped with your binary.
+This document describes the Pinset v1.5 command-line contract. Run `pinset <command> --help` for the exact parser help shipped with your binary.
 
 ## Conventions
 
 ### Selections and scope
 
-A selection has the form `<tool>@<selector>`, for example `node@22`, `pnpm@latest`, `java@lts`, or `rust@stable`. Pinset resolves selectors to exact versions before writing a lockfile.
+A selection has the form `<tool>@<selector>`, for example `node@22`, `pnpm@latest`, `java@lts`, or `rust@stable`. Schema 3 keeps that requested selector in configuration and records its exact resolved version in the lockfile.
 
-Supported tools are Node.js, pnpm, Bun, Go, Python, Java, Rust, .NET, and Flutter. Dart is provided by the selected Flutter SDK. A nearest project `pinset.toml` takes precedence over global state; Pinset can then fall back to an eligible system command.
+Supported tools are Node.js, pnpm, Bun, Go, Python, Java, Rust, .NET, and Flutter. Dart is provided by the selected Flutter SDK. Project discovery stops at the nearest Git root by default; without a Git marker it inspects only the start directory. A project is strict by default: an undeclared tool neither inherits global state nor falls back to the system command unless `[policy]` explicitly enables `inherit-global` or `system-fallback`. Outside a project, global state then system `PATH` remain eligible.
 
 The global `--lang <en|zh-CN>` option selects output language for one invocation. Running `pinset --lang <language>` without a subcommand saves the default language.
 
@@ -52,7 +52,7 @@ The tables below repeat exceptional behavior where it matters. Otherwise the com
 | --- | --- |
 | Purpose | Create a minimal project configuration in the current directory. |
 | Syntax and arguments | `pinset init`; no command-specific options. |
-| Modifies state | **Yes.** Creates `pinset.toml`; it does not select or install a runtime. |
+| Modifies state | **Yes.** Creates schema 3 `pinset.toml` with strict project policy; it does not select or install a runtime. |
 | Example | `mkdir app && cd app && pinset init` |
 | JSON | No. |
 | Exit | `0` success; `2` if the file cannot be safely created. |
@@ -76,9 +76,9 @@ Recognized selection sources include `.nvmrc`, `.node-version`, `.bun-version`, 
 
 | Field | Description |
 | --- | --- |
-| Purpose | Re-scan and import every safe traditional selection into schema-2 `pinset.toml` and `pinset.lock`. |
-| Syntax and arguments | `pinset import [--cwd <path>] [--force] [--no-install]`. `--force` replaces only discovered tools already selected at another exact version. |
-| Modifies state | **Yes.** Resolves metadata, writes lock then config atomically, and installs all project selections by default. `--no-install` skips runtime archives and Python `.venv`, but still resolves and locks metadata. |
+| Purpose | Re-scan and import every safe traditional selection into schema 3 `pinset.toml` and `pinset.lock`. |
+| Syntax and arguments | `pinset import [--cwd <path>] [--force] [--no-install]`. `--force` replaces only discovered tools whose existing requested selector differs. |
+| Modifies state | **Yes.** Resolves metadata, atomically replaces the lock file and then the config file, and installs all project selections by default. `--no-install` skips runtime archives and Python `.venv`, but still resolves and locks metadata. |
 | Example | `pinset import --no-install` |
 | JSON | No. |
 | Exit | `0` after a complete import/install; `2` for no selection, blockers, invalid existing Pinset state, resolution/write failure, or installation failure. |
@@ -141,10 +141,10 @@ Import never reads installed state from another runtime manager, executes manage
 | Field | Description |
 | --- | --- |
 | Purpose | Print the exact executable Pinset would use for a command. |
-| Syntax and arguments | `pinset which <command> [--cwd <path>] [--json]`. |
+| Syntax and arguments | `pinset which <command> [--cwd <path>] [--explain] [--json]`. |
 | Modifies state | No. |
 | Example | `pinset which node --json` |
-| JSON | **Yes**; command name `which`. |
+| JSON | **Yes**; command name `which`. With `--explain`, `data.explanation` includes the boundary, candidate chain, policy result, and traditional migration-only sources. |
 | Exit | `0` when resolved; `2` when no usable command can be resolved. |
 | Key errors | Unknown managed command, missing selected runtime, invalid lock, or no eligible system fallback. |
 
@@ -153,10 +153,10 @@ Import never reads installed state from another runtime manager, executes manage
 | Field | Description |
 | --- | --- |
 | Purpose | Show the effective project, global, or system runtime selection and executable. |
-| Syntax and arguments | `pinset current [tool] [--cwd <path>] [--json]`; the default tool is Node.js. |
+| Syntax and arguments | `pinset current [tool] [--cwd <path>] [--explain] [--json]`; the default tool is Node.js. |
 | Modifies state | No. |
 | Example | `pinset current python --cwd ./app` |
-| JSON | **Yes**; command name `current`. |
+| JSON | **Yes**; command name `current`, including both `requested` and exact `version`; `--explain` adds the resolution trace. |
 | Exit | `0` when resolved; `2` when selection or installation is unusable. |
 | Key errors | Unsupported tool, invalid config/lock, missing runtime, or blocked system fallback. |
 
@@ -176,13 +176,37 @@ Import never reads installed state from another runtime manager, executes manage
 
 | Field | Description |
 | --- | --- |
-| Purpose | Compare selected project and global runtimes with current stable releases. |
+| Purpose | Compare each exact locked version with the newest version compatible with its requested selector and with the latest stable release. |
 | Syntax and arguments | `pinset outdated [tool] [--global | --cwd <path>] [--json]`. |
 | Modifies state | No. |
 | Example | `pinset outdated --cwd ./app --json` |
-| JSON | **Yes**; command name `outdated`, with results under `data.runtimes`. |
+| JSON | **Yes**; command name `outdated`, with `requested`, `current`, `latest_compatible`, `latest`, `update_available`, and `upgrade_available` under `data.runtimes`. |
 | Exit | `0` after a complete comparison; `2` if scope, lock, or metadata validation fails. |
 | Key errors | Missing project, unsupported tool, invalid lock, or Provider metadata failure. |
+
+### `update`
+
+| Field | Description |
+| --- | --- |
+| Purpose | Re-resolve requested selectors and refresh exact lock records without changing selectors or installing runtimes. |
+| Syntax and arguments | `pinset update [tool] [--global | --cwd <path>] [--dry-run] [--json]`. |
+| Modifies state | **Yes**, unless `--dry-run`; updates only the selected lockfile. |
+| Example | `pinset update node --cwd ./app --dry-run` |
+| JSON | **Yes**; command name `update`, with previous/resolved exact versions and requested selector. |
+| Exit | `0` after comparison/write; `2` on scope, lock, or Provider metadata failure. |
+| Key errors | Missing project/selection, invalid lock, unsupported tool, or unavailable metadata. |
+
+### `migrate`
+
+| Field | Description |
+| --- | --- |
+| Purpose | Validate and rewrite existing schema 1/2 project or global config and lock state as schema 3 without re-resolving versions. |
+| Syntax and arguments | `pinset migrate [--global | --cwd <path>] [--dry-run] [--json]`. |
+| Modifies state | **Yes**, unless `--dry-run`; normalizes the config and lock with atomic per-file replacement only. |
+| Example | `pinset migrate --cwd ./app --dry-run` |
+| JSON | **Yes**; command name `migrate`, including source and target schemas. |
+| Exit | `0` after validation/migration; `2` when config and lock cannot be proven consistent. |
+| Key errors | Missing config/lock, unsupported schema, config-lock mismatch, or write failure. |
 
 ### `uninstall`
 
@@ -224,7 +248,7 @@ Import never reads installed state from another runtime manager, executes manage
 
 | Field | Description |
 | --- | --- |
-| Purpose | Diagnose project, lockfile, installation, command-routing, environment, and PATH state. |
+| Purpose | Diagnose the project boundary and strict policy, lockfile, installation, command routing, environment, PATH state, and traditional migration-only sources. |
 | Syntax and arguments | `pinset doctor [--cwd <path>] [--json]`. |
 | Modifies state | No. |
 | Example | `pinset doctor --json` |
@@ -536,4 +560,4 @@ Custom source configuration currently applies to Node.js, Go, Python, and Flutte
 
 ## Stable protocol boundary
 
-Pinset v1.0 writes schema 2 for project/global configuration, lockfiles, global state, and installation receipts. Compatible readers may add fields within a major version. Removing a field or changing its type or meaning requires a new major version; a future disk-format change must remain readable or provide an explicit migration. A pre-v1 Node lock that records only an HTTPS checksum is rejected with instructions to run `pinset use` again, because it lacks the v1 OpenPGP verification evidence.
+Pinset v1.5 writes schema 3 for project/global configuration and lockfiles. Schema 1/2 remains readable; `pinset migrate` validates and upgrades existing config-lock pairs. Schema 3 deliberately separates the requested selector from the exact resolved lock version and introduces explicit project fallback/boundary policy. Direct downgrade from schema 3 is not supported. Installation receipts retain their own independent schema. A pre-v1 Node lock that records only an HTTPS checksum is rejected with instructions to run `pinset use` again, because it lacks the v1 OpenPGP verification evidence.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -2,15 +2,15 @@
 
 [English](commands.md) | [简体中文](commands.zh-CN.md) · [README](../README.zh-CN.md)
 
-本文档描述 Pinset v1.1 命令行协议。可以运行 `pinset <command> --help` 查看当前二进制附带的精确参数帮助。
+本文档描述 Pinset v1.5 命令行协议。可以运行 `pinset <command> --help` 查看当前二进制附带的精确参数帮助。
 
 ## 通用约定
 
 ### 选择器与作用域
 
-选择表达式格式为 `<tool>@<selector>`，例如 `node@22`、`pnpm@latest`、`java@lts` 或 `rust@stable`。Pinset 会先把选择器解析成精确版本，再写入锁文件。
+选择表达式格式为 `<tool>@<selector>`，例如 `node@22`、`pnpm@latest`、`java@lts` 或 `rust@stable`。schema 3 会在配置中保留这个请求选择器，并在锁文件中记录精确解析版本。
 
-支持的工具为 Node.js、pnpm、Bun、Go、Python、Java、Rust、.NET 和 Flutter。Dart 由所选 Flutter SDK 提供。最近项目的 `pinset.toml` 优先于全局状态；之后 Pinset 可以回退到符合条件的系统命令。
+支持的工具为 Node.js、pnpm、Bun、Go、Python、Java、Rust、.NET 和 Flutter。Dart 由所选 Flutter SDK 提供。项目发现默认在最近的 Git 根目录停止；没有 Git 标记时只检查起始目录。项目默认严格：未声明工具不会继承全局状态，也不会回退系统命令；只有 `[policy]` 显式启用 `inherit-global` 或 `system-fallback` 时才允许。项目之外仍按全局状态、系统 `PATH` 的顺序解析。
 
 全局选项 `--lang <en|zh-CN>` 用于选择单次调用的输出语言。不带子命令运行 `pinset --lang <language>` 会保存默认语言。
 
@@ -52,7 +52,7 @@
 | --- | --- |
 | 用途 | 在当前目录创建最小项目配置。 |
 | 语法与参数 | `pinset init`；没有命令专属选项。 |
-| 修改状态 | **是。** 创建 `pinset.toml`，但不选择或安装运行时。 |
+| 修改状态 | **是。** 创建带严格项目策略的 schema 3 `pinset.toml`，但不选择或安装运行时。 |
 | 示例 | `mkdir app && cd app && pinset init` |
 | JSON | 不支持。 |
 | 退出码 | 成功为 `0`；无法安全创建文件为 `2`。 |
@@ -76,9 +76,9 @@
 
 | 字段 | 说明 |
 | --- | --- |
-| 用途 | 重新扫描，并把所有可安全映射的传统选择导入 schema 2 的 `pinset.toml` 与 `pinset.lock`。 |
-| 语法与参数 | `pinset import [--cwd <目录>] [--force] [--no-install]`。`--force` 只替换本次发现且现有精确版本不同的工具。 |
-| 修改状态 | **是。** 解析元数据，按锁文件优先、配置随后顺序原子写入，并默认安装项目全部选择。`--no-install` 跳过运行时归档和 Python `.venv`，但仍解析并锁定元数据。 |
+| 用途 | 重新扫描，并把所有可安全映射的传统选择导入 schema 3 的 `pinset.toml` 与 `pinset.lock`。 |
+| 语法与参数 | `pinset import [--cwd <目录>] [--force] [--no-install]`。`--force` 只替换本次发现且现有请求选择器不同的工具。 |
+| 修改状态 | **是。** 解析元数据，先锁文件、后配置分别进行原子文件替换，并默认安装项目全部选择。`--no-install` 跳过运行时归档和 Python `.venv`，但仍解析并锁定元数据。 |
 | 示例 | `pinset import --no-install` |
 | JSON | 不支持。 |
 | 退出码 | 完整导入/安装后为 `0`；没有选择、存在阻断项、现有 Pinset 状态无效、解析/写入失败或安装失败为 `2`。 |
@@ -141,10 +141,10 @@
 | 字段 | 说明 |
 | --- | --- |
 | 用途 | 输出 Pinset 将为某命令使用的精确可执行文件。 |
-| 语法与参数 | `pinset which <command> [--cwd <path>] [--json]`。 |
+| 语法与参数 | `pinset which <command> [--cwd <path>] [--explain] [--json]`。 |
 | 修改状态 | 否。 |
 | 示例 | `pinset which node --json` |
-| JSON | **支持**；命令名为 `which`。 |
+| JSON | **支持**；命令名为 `which`。使用 `--explain` 时，`data.explanation` 包含边界、候选链、策略结果和只用于迁移的传统来源。 |
 | 退出码 | 成功解析为 `0`；无法解析可用命令为 `2`。 |
 | 关键错误 | 未知受管命令、所选运行时缺失、锁无效或没有符合条件的系统回退。 |
 
@@ -153,10 +153,10 @@
 | 字段 | 说明 |
 | --- | --- |
 | 用途 | 显示当前生效的项目、全局或系统运行时选择和可执行文件。 |
-| 语法与参数 | `pinset current [tool] [--cwd <path>] [--json]`；默认工具为 Node.js。 |
+| 语法与参数 | `pinset current [tool] [--cwd <path>] [--explain] [--json]`；默认工具为 Node.js。 |
 | 修改状态 | 否。 |
 | 示例 | `pinset current python --cwd ./app` |
-| JSON | **支持**；命令名为 `current`。 |
+| JSON | **支持**；命令名为 `current`，同时包含 `requested` 与精确 `version`；`--explain` 增加解析轨迹。 |
 | 退出码 | 成功解析为 `0`；选择或安装不可用为 `2`。 |
 | 关键错误 | 工具不支持、配置/锁无效、运行时缺失或系统回退被阻止。 |
 
@@ -176,13 +176,37 @@
 
 | 字段 | 说明 |
 | --- | --- |
-| 用途 | 将项目和全局所选运行时与当前稳定版本比较。 |
+| 用途 | 将每个精确锁定版本同时与“请求选择器允许的最新版本”和“最新稳定版本”比较。 |
 | 语法与参数 | `pinset outdated [tool] [--global | --cwd <path>] [--json]`。 |
 | 修改状态 | 否。 |
 | 示例 | `pinset outdated --cwd ./app --json` |
-| JSON | **支持**；命令名为 `outdated`，结果位于 `data.runtimes`。 |
+| JSON | **支持**；命令名为 `outdated`，`data.runtimes` 包含 `requested`、`current`、`latest_compatible`、`latest`、`update_available` 与 `upgrade_available`。 |
 | 退出码 | 完整比较后为 `0`；作用域、锁或元数据验证失败为 `2`。 |
 | 关键错误 | 项目缺失、工具不支持、锁无效或 Provider 元数据失败。 |
+
+### `update`
+
+| 字段 | 说明 |
+| --- | --- |
+| 用途 | 重新解析请求选择器并刷新精确锁记录，不改变选择器，也不安装运行时。 |
+| 语法与参数 | `pinset update [tool] [--global | --cwd <path>] [--dry-run] [--json]`。 |
+| 修改状态 | **是**，但 `--dry-run` 时不修改；只更新所选锁文件。 |
+| 示例 | `pinset update node --cwd ./app --dry-run` |
+| JSON | **支持**；命令名为 `update`，包含旧/新精确版本和请求选择器。 |
+| 退出码 | 完成比较/写入为 `0`；作用域、锁或 Provider 元数据失败为 `2`。 |
+| 关键错误 | 项目/选择缺失、锁无效、工具不支持或元数据不可用。 |
+
+### `migrate`
+
+| 字段 | 说明 |
+| --- | --- |
+| 用途 | 验证并把现有 schema 1/2 项目或全局配置/锁重写为 schema 3，不重新解析版本。 |
+| 语法与参数 | `pinset migrate [--global | --cwd <path>] [--dry-run] [--json]`。 |
+| 修改状态 | **是**，但 `--dry-run` 时不修改；仅以逐文件原子替换方式规范化配置与锁。 |
+| 示例 | `pinset migrate --cwd ./app --dry-run` |
+| JSON | **支持**；命令名为 `migrate`，包含来源与目标 schema。 |
+| 退出码 | 验证/迁移完成为 `0`；无法证明配置与锁一致时为 `2`。 |
+| 关键错误 | 配置/锁缺失、schema 不支持、配置与锁不匹配或写入失败。 |
 
 ### `uninstall`
 
@@ -224,7 +248,7 @@
 
 | 字段 | 说明 |
 | --- | --- |
-| 用途 | 诊断项目、锁、安装、命令路由、环境变量和 PATH 状态。 |
+| 用途 | 诊断项目边界与严格策略、锁、安装、命令路由、环境变量、PATH 状态和只用于迁移的传统来源。 |
 | 语法与参数 | `pinset doctor [--cwd <path>] [--json]`。 |
 | 修改状态 | 否。 |
 | 示例 | `pinset doctor --json` |
@@ -536,4 +560,4 @@
 
 ## 稳定协议边界
 
-Pinset v1.0 为项目/全局配置、锁文件、全局状态与安装收据写入 schema 2。同一主版本内允许兼容地增加字段。删除字段或改变字段类型/含义需要新的主版本；未来磁盘格式变更必须保持可读，或提供显式迁移。仅记录 HTTPS 摘要的 v1 前 Node 锁会被拒绝，并提示重新运行 `pinset use`，因为它缺少 v1 OpenPGP 验证证据。
+Pinset v1.5 为项目/全局配置与锁文件写入 schema 3。schema 1/2 仍可读取；`pinset migrate` 会验证并升级现有配置与锁。schema 3 明确区分请求选择器和锁中的精确解析版本，并引入显式项目回退/边界策略；不支持从 schema 3 直接降级。安装收据继续使用自身独立的 schema。仅记录 HTTPS 摘要的 v1 前 Node 锁会被拒绝，并提示重新运行 `pinset use`，因为它缺少 v1 OpenPGP 验证证据。

--- a/docs/comparison.zh-CN.md
+++ b/docs/comparison.zh-CN.md
@@ -1,0 +1,47 @@
+# Pinset v1.5 横向对比
+
+调研日期：2026-08-19。对比只使用各产品官方文档或官方仓库，并区分“运行时版本管理器”和“完整开发环境管理器”。后者解决的问题更大，不应直接当作 Pinset 的功能缺口。
+
+## 直接同类
+
+| 产品 | 定位与路由 | 传统配置 | 可复现锁 | 扩展方式 | Pinset 相比之下 |
+| --- | --- | --- | --- | --- | --- |
+| Pinset v1.5 | 9 个内置 Provider；项目默认严格，项目外才按全局、系统顺序解析 | 只由显式 `detect` / `import` 读取 | schema 3 始终分离 requested selector 与 exact version，并记录平台制品与完整性 | 当前为内置 Provider 清单 | 更保守、可解释、供应链边界统一；生态宽度较小 |
+| [proto](https://moonrepo.dev/docs/proto/detection) | CLI/环境变量、`.prototools`、生态文件、全局的上下文解析 | 日常 shim 会自动读取 `.nvmrc`、`package.json` 等 | [`.protolock`](https://moonrepo.dev/docs/proto/lockfile) 记录 spec、exact version、checksum、OS/arch，但目前标为 opt-in/unstable | 插件/后端体系 | proto 的扩展性和日常兼容更强；Pinset 不会被传统文件隐式改变运行时，且项目缺项默认失败关闭 |
+| [mise](https://mise.jdx.dev/dev-tools/shims.html) | 工具、环境、任务和多种 backend 的综合平台；支持 PATH 激活、shim、exec/run | 广泛兼容生态配置 | [mise.lock](https://mise.jdx.dev/dev-tools/mise-lock.html) 可锁 exact version、URL、checksum，但创建需启用设置或显式命令，完整性能力取决于 backend | 大型 backend/plugin 生态 | mise 覆盖面和集成远强；Pinset 的默认系统回退更安全、协议更窄且更容易审计 |
+| [asdf](https://asdf-vm.com/guide/introduction.html) | `.tool-versions` + shim 的经典多语言管理器 | 以自身统一配置为主 | 官方简介强调精确版本共享，未提供与 Pinset 同层级的平台制品锁模型 | 社区插件是核心 | asdf 成熟、工具覆盖广；Pinset 的制品身份、来源信任和锁验证更统一 |
+| [Volta](https://docs.volta.sh/guide/understanding) | JavaScript 专用，自动按目录路由 Node/npm/Yarn/包命令 | 读取项目内 Volta 配置 | 项目 pin 与包命令绑定 Node engine，范围比通用运行时锁更窄 | 聚焦 JavaScript，不追求通用插件 | Volta 在 JS 体验和包命令上更深；Pinset 适合多语言仓库并提供统一供应链策略 |
+| [vfox](https://vfox.dev/guides/intro.html) | Windows/Linux/macOS 原生、项目/会话/全局作用域与自动切换 | 日常兼容 `.node-version`、`.nvmrc`、`.sdkmanrc` | 本次官方资料未发现等价的平台制品锁协议 | Lua 插件生态 | vfox 的 Windows 体验、Shell 覆盖和可扩展性很有竞争力；Pinset 的锁与来源验证边界更明确 |
+
+## 邻近产品
+
+| 产品 | 它真正解决的问题 | 值得借鉴，但不应直接照搬 |
+| --- | --- | --- |
+| [aqua](https://aquaproj.github.io/docs/reference/security/checksum/) | 以安全安装 CLI 工具为中心，支持制品和 Registry 校验 | Registry 校验、自动生成 checksum 配置、CLI 工具目录；Pinset 不必扩张成通用包管理器 |
+| [Devbox](https://jetify.mintlify.app/docs/devbox/quickstart/index) | 基于 Nix 的隔离开发 Shell，`devbox.json` + `devbox.lock` 覆盖整个工具环境 | 一条命令进入可复现环境、IDE/direnv 集成；代价是更重的 Nix 与子 Shell 模型 |
+| [Flox](https://flox.dev/docs/concepts/environments) | 可组合、可共享的 Nix 环境，包含软件包、变量、脚本、服务和远端环境 | 环境分层、中心共享、manifest/lock；这属于 Pinset 目前有意不覆盖的平台级范围 |
+
+## Pinset 的现实优势
+
+1. **默认失败关闭。** 项目存在但未声明工具时，不会静默继承全局版本或命中系统同名程序；mise 官方文档明确说明 shim 在默认设置下可能自动安装或回退系统命令，Pinset 的行为更适合 CI、审计和高要求团队。
+2. **迁移输入与运行时输入分离。** proto、vfox 的便利来自日常自动兼容传统文件；Pinset 将它们限制在显式只读检测/导入，因此普通 shim 的结果只由 Pinset 配置、锁和明确策略决定。
+3. **一个受控供应链实现。** Provider 的元数据、可信来源、平台制品、摘要、解压、缓存、收据和卸载所有权由同一核心约束；插件型产品往往把最终保证交给不同 backend/plugin。
+4. **Windows 是一等平台。** Pinset 的小型独立 shim、PowerShell 补全和 Windows 原生目标不是 Unix Shell 方案的附带移植。
+5. **v1.5 的 selector/lock 语义清晰。** 配置回答“团队允许什么”，锁回答“这次实际用了什么”；`outdated`、`update`、`migrate` 使用同一语义。
+
+## 当前缺点
+
+1. **Provider 数量和插件生态不足。** proto、mise、asdf、vfox 都能让外部作者扩展工具；Pinset 新增 Provider 仍需进入主仓库、随主程序发布。
+2. **选择器语法较窄。** 当前擅长精确版本、major/minor 前缀和 `latest`/`lts`/`stable` 等通道，还不是 mise/proto 那样完整、跨工具一致的版本要求语言。
+3. **便利性有意让位于确定性。** 用户必须 `detect`/`import`，不会像 proto/vfox 一样放下 `.nvmrc` 就自动生效；需要通过提示、`doctor` 与初始化体验降低摩擦。
+4. **不管理完整开发环境。** 没有 mise 的变量/hooks/tasks，也没有 Devbox/Flox 的系统包、服务和隔离 Shell。这既是范围控制，也是对需要“一键完整环境”团队的劣势。
+5. **集成与分发仍薄。** IDE、direnv、Dev Container、Homebrew/Winget/Scoop、企业 Registry 和公开采用案例都落后于成熟产品。
+
+## 下一阶段最值得学的内容
+
+1. 设计**受能力限制的 Provider 扩展协议**：声明命令、版本语法、元数据源、制品和验证能力；第三方扩展不得绕过 HTTPS、完整性、路径和所有权规则。
+2. 让解释能力覆盖失败路径：`which --explain` 即使因严格策略、锁缺失或未安装失败，也应输出结构化候选链和稳定 reason code。
+3. 为所有 Provider 建立统一 selector AST 与兼容性测试，再考虑 `>=`、`^`、`~`、日期版本等语法；不要把字符串范围判断散落到 Provider 中。
+4. 借鉴 proto/mise 的 lock audit：检查 stale record、重复 selector/platform、缺少 provenance、配置已删除但锁仍残留，并提供只读修复计划。
+5. 借鉴 aqua 的 Registry/checksum 思路，对 Provider 清单、镜像策略和扩展包本身做签名或摘要验证。
+6. 优先补齐 IDE/direnv/Dev Container 与主流包管理器分发，而不是把 Pinset 扩张成任务运行器或 Nix 环境平台。

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="1.1.0"
+DEFAULT_VERSION="1.5.0"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -18,7 +18,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 1.1.0.
+  --version VERSION       Install an exact release, for example 1.5.0.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.


### PR DESCRIPTION
## What changed

- introduce schema 3 with requested selectors separated from exact locked versions
- make project routing strict by default with explicit global/system fallback and Git/filesystem boundaries
- add explainable resolution, constraint-aware outdated/update, and explicit migration commands
- move provider-specific traditional-file discovery declarations into provider manifests
- update lifecycle protection, Python environment routing, documentation, completions, changelog, and comparison research for v1.5.0

## Impact

This is an intentional breaking upgrade before broad adoption. Schema 1 and 2 remain readable and can be upgraded with pinset migrate; direct downgrade from schema 3 is not supported.

## Validation

- git diff --check passed locally
- version, schema, command, and documentation consistency were statically inspected
- formatting, Clippy, builds, tests, installer checks, and multi-platform release validation are delegated to GitHub Actions as required by CONTRIBUTING.md