### PR TITLE
style: apply v1.5.0 rustfmt output

### DIFF
--- a/crates/pinset-core/src/config.rs
+++ b/crates/pinset-core/src/config.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::BTreeMap,
-    env,
-    fs,
+    env, fs,
     path::{Path, PathBuf},
 };
 
@@ -82,9 +81,11 @@ impl ProjectConfig {
 
 pub fn find_project_config(start: &Path) -> Result<PathBuf> {
     let context = find_project_context(start)?;
-    context.config_path.ok_or_else(|| Error::ProjectConfigNotFound {
-        start: context.start,
-    })
+    context
+        .config_path
+        .ok_or_else(|| Error::ProjectConfigNotFound {
+            start: context.start,
+        })
 }
 
 pub fn find_optional_project_config(start: &Path) -> Result<Option<PathBuf>> {
@@ -173,11 +174,7 @@ fn nearest_git_root(start: &Path) -> Option<PathBuf> {
 }
 
 fn filesystem_root(start: &Path) -> PathBuf {
-    start
-        .ancestors()
-        .last()
-        .unwrap_or(start)
-        .to_path_buf()
+    start.ancestors().last().unwrap_or(start).to_path_buf()
 }
 
 fn ancestors_through<'a>(start: &'a Path, boundary: &'a Path) -> impl Iterator<Item = &'a Path> {

--- a/crates/pinset-core/src/node_lifecycle.rs
+++ b/crates/pinset-core/src/node_lifecycle.rs
@@ -6,9 +6,9 @@ use std::{
 
 use serde::Deserialize;
 
-use crate::{Error, Result, find_tool_version_references, validate_exact_node_version};
 #[cfg(test)]
 use crate::global_config_path;
+use crate::{Error, Result, find_tool_version_references, validate_exact_node_version};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstalledNodeVersion {

--- a/crates/pinset-core/src/project_discovery.rs
+++ b/crates/pinset-core/src/project_discovery.rs
@@ -7,9 +7,7 @@ use std::{
 
 use serde::Serialize;
 
-use crate::{
-    PROJECT_CONFIG_FILENAME, RuntimeDiscoveryKind, runtime_provider, runtime_providers,
-};
+use crate::{PROJECT_CONFIG_FILENAME, RuntimeDiscoveryKind, runtime_provider, runtime_providers};
 
 const MAX_SOURCE_BYTES: u64 = 1024 * 1024;
 

--- a/crates/pinset-core/src/resolver.rs
+++ b/crates/pinset-core/src/resolver.rs
@@ -15,10 +15,9 @@ use std::{
 use crate::current_target;
 use crate::{
     Error, Result, RuntimeCommandLayout, RuntimeEnvironmentKind, current_target_for_tool,
-    find_project_context, global_config_path, is_managed_command_shim,
-    load_optional_global_config, load_project_config, load_project_python_environment,
-    project_python_command_candidates, runtime_provider, runtime_provider_for_command,
-    runtime_providers,
+    find_project_context, global_config_path, is_managed_command_shim, load_optional_global_config,
+    load_project_config, load_project_python_environment, project_python_command_candidates,
+    runtime_provider, runtime_provider_for_command, runtime_providers,
 };
 #[cfg(feature = "lockfile")]
 use crate::{
@@ -954,12 +953,10 @@ mod tests {
         let project = root.path().join("project");
         let home = root.path().join("home");
         fs::create_dir_all(&project).expect("project");
-        fs::write(project.join("pinset.toml"), "schema = 2\n[tools]\n")
-            .expect("project config");
+        fs::write(project.join("pinset.toml"), "schema = 2\n[tools]\n").expect("project config");
         let global_path = global_config_path(&home);
         fs::create_dir_all(global_path.parent().expect("state directory")).expect("state");
-        fs::write(global_path, "schema = 1\n[tools]\nnode = \"24.0.0\"\n")
-            .expect("global config");
+        fs::write(global_path, "schema = 1\n[tools]\nnode = \"24.0.0\"\n").expect("global config");
 
         assert!(matches!(
             resolve_tool_selection("node", &project, &home),

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -25,25 +25,25 @@ use pinset_core::{
     ShimInstallMethod, SourceView, clean_download_cache, command_tool, create_project_config,
     create_project_python_environment, current_target_for_tool, download_cache_info, ensure_shims,
     find_optional_project_config, find_project_config, find_project_context, global_config_path,
-    global_lockfile_path,
-    import_download_cache, import_download_cache_with_integrity, install_locked_dotnet,
-    install_locked_flutter, install_locked_go, install_locked_java, install_locked_node,
-    install_locked_npm_tool, install_locked_python, install_locked_rust, is_managed_command_shim,
-    list_all_installed_tool_versions, list_download_cache, list_installed_tool_versions,
-    load_global_config, load_lockfile, load_optional_global_config, load_optional_lockfile,
-    load_project_config, load_project_python_environment, load_source_config, load_user_settings,
-    lockfile_path, managed_runtime_arguments, path_with_selected_tools, pinset_home,
-    plan_prune_tool_versions, plan_uninstall_tool_version, project_python_environment_path,
-    repair_download_cache, resolve_command, resolve_project_python_command, resolve_tool_selection,
-    runtime_command_candidates, runtime_command_directory, runtime_environment_for_install,
-    runtime_provider, save_global_config, save_global_state, save_lockfile, save_project_config,
-    save_project_state, save_source_config, save_user_settings, scan_project_sources,
-    selected_runtime_environment, source_config_path, uninstall_node_version,
-    uninstall_tool_version, user_settings_path, validate_exact_dotnet_version,
-    validate_exact_flutter_version, validate_exact_go_version, validate_exact_java_version,
-    validate_exact_node_version, validate_exact_npm_tool_version, validate_exact_python_version,
-    validate_exact_rust_version, validate_lock_matches_selection, validate_lock_matches_tool,
-    validate_lock_matches_tools, validate_managed_runtime_invocation, verify_download_cache,
+    global_lockfile_path, import_download_cache, import_download_cache_with_integrity,
+    install_locked_dotnet, install_locked_flutter, install_locked_go, install_locked_java,
+    install_locked_node, install_locked_npm_tool, install_locked_python, install_locked_rust,
+    is_managed_command_shim, list_all_installed_tool_versions, list_download_cache,
+    list_installed_tool_versions, load_global_config, load_lockfile, load_optional_global_config,
+    load_optional_lockfile, load_project_config, load_project_python_environment,
+    load_source_config, load_user_settings, lockfile_path, managed_runtime_arguments,
+    path_with_selected_tools, pinset_home, plan_prune_tool_versions, plan_uninstall_tool_version,
+    project_python_environment_path, repair_download_cache, resolve_command,
+    resolve_project_python_command, resolve_tool_selection, runtime_command_candidates,
+    runtime_command_directory, runtime_environment_for_install, runtime_provider,
+    save_global_config, save_global_state, save_lockfile, save_project_config, save_project_state,
+    save_source_config, save_user_settings, scan_project_sources, selected_runtime_environment,
+    source_config_path, uninstall_node_version, uninstall_tool_version, user_settings_path,
+    validate_exact_dotnet_version, validate_exact_flutter_version, validate_exact_go_version,
+    validate_exact_java_version, validate_exact_node_version, validate_exact_npm_tool_version,
+    validate_exact_python_version, validate_exact_rust_version, validate_lock_matches_selection,
+    validate_lock_matches_tool, validate_lock_matches_tools, validate_managed_runtime_invocation,
+    verify_download_cache,
 };
 use serde::Serialize;
 use terminal_size::{Width, terminal_size_of};
@@ -1432,9 +1432,7 @@ fn print_resolution_explanation(explanation: &ResolutionExplanation) {
     println!("resolution boundary={}", explanation.boundary.display());
     println!(
         "resolution policy project-strict={} global-eligible={} system-eligible={}",
-        explanation.project_strict,
-        explanation.global_eligible,
-        explanation.system_eligible
+        explanation.project_strict, explanation.global_eligible, explanation.system_eligible
     );
     for candidate in &explanation.candidates {
         println!(
@@ -1782,9 +1780,11 @@ fn selected_version_from_lock(
     lock_path: &Path,
 ) -> Result<String, Box<dyn std::error::Error>> {
     if let Some(lockfile) = load_optional_lockfile(lock_path)? {
-        return Ok(validate_lock_matches_tool(&lockfile, tool, requested, config_path)?
-            .version
-            .clone());
+        return Ok(
+            validate_lock_matches_tool(&lockfile, tool, requested, config_path)?
+                .version
+                .clone(),
+        );
     }
     if config_schema < PROJECT_CONFIG_SCHEMA {
         return Ok(requested.to_owned());
@@ -2320,9 +2320,7 @@ fn resolve_locked_tool(
         RuntimeMetadataKind::Python => PythonMetadataClient::official()?.resolve_tool(selector)?,
         RuntimeMetadataKind::Java => JavaMetadataClient::official()?.resolve_tool(selector)?,
         RuntimeMetadataKind::Rust => RustMetadataClient::official()?.resolve_tool(selector)?,
-        RuntimeMetadataKind::Dotnet => {
-            DotnetMetadataClient::official()?.resolve_tool(selector)?
-        }
+        RuntimeMetadataKind::Dotnet => DotnetMetadataClient::official()?.resolve_tool(selector)?,
     };
     locked.requested = selector.to_owned();
     Ok(locked)
@@ -2729,8 +2727,7 @@ fn import_replacement_conflict(
 ) -> Option<(String, String, String)> {
     resolved.iter().find_map(|(tool, selector, _)| {
         project.tools.get(tool).and_then(|existing| {
-            (existing != selector)
-                .then(|| (tool.clone(), existing.clone(), selector.clone()))
+            (existing != selector).then(|| (tool.clone(), existing.clone(), selector.clone()))
         })
     })
 }
@@ -3565,13 +3562,8 @@ fn print_global_current(catalog: Catalog) -> Result<(), Box<dyn std::error::Erro
     }
     let lock_path = global_lockfile_path(&home);
     for (tool, requested) in &config.tools {
-        let version = selected_version_from_lock(
-            tool,
-            requested,
-            config.schema,
-            &config_path,
-            &lock_path,
-        )?;
+        let version =
+            selected_version_from_lock(tool, requested, config.schema, &config_path, &lock_path)?;
         print_declared_tool(
             &home,
             tool,
@@ -5271,14 +5263,8 @@ mod tests {
             })
         ));
 
-        let update = Cli::try_parse_from([
-            "pinset",
-            "update",
-            "node",
-            "--dry-run",
-            "--json",
-        ])
-        .expect("update");
+        let update = Cli::try_parse_from(["pinset", "update", "node", "--dry-run", "--json"])
+            .expect("update");
         assert!(matches!(
             update.command,
             Some(Commands::Update {
@@ -5289,8 +5275,8 @@ mod tests {
             }) if tool == "node"
         ));
 
-        let migrate = Cli::try_parse_from(["pinset", "migrate", "--global", "--dry-run"])
-            .expect("migrate");
+        let migrate =
+            Cli::try_parse_from(["pinset", "migrate", "--global", "--dry-run"]).expect("migrate");
         assert!(matches!(
             migrate.command,
             Some(Commands::Migrate {

--- a/crates/pinset/tests/mvp_cli.rs
+++ b/crates/pinset/tests/mvp_cli.rs
@@ -77,8 +77,7 @@ fn current_keeps_requested_selector_separate_from_locked_version() {
         "stderr: {}",
         String::from_utf8_lossy(&current.stderr)
     );
-    let report: serde_json::Value =
-        serde_json::from_slice(&current.stdout).expect("current JSON");
+    let report: serde_json::Value = serde_json::from_slice(&current.stdout).expect("current JSON");
     assert_eq!(report["data"]["requested"], "24");
     assert_eq!(report["data"]["version"], "24.0.0");
 
@@ -685,11 +684,7 @@ fn migrate_previews_and_upgrades_schema_two_without_resolving_versions() {
     fs::create_dir(&project).expect("project");
     let config_path = project.join("pinset.toml");
     let lock_path = project.join("pinset.lock");
-    fs::write(
-        &config_path,
-        "schema = 2\n\n[tools]\nnode = \"24.0.0\"\n",
-    )
-    .expect("legacy config");
+    fs::write(&config_path, "schema = 2\n\n[tools]\nnode = \"24.0.0\"\n").expect("legacy config");
     let artifacts = MVP_NODE_TARGETS
         .into_iter()
         .map(|target| locked_artifact("24.0.0", target))
@@ -715,9 +710,11 @@ fn migrate_previews_and_upgrades_schema_two_without_resolving_versions() {
     assert_eq!(preview["data"]["from_config_schema"], 2);
     assert_eq!(preview["data"]["from_lock_schema"], 2);
     assert_eq!(preview["data"]["to_schema"], 3);
-    assert!(fs::read_to_string(&config_path)
-        .expect("unchanged config")
-        .starts_with("schema = 2"));
+    assert!(
+        fs::read_to_string(&config_path)
+            .expect("unchanged config")
+            .starts_with("schema = 2")
+    );
 
     let migrated = pinset(&project, &home, &["migrate"]);
     assert!(
@@ -728,9 +725,11 @@ fn migrate_previews_and_upgrades_schema_two_without_resolving_versions() {
     let config = fs::read_to_string(config_path).expect("migrated config");
     assert!(config.starts_with("schema = 3"));
     assert!(config.contains("inherit-global = false"));
-    assert!(fs::read_to_string(lock_path)
-        .expect("migrated lock")
-        .starts_with("schema = 3"));
+    assert!(
+        fs::read_to_string(lock_path)
+            .expect("migrated lock")
+            .starts_with("schema = 3")
+    );
 }
 
 fn write_project(project: &Path, configured_version: &str, locked_version: &str) {


### PR DESCRIPTION
## Summary
- apply the exact formatting diff reported by the failed v1.5.0 release validation
- no behavior or dependency changes

## Validation
- git diff --check
- full validation remains in GitHub Actions per repository policy