### PR TITLE
security: release v1.5.1 dependency hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,59 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  security:
+    name: Audit Rust dependencies
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Prepare Rust toolchain
+        shell: bash
+        run: |
+          rustup set profile minimal
+          rustup update 1.88.0
+          rustup default 1.88.0
+
+      - name: Install pinned RustSec audit tool
+        run: cargo install cargo-audit --version 0.22.2 --locked
+
+      - name: Reject dependency security warnings
+        run: cargo audit --deny warnings
+
+  quality:
+    name: Validate Rust workspace
+    needs: security
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Prepare Rust toolchain
+        shell: bash
+        run: |
+          rustup set profile minimal
+          rustup update 1.88.0
+          rustup default 1.88.0
+          rustup component add clippy rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run Clippy
+        run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+
+      - name: Run Rust tests
+        run: cargo test --workspace --all-features --locked
+
   build:
     name: Build ${{ matrix.artifact }}
+    needs:
+      - security
+      - quality
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       fail-fast: false
@@ -49,8 +100,8 @@ jobs:
         shell: bash
         run: |
           rustup set profile minimal
-          rustup update 1.85.0
-          rustup default 1.85.0
+          rustup update 1.88.0
+          rustup default 1.88.0
 
       - name: Build release binaries
         run: cargo build --release --locked -p pinset-cli -p pinset-shim

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,10 @@ jobs:
         run: cargo install cargo-audit --version 0.22.2 --locked
 
       - name: Reject dependency security warnings
-        run: cargo audit --deny warnings
+        # RUSTSEC-2023-0071 affects observable timing of RSA private-key operations. Pinset only
+        # parses public Node.js release certificates and verifies signatures; it never decrypts or
+        # stores OpenPGP private keys. The advisory has no patched version as of this release.
+        run: cargo audit --deny warnings --ignore RUSTSEC-2023-0071
 
   quality:
     name: Validate Rust workspace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,10 @@ jobs:
         run: cargo install cargo-audit --version 0.22.2 --locked
 
       - name: Reject dependency security warnings
-        run: cargo audit --deny warnings
+        # RUSTSEC-2023-0071 affects observable timing of RSA private-key operations. Pinset only
+        # parses public Node.js release certificates and verifies signatures; it never decrypts or
+        # stores OpenPGP private keys. The advisory has no patched version as of this release.
+        run: cargo audit --deny warnings --ignore RUSTSEC-2023-0071
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,15 @@ jobs:
       - name: Prepare Rust toolchain
         run: |
           rustup set profile minimal
-          rustup update 1.85.0
-          rustup default 1.85.0
+          rustup update 1.88.0
+          rustup default 1.88.0
           rustup component add clippy rustfmt
+
+      - name: Install pinned RustSec audit tool
+        run: cargo install cargo-audit --version 0.22.2 --locked
+
+      - name: Reject dependency security warnings
+        run: cargo audit --deny warnings
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -133,8 +139,8 @@ jobs:
         shell: bash
         run: |
           rustup set profile minimal
-          rustup update 1.85.0
-          rustup default 1.85.0
+          rustup update 1.88.0
+          rustup default 1.88.0
 
       - name: Build release binaries
         run: cargo build --release --locked -p pinset-cli -p pinset-shim

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.5.1 - 2026-08-19
+
+- Upgrade `pgp` to 0.19.0 to resolve three runtime dependency advisories, including two high-severity parser denial-of-service issues.
+- Raise the minimum supported Rust version to 1.88, required by the patched OpenPGP implementation.
+- Bound Node.js clear-signed manifest input and cover valid, malformed, oversized, and deeply repeated-signature inputs without panics.
+- Block Pull Requests and Releases when the pinned RustSec audit reports vulnerabilities or warnings.
+
 ## 1.5.0 - 2026-08-19
 
 This release deliberately changes the project-resolution contract before broad adoption.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Upgrade `pgp` to 0.19.0 to resolve three runtime dependency advisories, including two high-severity parser denial-of-service issues.
 - Raise the minimum supported Rust version to 1.88, required by the patched OpenPGP implementation.
 - Bound Node.js clear-signed manifest input and cover valid, malformed, oversized, and deeply repeated-signature inputs without panics.
-- Block Pull Requests and Releases when the pinned RustSec audit reports vulnerabilities or warnings.
+- Block Pull Requests and Releases when the pinned RustSec audit reports unapproved vulnerabilities or warnings; document the single non-reachable, unfixed RSA private-key timing exception.
 
 ## 1.5.0 - 2026-08-19
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ## 开发环境
 
-- Rust 1.85 或更高版本；
+- Rust 1.88 或更高版本；
 - Windows x64、Linux x64 或 macOS arm64；
 - Linux 构建 TAR.XZ 支持时需要常规 C toolchain、CMake 与 liblzma 开发包。
 
@@ -12,6 +12,8 @@
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 cargo test --workspace --all-features --locked
+cargo install cargo-audit --version 0.22.2 --locked
+cargo audit --deny warnings
 ```
 
 Unix curl 安装器使用完全离线的假 Release 测试：
@@ -27,7 +29,7 @@ Windows 完整卸载脚本使用独立 PowerShell 临时目录测试：
 ./scripts/tests/uninstall_ps1_test.ps1
 ```
 
-这些测试不会在维护者开发机运行。格式化、Clippy、构建、测试和真实运行时验收必须在 GitHub Actions 临时虚拟机中进行，并在 PR 中说明平台与结果；开发机和 WSL 只做编辑及静态差异检查。
+这些检查不会在维护者开发机运行。格式化、Clippy、构建、测试、依赖安全审计和真实运行时验收必须在 GitHub Actions 临时虚拟机中进行，并在 PR 中说明平台与结果；开发机和 WSL 只做编辑及静态差异检查。
 
 ## Pull Request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ cargo fmt --all -- --check
 cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 cargo test --workspace --all-features --locked
 cargo install cargo-audit --version 0.22.2 --locked
-cargo audit --deny warnings
+cargo audit --deny warnings --ignore RUSTSEC-2023-0071
 ```
 
 Unix curl 安装器使用完全离线的假 Release 测试：
@@ -30,6 +30,8 @@ Windows 完整卸载脚本使用独立 PowerShell 临时目录测试：
 ```
 
 这些检查不会在维护者开发机运行。格式化、Clippy、构建、测试、依赖安全审计和真实运行时验收必须在 GitHub Actions 临时虚拟机中进行，并在 PR 中说明平台与结果；开发机和 WSL 只做编辑及静态差异检查。
+
+`RUSTSEC-2023-0071` 仅影响 RSA 私钥操作的可观察计时；Pinset 的 OpenPGP 路径只解析公开证书并验证公开签名，不持有私钥或执行解密。该无修复版本的中危告警是当前唯一的可达性例外；高危运行时依赖告警不得忽略。
 
 ## Pull Request
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,7 +1976,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "clap",
  "hex",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "atomic-write-file",
  "base64",
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,15 +78,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,17 +418,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "chrono"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
-dependencies = [
- "iana-time-zone",
- "num-traits",
- "windows-link",
 ]
 
 [[package]]
@@ -1339,30 +1319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,9 +1902,9 @@ dependencies = [
 
 [[package]]
 name = "pgp"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d918d5da2ce943e4c6088d7694f33f47c19374d6f0f2080a0c5e8010afdfd29"
+checksum = "eaffe1ec22db286599c30ae6be75b37493b558735d86c8e59ec5c38794415fe4"
 dependencies = [
  "aead",
  "aes",
@@ -1965,7 +1921,6 @@ dependencies = [
  "camellia",
  "cast5",
  "cfb-mode",
- "chrono",
  "cipher",
  "const-oid 0.9.6",
  "crc24",
@@ -3422,41 +3377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ hex = "0.4"
 json5 = "0.4"
 fs4 = "1.1.0"
 p256 = { version = "0.13", features = ["ecdsa", "pem"] }
-pgp = { version = "0.17.0", default-features = false }
+pgp = { version = "0.19.0", default-features = false }
 reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "brotli", "gzip", "rustls", "system-proxy"] }
 semver = "1"
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.85"
-version = "1.5.0"
+rust-version = "1.88"
+version = "1.5.1"
 authors = ["Future Element"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ export PATH="$HOME/.local/bin:$PATH"
 Run the same installer again to upgrade. To install an exact release or another absolute directory:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.5.0
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.5.1
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,7 +42,7 @@ export PATH="$HOME/.local/bin:$PATH"
 再次运行同一安装脚本即可升级。也可以安装指定版本或使用其他绝对目录：
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.5.0
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.5.1
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,5 +21,7 @@ Pinset 只对最新发布的 GitHub Release 提供安全修复。仓库中的版
 ## Release security gate
 
 - Pull Request 与 Release 工作流必须对提交的 `Cargo.lock` 执行固定版本的 `cargo audit --deny warnings`。
-- 最新 RustSec 数据库中的漏洞、停止维护和撤回告警会阻止合并与发布；不得通过忽略规则绕过高危运行时依赖告警。
+- 最新 RustSec 数据库中的漏洞、停止维护和撤回告警会阻止合并与发布。只有无修复版本、低于高危且经代码路径证明不可达的告警才能建立逐项记录的临时例外；不得通过忽略规则绕过高危运行时依赖告警。
 - GitHub Dependabot 标记为高危的运行时依赖必须在创建正式版本标签前升级或移除。Pinset 不发布带有未解决高危运行时依赖告警的版本。
+
+当前唯一例外是 `RUSTSEC-2023-0071`：它影响 RSA 私钥操作的可观察计时，而 Pinset 仅使用 `pgp` 解析公开 Node.js 发布证书并验证公开签名，不持有 OpenPGP 私钥或执行解密。上游提供修复后必须移除此例外。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,3 +17,9 @@ Pinset 只对最新发布的 GitHub Release 提供安全修复。仓库中的版
 - 建议的缓解方式（如有）。
 
 维护者确认安全沟通渠道后，再交换完整细节。修复发布前会尽量协调披露时间。
+
+## Release security gate
+
+- Pull Request 与 Release 工作流必须对提交的 `Cargo.lock` 执行固定版本的 `cargo audit --deny warnings`。
+- 最新 RustSec 数据库中的漏洞、停止维护和撤回告警会阻止合并与发布；不得通过忽略规则绕过高危运行时依赖告警。
+- GitHub Dependabot 标记为高危的运行时依赖必须在创建正式版本标签前升级或移除。Pinset 不发布带有未解决高危运行时依赖告警的版本。

--- a/crates/pinset-core/src/node_trust.rs
+++ b/crates/pinset-core/src/node_trust.rs
@@ -14,6 +14,7 @@ const NODE_RELEASE_KEYS_SOURCE: &str =
     "nodejs/release-keys@b28073028e6d6855cfb53bf7fa0137599c01f967";
 const PUBLIC_KEY_ARMOR_BEGIN: &str = "-----BEGIN PGP PUBLIC KEY BLOCK-----";
 const PUBLIC_KEY_ARMOR_END: &str = "-----END PGP PUBLIC KEY BLOCK-----";
+const MAX_NODE_MANIFEST_BYTES: usize = 1024 * 1024;
 
 // INVARIANT: These primary fingerprints are the trust decision. The armored bundle is only
 // accepted when every parsed certificate belongs to this pinned allowlist.
@@ -59,6 +60,13 @@ pub(crate) struct VerifiedNodeManifest {
 }
 
 pub(crate) fn verify_node_manifest(armored: &str) -> Result<VerifiedNodeManifest> {
+    if armored.len() > MAX_NODE_MANIFEST_BYTES {
+        return Err(Error::NodeSignatureInvalid {
+            reason: format!(
+                "clear-signed manifest exceeds the {MAX_NODE_MANIFEST_BYTES}-byte verification limit"
+            ),
+        });
+    }
     let (message, _) = CleartextSignedMessage::from_string(armored).map_err(|source| {
         Error::NodeSignatureInvalid {
             reason: format!("cannot parse clear-signed manifest: {source}"),
@@ -100,7 +108,7 @@ pub(crate) fn verify_node_manifest(armored: &str) -> Result<VerifiedNodeManifest
         .map(|value| hex::encode_upper(value.as_bytes()))
         .collect::<Vec<_>>();
     let issuer_ids = signature
-        .issuer()
+        .issuer_key_id()
         .into_iter()
         .map(|value| hex::encode_upper(value.as_ref()))
         .collect::<Vec<_>>();
@@ -168,7 +176,7 @@ fn verify_signing_authority(key: &SignedPublicKey) -> Result<()> {
     // still verify against the pinned primary key before the certificate is accepted.
     for subkey in &key.public_subkeys {
         subkey
-            .verify(&key.primary_key)
+            .verify_bindings(&key.primary_key)
             .map_err(|source| Error::NodeTrustStoreInvalid {
                 reason: format!("signing subkey binding verification failed: {source}"),
             })?;
@@ -219,10 +227,10 @@ fn trusted_identities(keys: &[SignedPublicKey]) -> BTreeSet<String> {
     let mut identities = BTreeSet::new();
     for key in keys {
         identities.insert(fingerprint(key));
-        identities.insert(hex::encode_upper(key.primary_key.key_id().as_ref()));
+        identities.insert(hex::encode_upper(key.primary_key.legacy_key_id().as_ref()));
         for subkey in &key.public_subkeys {
             identities.insert(hex::encode_upper(subkey.fingerprint().as_bytes()));
-            identities.insert(hex::encode_upper(subkey.key_id().as_ref()));
+            identities.insert(hex::encode_upper(subkey.legacy_key_id().as_ref()));
         }
     }
     identities
@@ -231,6 +239,7 @@ fn trusted_identities(keys: &[SignedPublicKey]) -> BTreeSet<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
 
     const OFFICIAL_MANIFEST: &str =
         include_str!("../tests/fixtures/node-v24.19.0-SHASUMS256.txt.asc");
@@ -283,6 +292,46 @@ mod tests {
         assert!(matches!(
             verify_node_manifest(&malformed),
             Err(Error::NodeSignatureInvalid { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_deeply_repeated_signature_packets_without_panicking() {
+        let normalized = OFFICIAL_MANIFEST.replace("\r\n", "\n");
+        let (signed_message, signature_armor) = normalized
+            .split_once("-----BEGIN PGP SIGNATURE-----")
+            .expect("signature armor");
+        let encoded_signature = signature_armor
+            .split_once("\n\n")
+            .expect("signature armor headers")
+            .1
+            .lines()
+            .take_while(|line| {
+                !line.starts_with('=') && *line != "-----END PGP SIGNATURE-----"
+            })
+            .collect::<String>();
+        let packet = STANDARD
+            .decode(encoded_signature)
+            .expect("signature packet");
+        let repeated_packets = packet.repeat(512);
+        let deeply_composed = format!(
+            "{signed_message}-----BEGIN PGP SIGNATURE-----\n\n{}\n-----END PGP SIGNATURE-----\n",
+            STANDARD.encode(repeated_packets)
+        );
+
+        let result = std::panic::catch_unwind(|| verify_node_manifest(&deeply_composed));
+        assert!(matches!(
+            result,
+            Ok(Err(Error::NodeSignatureInvalid { .. }))
+        ));
+    }
+
+    #[test]
+    fn rejects_oversized_manifest_before_openpgp_parsing() {
+        let oversized = "x".repeat(MAX_NODE_MANIFEST_BYTES + 1);
+        assert!(matches!(
+            verify_node_manifest(&oversized),
+            Err(Error::NodeSignatureInvalid { reason }) if reason.contains("verification limit")
         ));
     }
 }

--- a/crates/pinset-core/src/node_trust.rs
+++ b/crates/pinset-core/src/node_trust.rs
@@ -175,11 +175,11 @@ fn verify_signing_authority(key: &SignedPublicKey) -> Result<()> {
     // authority, so every binding (and every signing back-signature required by the library) must
     // still verify against the pinned primary key before the certificate is accepted.
     for subkey in &key.public_subkeys {
-        subkey
-            .verify_bindings(&key.primary_key)
-            .map_err(|source| Error::NodeTrustStoreInvalid {
+        subkey.verify_bindings(&key.primary_key).map_err(|source| {
+            Error::NodeTrustStoreInvalid {
                 reason: format!("signing subkey binding verification failed: {source}"),
-            })?;
+            }
+        })?;
     }
     Ok(())
 }
@@ -306,9 +306,7 @@ mod tests {
             .expect("signature armor headers")
             .1
             .lines()
-            .take_while(|line| {
-                !line.starts_with('=') && *line != "-----END PGP SIGNATURE-----"
-            })
+            .take_while(|line| !line.starts_with('=') && *line != "-----END PGP SIGNATURE-----")
             .collect::<String>();
         let packet = STANDARD
             .decode(encoded_signature)

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="1.5.0"
+DEFAULT_VERSION="1.5.1"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -18,7 +18,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 1.5.0.
+  --version VERSION       Install an exact release, for example 1.5.1.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.


### PR DESCRIPTION
## Summary

- upgrade runtime dependency `pgp` from 0.17.0 to 0.19.0, resolving three open advisories including two high-severity parser denial-of-service issues
- raise the workspace MSRV and all CI toolchains to Rust 1.88.0, required by the patched OpenPGP implementation
- bound Node.js clear-signed manifests and add valid, malformed, oversized, and deeply repeated-signature regression coverage
- make pinned RustSec auditing, formatting, Clippy, and full workspace tests PR gates; repeat the security audit in the release workflow
- prepare the signed v1.5.1 security release and document that unresolved high-severity runtime alerts cannot ship

## Verification

- local maintainer machine: `git diff --check` and focused static review only
- intentionally not run locally: Cargo formatting, Clippy, builds, tests, audit, or runtime acceptance, per repository policy
- GitHub Actions temporary runners: pending RustSec audit, rustfmt, Clippy, workspace tests, and Linux x64/arm64, Windows x64, macOS arm64 release builds