### PR TITLE
feat: release v1.6.0 lock audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.6.0 - 2026-08-20
+
+- Add `pinset lock audit` for project or global scope. It is always read-only and offline, checks config/lock consistency, current-platform artifacts, referenced cache bytes, install receipts, receipt-backed ownership, and project Python environment ownership.
+- Add a stable audit finding contract with snake_case reason codes, severity/category/subject/path context, explicit repair plans, and JSON schema 1 command identity `lock.audit`.
+- Reserve exit code `1` for a completed audit that found action-required errors or warnings; clean audits and informational-only optional cache misses return `0`, while command failures remain `2`.
+- Consolidate command layout, metadata, installation, environment, traditional discovery, and lock-audit behavior into one capability model shared by all nine built-in Providers.
+- Add cross-platform CLI and core regression coverage for read-only behavior, matching/missing receipts, optional cache state, JSON output, exit semantics, Provider capability coverage, completions, and parser options.
+
+No configuration or lock schema migration is required. v1.6 continues to write schema 3 and read schema 1/2; `lock audit` reports legacy state and repair plans without changing it.
+
 ## 1.5.1 - 2026-08-19
 
 - Upgrade `pgp` to 0.19.0 to resolve three runtime dependency advisories, including two high-severity parser denial-of-service issues.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,7 +1976,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "clap",
  "hex",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "atomic-write-file",
  "base64",
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "1.5.1"
+version = "1.6.0"
 authors = ["Future Element"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It manages Node.js, pnpm, Bun, Go, Python, Java, Rust, .NET, and Flutter/Dart th
 - First-class English and Simplified Chinese output, JSON schema 1 for automation, and shell completion.
 - Project-owned Python `.venv` support without requiring shell activation.
 - Read-only detection and explicit import of repository-local traditional version files.
+- Read-only, offline lock auditing with stable reason codes and repair plans that never run automatically.
 
 ## Install and upgrade
 
@@ -42,7 +43,7 @@ export PATH="$HOME/.local/bin:$PATH"
 Run the same installer again to upgrade. To install an exact release or another absolute directory:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.5.1
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.6.0
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -126,6 +127,7 @@ pinset use node@22
 pinset use pnpm@10
 pinset use python@3.14
 pinset install --locked
+pinset lock audit
 pinset exec -- node --version
 ```
 
@@ -151,6 +153,15 @@ pinset import
 
 `detect` never uses the network or writes files. `import --no-install` writes the Pinset config and exact lock without downloading runtimes. Pinset scans from the working directory to the nearest Git repository root and does not modify or delete the source files.
 
+Audit the selected state before CI, packaging, or an offline handoff:
+
+```sh
+pinset lock audit --json
+pinset lock audit --global
+```
+
+`lock audit` is always read-only and offline. It checks configuration/lock consistency, the current platform artifact, referenced cache bytes when present, install receipts, and receipt-backed ownership. It returns `0` when no action is required, `1` when the completed audit contains errors or warnings, and `2` only when the command itself cannot run. Findings include stable snake_case `reason_code` values and repair plans; Pinset never executes those plans automatically.
+
 Discover available and installed versions:
 
 ```sh
@@ -175,11 +186,17 @@ pinset list
 
 Flutter does not publish an official Linux ARM64 SDK archive that matches Pinset's install model, so Pinset returns an explicit unsupported-target error instead of falling back to x64. macOS Intel is not a Pinset v1.0 release target.
 
+All nine built-in Providers declare command layout, metadata resolution, installation, environment, traditional-file discovery, and lock-audit support through one capability model. Resolver, installer, discovery, routing, and audit code consume that shared declaration instead of maintaining separate Provider lists.
+
 ## Command reference
 
 See the complete [English command reference](docs/commands.md) or [Chinese command reference](docs/commands.zh-CN.md). It documents every command and subcommand, state changes, JSON support, exit codes, and common failures.
 
-For product positioning and trade-offs, see the sourced [Pinset v1.5 comparison (Chinese)](docs/comparison.zh-CN.md).
+For product positioning and trade-offs, see the sourced [Pinset comparison (Chinese)](docs/comparison.zh-CN.md).
+
+## v1.6
+
+v1.6 delivers the first lock-audit and security-foundation release: the offline/read-only `pinset lock audit`, stable automation reason codes, explicit repair plans, and one capability model covering all nine built-in Providers. It deliberately reports state drift without changing it; provenance policy and automatic remediation remain outside this release.
 
 ## Future Roadmap
 
@@ -187,7 +204,6 @@ The roadmap describes direction, not promised versions or dates.
 
 | Version | Theme | Planned work |
 | --- | --- | --- |
-| v1.6 | Lock auditing and security foundations | Add a read-only, offline-by-default `pinset lock audit` that checks configuration, locks, platform artifacts, caches, install receipts, and ownership state; expose stable reason codes for automation; and define one capability model for all nine built-in Providers. The first release will report issues and repair plans without changing state automatically. |
 | v1.7 | General provenance verification | Move the existing Node.js OpenPGP verification behind a common verifier interface, then add signed checksums, Minisign, Sigstore, GitHub Attestations, and SLSA provenance where upstreams actually provide them. Add optional verification-strength and `minimum-release-age` policies, and reject silent verification downgrades. |
 | v1.8 | Constrained Provider Registry | Preview declarative Provider manifests and a signed Registry. Third-party Providers must reuse Pinset's HTTPS, integrity, safe extraction, path, and ownership rules and cannot run arbitrary Shell/Lua or post-install scripts. Add toolchain dependency graphs, a composite `PATH`, and cycle detection so tools such as pnpm run with the correct runtime. |
 | v1.9 | Developer experience and distribution | Add `pinset x <tool>@<selector> -- <command>` for verified one-shot execution without modifying project state. Provide a GitHub Action, Renovate integration, VS Code schemas, Dev Container examples, and official Winget, Scoop, and Homebrew distribution. |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,6 +22,7 @@ Pinset 是一个行为可预测、理解项目边界的多语言运行时版本�
 - 原生支持英文和简体中文输出、自动化用 JSON schema 1 与 Shell 补全。
 - 支持项目所有的 Python `.venv`，无需激活 Shell 环境。
 - 支持只读检测和显式导入仓库内的传统版本配置。
+- 支持带稳定 reason code 的只读离线锁审计；修复计划只报告、不自动执行。
 
 ## 安装与升级
 
@@ -42,7 +43,7 @@ export PATH="$HOME/.local/bin:$PATH"
 再次运行同一安装脚本即可升级。也可以安装指定版本或使用其他绝对目录：
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.5.1
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.6.0
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -126,6 +127,7 @@ pinset use node@22
 pinset use pnpm@10
 pinset use python@3.14
 pinset install --locked
+pinset lock audit
 pinset exec -- node --version
 ```
 
@@ -151,6 +153,15 @@ pinset import
 
 `detect` 不联网、也不写文件。`import --no-install` 会写入 Pinset 配置和精确锁，但不下载运行时。扫描范围从工作目录到最近的 Git 仓库根目录，并且不会修改或删除来源文件。
 
+在 CI、制品打包或离线交接前审计当前选择状态：
+
+```sh
+pinset lock audit --json
+pinset lock audit --global
+```
+
+`lock audit` 始终只读、离线运行。它检查配置与锁是否一致、当前平台制品、存在时的相关缓存字节、安装收据及由收据证明的所有权。无需处理时返回 `0`；审计正常完成但包含错误或警告时返回 `1`；只有命令本身无法运行时才返回 `2`。每条发现都包含稳定的 snake_case `reason_code` 与修复计划，Pinset 不会自动执行修复计划。
+
 查看可用版本与已安装版本：
 
 ```sh
@@ -175,11 +186,17 @@ pinset list
 
 Flutter 没有发布符合 Pinset 安装模型的官方 Linux ARM64 SDK 归档，因此 Pinset 会返回明确的不支持目标错误，不会回退到 x64。macOS Intel 不是 Pinset v1.0 的发布目标。
 
+9 个内置 Provider 都通过同一 capability model 声明命令布局、元数据解析、安装、环境、传统文件发现与锁审计支持。解析器、安装器、发现、路由与审计逻辑共同消费这份声明，不再分别维护 Provider 列表。
+
 ## 命令文档
 
 请查阅完整的[中文命令文档](docs/commands.zh-CN.md)或[英文命令文档](docs/commands.md)。其中记录了每个命令及二级命令、状态修改、JSON 支持、退出码与常见错误。
 
-产品定位与取舍见带官方来源的 [Pinset v1.5 横向对比](docs/comparison.zh-CN.md)。
+产品定位与取舍见带官方来源的 [Pinset 横向对比](docs/comparison.zh-CN.md)。
+
+## v1.6
+
+v1.6 交付第一阶段锁审计与安全基础：离线/只读的 `pinset lock audit`、稳定的自动化 reason code、明确但不自动执行的修复计划，以及覆盖全部 9 个内置 Provider 的统一 capability model。来源证明策略与自动修复不属于本版本范围。
 
 ## 未来规划
 
@@ -187,7 +204,6 @@ Flutter 没有发布符合 Pinset 安装模型的官方 Linux ARM64 SDK 归档�
 
 | 版本 | 主题 | 计划内容 |
 | --- | --- | --- |
-| v1.6 | 锁审计与安全策略基础 | 增加只读、默认离线的 `pinset lock audit`，检查配置、锁、平台制品、缓存、安装收据与所有权状态；为自动化提供稳定 reason code；建立 9 个内置 Provider 的统一 capability model。首版只报告问题与修复计划，不自动修改状态。 |
 | v1.7 | 通用来源证明 | 把 Node.js 已有的 OpenPGP 验证迁移到统一验证接口，并按上游实际能力逐步支持 signed checksum、Minisign、Sigstore、GitHub Attestation 与 SLSA provenance；增加可选的验证强度和 `minimum-release-age` 策略，禁止静默降低验证能力。 |
 | v1.8 | 受约束的 Provider Registry | 预览纯声明式 Provider manifest 与签名 Registry；第三方 Provider 必须复用 Pinset 的 HTTPS、完整性、安全解压、路径和所有权规则，不能执行任意 Shell/Lua 或 post-install 脚本；增加工具链依赖图、composite `PATH` 与循环检测，支持 pnpm 等工具与正确运行时组合。 |
 | v1.9 | 开发者体验与正式分发 | 增加不修改项目状态的 `pinset x <tool>@<selector> -- <command>`；补齐 GitHub Action、Renovate、VS Code schema、Dev Container 示例，以及 Winget、Scoop、Homebrew 等官方分发渠道。 |

--- a/crates/pinset-core/src/download_cache.rs
+++ b/crates/pinset-core/src/download_cache.rs
@@ -130,6 +130,48 @@ pub fn verify_download_cache(pinset_home: &Path) -> Result<DownloadCacheVerifica
     Ok(verification)
 }
 
+pub(crate) fn verify_download_cache_integrity(
+    pinset_home: &Path,
+    integrity: &ArtifactIntegrity,
+) -> Result<Option<DownloadCacheVerificationEntry>> {
+    let mut directory = pinset_home.to_path_buf();
+    for segment in [CACHE_DIRECTORY, integrity.algorithm().as_str()] {
+        directory.push(segment);
+        let metadata = match fs::symlink_metadata(&directory) {
+            Ok(metadata) => metadata,
+            Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => {
+                return Err(Error::ReadDownloadCache {
+                    path: directory,
+                    source,
+                });
+            }
+        };
+        if !metadata.file_type().is_dir() || metadata.file_type().is_symlink() {
+            return Err(Error::UnsafeDownloadCacheEntry { path: directory });
+        }
+    }
+    let path = download_cache_path_for_integrity(pinset_home, integrity)?;
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(Error::ReadDownloadCache { path, source }),
+    };
+    if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+        return Err(Error::UnsafeDownloadCacheEntry { path });
+    }
+    let expected = integrity.canonical();
+    let (actual, size) = hash_file(&path, integrity)?;
+    let valid = actual == expected;
+    Ok(Some(DownloadCacheVerificationEntry {
+        integrity: expected,
+        actual,
+        size,
+        path,
+        valid,
+    }))
+}
+
 pub fn repair_download_cache(pinset_home: &Path) -> Result<DownloadCacheCleanOutcome> {
     let verification = verify_download_cache(pinset_home)?;
     let mut outcome = DownloadCacheCleanOutcome {

--- a/crates/pinset-core/src/lib.rs
+++ b/crates/pinset-core/src/lib.rs
@@ -39,6 +39,8 @@ mod java_metadata;
 mod java_provider;
 #[cfg(all(feature = "installer", feature = "java-provider", feature = "lockfile"))]
 mod java_runtime;
+#[cfg(all(feature = "installer", feature = "lockfile"))]
+mod lock_audit;
 #[cfg(feature = "lockfile")]
 mod lockfile;
 #[cfg(feature = "node-provider")]
@@ -159,6 +161,11 @@ pub use java_provider::{
 };
 #[cfg(all(feature = "installer", feature = "java-provider", feature = "lockfile"))]
 pub use java_runtime::install_locked_java;
+#[cfg(all(feature = "installer", feature = "lockfile"))]
+pub use lock_audit::{
+    LockAuditCategory, LockAuditFinding, LockAuditReasonCode, LockAuditRepair, LockAuditReport,
+    LockAuditScope, LockAuditSeverity, LockAuditSummary, audit_global_lock, audit_project_lock,
+};
 #[cfg(feature = "lockfile")]
 pub use lockfile::{
     LOCKFILE_FILENAME, LOCKFILE_SCHEMA, LockedArtifact, LockedArtifactFormat,
@@ -226,8 +233,8 @@ pub use runtime_lifecycle::{
 };
 pub use runtime_provider::{
     RuntimeCommandLayout, RuntimeDiscoveryKind, RuntimeDiscoveryRule, RuntimeEnvironmentKind,
-    RuntimeInstallKind, RuntimeMetadataKind, RuntimeProvider, runtime_provider,
-    runtime_provider_for_command, runtime_providers,
+    RuntimeInstallKind, RuntimeLockAuditKind, RuntimeMetadataKind, RuntimeProvider,
+    RuntimeProviderCapabilities, runtime_provider, runtime_provider_for_command, runtime_providers,
 };
 #[cfg(feature = "rust-metadata")]
 pub use rust_metadata::{RustMetadataClient, RustRelease};

--- a/crates/pinset-core/src/lock_audit.rs
+++ b/crates/pinset-core/src/lock_audit.rs
@@ -770,10 +770,7 @@ fn audit_install_receipt(
             LockAuditCategory::InstallReceipt,
             subject,
             Some(&receipt_path),
-            format!(
-                "the ownership receipt exceeds the {} byte audit limit",
-                MAX_AUDIT_RECEIPT_BYTES
-            ),
+            format!("the ownership receipt exceeds the {MAX_AUDIT_RECEIPT_BYTES} byte audit limit"),
             Some(repair(
                 "review the oversized receipt before replacing the installation",
                 None,

--- a/crates/pinset-core/src/lock_audit.rs
+++ b/crates/pinset-core/src/lock_audit.rs
@@ -1,0 +1,1286 @@
+//! Read-only, offline auditing for selected configuration and lock state.
+//!
+//! The audit deliberately treats configuration, lock, cache, receipt, and ownership
+//! problems as report findings instead of mutating state or contacting a Provider.
+
+use std::{
+    collections::BTreeMap,
+    fs,
+    io::ErrorKind,
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ArtifactIntegrity, Error, GLOBAL_STATE_SCHEMA, LOCKFILE_SCHEMA, LockedArtifact, Lockfile,
+    PROJECT_CONFIG_FILENAME, PROJECT_CONFIG_SCHEMA, RuntimeLockAuditKind, current_target_for_tool,
+    download_cache::verify_download_cache_integrity, find_optional_project_config,
+    global_config_path, global_lockfile_path, load_global_config, load_lockfile,
+    load_project_config, load_project_python_environment, lockfile_path, runtime_provider,
+};
+
+const MAX_AUDIT_RECEIPT_BYTES: u64 = 64 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LockAuditScope {
+    Project,
+    Global,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LockAuditSeverity {
+    Error,
+    Warning,
+    Info,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LockAuditCategory {
+    Configuration,
+    Lock,
+    PlatformArtifact,
+    Cache,
+    InstallReceipt,
+    Ownership,
+}
+
+/// Stable identifiers intended for scripts and policy checks. Messages and repair text are
+/// human-facing and may be refined without changing these values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LockAuditReasonCode {
+    ConfigMissing,
+    ConfigInvalid,
+    ConfigSchemaLegacy,
+    LockMissing,
+    LockInvalid,
+    LockSchemaLegacy,
+    LockToolMissing,
+    LockToolUnconfigured,
+    LockSelectorMismatch,
+    ProviderUnsupported,
+    ProviderAuditUnsupported,
+    PlatformArtifactMissing,
+    PlatformArtifactInvalid,
+    CacheEntryMissing,
+    CacheEntryCorrupt,
+    CacheEntryUnsafe,
+    CacheEntryUnreadable,
+    InstallMissing,
+    InstallPathUnsafe,
+    ReceiptMissing,
+    ReceiptUnreadable,
+    ReceiptInvalid,
+    ReceiptSchemaLegacy,
+    ReceiptSchemaUnsupported,
+    ReceiptIncomplete,
+    ReceiptIdentityMismatch,
+    ReceiptIntegrityMissing,
+    ReceiptIntegrityMismatch,
+    ReceiptOverlayMismatch,
+    PythonEnvironmentMissing,
+    PythonEnvironmentOwnershipInvalid,
+}
+
+impl LockAuditReasonCode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ConfigMissing => "config_missing",
+            Self::ConfigInvalid => "config_invalid",
+            Self::ConfigSchemaLegacy => "config_schema_legacy",
+            Self::LockMissing => "lock_missing",
+            Self::LockInvalid => "lock_invalid",
+            Self::LockSchemaLegacy => "lock_schema_legacy",
+            Self::LockToolMissing => "lock_tool_missing",
+            Self::LockToolUnconfigured => "lock_tool_unconfigured",
+            Self::LockSelectorMismatch => "lock_selector_mismatch",
+            Self::ProviderUnsupported => "provider_unsupported",
+            Self::ProviderAuditUnsupported => "provider_audit_unsupported",
+            Self::PlatformArtifactMissing => "platform_artifact_missing",
+            Self::PlatformArtifactInvalid => "platform_artifact_invalid",
+            Self::CacheEntryMissing => "cache_entry_missing",
+            Self::CacheEntryCorrupt => "cache_entry_corrupt",
+            Self::CacheEntryUnsafe => "cache_entry_unsafe",
+            Self::CacheEntryUnreadable => "cache_entry_unreadable",
+            Self::InstallMissing => "install_missing",
+            Self::InstallPathUnsafe => "install_path_unsafe",
+            Self::ReceiptMissing => "receipt_missing",
+            Self::ReceiptUnreadable => "receipt_unreadable",
+            Self::ReceiptInvalid => "receipt_invalid",
+            Self::ReceiptSchemaLegacy => "receipt_schema_legacy",
+            Self::ReceiptSchemaUnsupported => "receipt_schema_unsupported",
+            Self::ReceiptIncomplete => "receipt_incomplete",
+            Self::ReceiptIdentityMismatch => "receipt_identity_mismatch",
+            Self::ReceiptIntegrityMissing => "receipt_integrity_missing",
+            Self::ReceiptIntegrityMismatch => "receipt_integrity_mismatch",
+            Self::ReceiptOverlayMismatch => "receipt_overlay_mismatch",
+            Self::PythonEnvironmentMissing => "python_environment_missing",
+            Self::PythonEnvironmentOwnershipInvalid => "python_environment_ownership_invalid",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LockAuditRepair {
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LockAuditFinding {
+    pub reason_code: LockAuditReasonCode,
+    pub severity: LockAuditSeverity,
+    pub category: LockAuditCategory,
+    pub subject: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repair: Option<LockAuditRepair>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct LockAuditSummary {
+    pub tools: usize,
+    pub platform_artifacts: usize,
+    pub cache_entries: usize,
+    pub receipts: usize,
+    pub owned_installs: usize,
+    pub errors: usize,
+    pub warnings: usize,
+    pub info: usize,
+    pub action_required: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LockAuditReport {
+    pub scope: LockAuditScope,
+    pub offline: bool,
+    pub passed: bool,
+    pub config: PathBuf,
+    pub lockfile: PathBuf,
+    pub summary: LockAuditSummary,
+    pub findings: Vec<LockAuditFinding>,
+}
+
+impl LockAuditReport {
+    pub fn action_required(&self) -> bool {
+        self.summary.action_required
+    }
+
+    fn push(&mut self, finding: LockAuditFinding) {
+        match finding.severity {
+            LockAuditSeverity::Error => self.summary.errors += 1,
+            LockAuditSeverity::Warning => self.summary.warnings += 1,
+            LockAuditSeverity::Info => self.summary.info += 1,
+        }
+        self.findings.push(finding);
+    }
+
+    fn finish(&mut self) {
+        self.summary.action_required = self.summary.errors > 0 || self.summary.warnings > 0;
+        self.passed = !self.summary.action_required;
+    }
+}
+
+#[derive(Debug)]
+struct ConfigSelection {
+    schema: u32,
+    tools: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AuditInstallReceipt {
+    #[serde(default)]
+    schema: u32,
+    #[serde(default)]
+    complete: bool,
+    #[serde(default)]
+    tool: String,
+    #[serde(default)]
+    version: String,
+    #[serde(default)]
+    target: String,
+    #[serde(default)]
+    canonical_url: Option<String>,
+    #[serde(default)]
+    selected_source: Option<String>,
+    #[serde(default)]
+    selected_source_kind: Option<String>,
+    #[serde(default)]
+    selected_url: Option<String>,
+    #[serde(default)]
+    artifact_integrity: Option<String>,
+    #[serde(default)]
+    artifact_sha256: Option<String>,
+    #[serde(default)]
+    artifact_format: Option<String>,
+    #[serde(default)]
+    base_artifact_integrities: Vec<String>,
+    #[serde(default)]
+    bytes_downloaded: Option<u64>,
+}
+
+pub fn audit_project_lock(pinset_home: &Path, cwd: &Path) -> LockAuditReport {
+    let config = project_config_path_for_audit(cwd);
+    let lockfile = lockfile_path(&config);
+    audit_lock_paths(pinset_home, LockAuditScope::Project, config, lockfile)
+}
+
+pub fn audit_global_lock(pinset_home: &Path) -> LockAuditReport {
+    let config = global_config_path(pinset_home);
+    let lockfile = global_lockfile_path(pinset_home);
+    audit_lock_paths(pinset_home, LockAuditScope::Global, config, lockfile)
+}
+
+fn audit_lock_paths(
+    pinset_home: &Path,
+    scope: LockAuditScope,
+    config_path: PathBuf,
+    lock_path: PathBuf,
+) -> LockAuditReport {
+    let mut report = LockAuditReport {
+        scope,
+        offline: true,
+        passed: false,
+        config: config_path.clone(),
+        lockfile: lock_path.clone(),
+        summary: LockAuditSummary::default(),
+        findings: Vec::new(),
+    };
+
+    let config = load_config_selection(scope, &config_path, &mut report);
+    let lockfile = load_audited_lock(&lock_path, &mut report);
+    if let (Some(config), Some(lockfile)) = (&config, &lockfile) {
+        audit_config_lock_pair(
+            pinset_home,
+            scope,
+            &config_path,
+            config,
+            lockfile,
+            &mut report,
+        );
+    }
+    report.finish();
+    report
+}
+
+fn load_config_selection(
+    scope: LockAuditScope,
+    path: &Path,
+    report: &mut LockAuditReport,
+) -> Option<ConfigSelection> {
+    let result = match scope {
+        LockAuditScope::Project => load_project_config(path).map(|config| ConfigSelection {
+            schema: config.schema,
+            tools: config.tools,
+        }),
+        LockAuditScope::Global => load_global_config(path).map(|config| ConfigSelection {
+            schema: config.schema,
+            tools: config.tools,
+        }),
+    };
+    match result {
+        Ok(config) => {
+            let expected_schema = match scope {
+                LockAuditScope::Project => PROJECT_CONFIG_SCHEMA,
+                LockAuditScope::Global => GLOBAL_STATE_SCHEMA,
+            };
+            if config.schema < expected_schema {
+                report.push(finding(
+                    LockAuditReasonCode::ConfigSchemaLegacy,
+                    LockAuditSeverity::Warning,
+                    LockAuditCategory::Configuration,
+                    "configuration",
+                    Some(path),
+                    format!(
+                        "configuration schema {} remains readable but should be migrated to schema {}",
+                        config.schema, expected_schema
+                    ),
+                    Some(repair(
+                        "migrate the configuration and lock pair",
+                        Some(migrate_command(scope, path)),
+                    )),
+                ));
+            }
+            Some(config)
+        }
+        Err(error) if config_missing(&error) => {
+            report.push(finding(
+                LockAuditReasonCode::ConfigMissing,
+                LockAuditSeverity::Error,
+                LockAuditCategory::Configuration,
+                "configuration",
+                Some(path),
+                error.to_string(),
+                Some(repair(
+                    match scope {
+                        LockAuditScope::Project => "create a project configuration",
+                        LockAuditScope::Global => "select a global runtime",
+                    },
+                    Some(match scope {
+                        LockAuditScope::Project => "pinset init".to_owned(),
+                        LockAuditScope::Global => "pinset global <tool>@<selector>".to_owned(),
+                    }),
+                )),
+            ));
+            None
+        }
+        Err(error) => {
+            report.push(finding(
+                LockAuditReasonCode::ConfigInvalid,
+                LockAuditSeverity::Error,
+                LockAuditCategory::Configuration,
+                "configuration",
+                Some(path),
+                error.to_string(),
+                Some(repair(
+                    "review the configuration before regenerating its lock",
+                    None,
+                )),
+            ));
+            None
+        }
+    }
+}
+
+fn load_audited_lock(path: &Path, report: &mut LockAuditReport) -> Option<Lockfile> {
+    match load_lockfile(path) {
+        Ok(lockfile) => {
+            if lockfile.schema < LOCKFILE_SCHEMA {
+                report.push(finding(
+                    LockAuditReasonCode::LockSchemaLegacy,
+                    LockAuditSeverity::Warning,
+                    LockAuditCategory::Lock,
+                    "lockfile",
+                    Some(path),
+                    format!(
+                        "lockfile schema {} remains readable but should be migrated to schema {}",
+                        lockfile.schema, LOCKFILE_SCHEMA
+                    ),
+                    Some(repair("migrate the configuration and lock pair", None)),
+                ));
+            }
+            Some(lockfile)
+        }
+        Err(Error::ReadLockfile { source, .. }) if source.kind() == ErrorKind::NotFound => {
+            report.push(finding(
+                LockAuditReasonCode::LockMissing,
+                LockAuditSeverity::Error,
+                LockAuditCategory::Lock,
+                "lockfile",
+                Some(path),
+                format!("lockfile does not exist: {}", path.display()),
+                Some(repair(
+                    "generate an exact lock for every configured runtime",
+                    None,
+                )),
+            ));
+            None
+        }
+        Err(error) => {
+            let (reason_code, category) = lock_error_classification(&error);
+            report.push(finding(
+                reason_code,
+                LockAuditSeverity::Error,
+                category,
+                "lockfile",
+                Some(path),
+                error.to_string(),
+                Some(repair("review and regenerate the lockfile", None)),
+            ));
+            None
+        }
+    }
+}
+
+fn lock_error_classification(error: &Error) -> (LockAuditReasonCode, LockAuditCategory) {
+    let artifact_related = match error {
+        Error::InvalidArtifactIntegrity { .. } | Error::InvalidSha256 { .. } => true,
+        Error::InvalidLockfile { reason } => [
+            "artifact",
+            "archive",
+            "checksum",
+            "integrity",
+            "target",
+            "URL",
+            "verification",
+        ]
+        .into_iter()
+        .any(|keyword| reason.contains(keyword)),
+        _ => false,
+    };
+    if artifact_related {
+        (
+            LockAuditReasonCode::PlatformArtifactInvalid,
+            LockAuditCategory::PlatformArtifact,
+        )
+    } else {
+        (LockAuditReasonCode::LockInvalid, LockAuditCategory::Lock)
+    }
+}
+
+fn audit_config_lock_pair(
+    pinset_home: &Path,
+    scope: LockAuditScope,
+    config_path: &Path,
+    config: &ConfigSelection,
+    lockfile: &Lockfile,
+    report: &mut LockAuditReport,
+) {
+    let lock_path = report.lockfile.clone();
+    for (tool, requested) in &config.tools {
+        report.summary.tools += 1;
+        let Some(provider) = runtime_provider(tool) else {
+            report.push(finding(
+                LockAuditReasonCode::ProviderUnsupported,
+                LockAuditSeverity::Error,
+                LockAuditCategory::Configuration,
+                tool,
+                Some(config_path),
+                format!("configuration selects unsupported Provider {tool:?}"),
+                Some(repair(
+                    "remove the unsupported selection or install a supported Provider",
+                    None,
+                )),
+            ));
+            continue;
+        };
+        if provider.capabilities.lock_audit != RuntimeLockAuditKind::ArtifactReceipt {
+            report.push(finding(
+                LockAuditReasonCode::ProviderAuditUnsupported,
+                LockAuditSeverity::Error,
+                LockAuditCategory::Lock,
+                tool,
+                Some(config_path),
+                format!("Provider {tool:?} does not declare a lock audit capability"),
+                None,
+            ));
+            continue;
+        }
+        let Some(locked) = lockfile.tool(tool) else {
+            report.push(finding(
+                LockAuditReasonCode::LockToolMissing,
+                LockAuditSeverity::Error,
+                LockAuditCategory::Lock,
+                tool,
+                Some(&lock_path),
+                format!("lockfile has no record for configured selection {tool}@{requested}"),
+                Some(repair("regenerate the lockfile from configuration", None)),
+            ));
+            continue;
+        };
+        if locked.requested != *requested {
+            report.push(finding(
+                LockAuditReasonCode::LockSelectorMismatch,
+                LockAuditSeverity::Error,
+                LockAuditCategory::Lock,
+                tool,
+                Some(&lock_path),
+                format!(
+                    "configuration requests {tool}@{requested}, but the lock records {} -> {}",
+                    locked.requested, locked.version
+                ),
+                Some(repair("regenerate the lockfile from configuration", None)),
+            ));
+            continue;
+        }
+        audit_locked_tool(pinset_home, scope, config_path, locked, report);
+    }
+
+    for locked in &lockfile.tools {
+        if !config.tools.contains_key(&locked.name) {
+            report.push(finding(
+                LockAuditReasonCode::LockToolUnconfigured,
+                LockAuditSeverity::Error,
+                LockAuditCategory::Lock,
+                &locked.name,
+                Some(&lock_path),
+                format!(
+                    "lockfile records {}@{}, but configuration does not select it",
+                    locked.name, locked.version
+                ),
+                Some(repair("regenerate the lockfile from configuration", None)),
+            ));
+        }
+    }
+}
+
+fn audit_locked_tool(
+    pinset_home: &Path,
+    scope: LockAuditScope,
+    config_path: &Path,
+    locked: &crate::LockedTool,
+    report: &mut LockAuditReport,
+) {
+    let lock_path = report.lockfile.clone();
+    let target = current_target_for_tool(&locked.name);
+    let subject = format!("{}@{}:{target}", locked.name, locked.version);
+    let Some(artifact) = locked.artifact(&target) else {
+        report.push(finding(
+            LockAuditReasonCode::PlatformArtifactMissing,
+            LockAuditSeverity::Error,
+            LockAuditCategory::PlatformArtifact,
+            &subject,
+            Some(&lock_path),
+            format!(
+                "lockfile has no {} artifact for the current target {target}",
+                locked.name
+            ),
+            Some(repair(
+                "regenerate the lock with a Pinset release that supports this platform",
+                None,
+            )),
+        ));
+        return;
+    };
+    report.summary.platform_artifacts += 1;
+    audit_artifact_cache(pinset_home, &subject, artifact, report);
+    audit_install_receipt(
+        pinset_home,
+        scope,
+        config_path,
+        &subject,
+        locked,
+        &target,
+        artifact,
+        report,
+    );
+    if scope == LockAuditScope::Project && locked.name == "python" {
+        audit_python_environment(config_path, locked, &target, report);
+    }
+}
+
+fn audit_artifact_cache(
+    pinset_home: &Path,
+    subject: &str,
+    artifact: &LockedArtifact,
+    report: &mut LockAuditReport,
+) {
+    let lock_path = report.lockfile.clone();
+    let mut identities = Vec::with_capacity(1 + artifact.overlays.len());
+    match artifact.artifact_integrity() {
+        Ok(integrity) => identities.push(("primary", integrity)),
+        Err(error) => {
+            report.push(finding(
+                LockAuditReasonCode::PlatformArtifactInvalid,
+                LockAuditSeverity::Error,
+                LockAuditCategory::PlatformArtifact,
+                subject,
+                Some(&lock_path),
+                error.to_string(),
+                Some(repair("regenerate the invalid lockfile", None)),
+            ));
+            return;
+        }
+    }
+    for (index, overlay) in artifact.overlays.iter().enumerate() {
+        match overlay.artifact_integrity() {
+            Ok(integrity) => identities.push((
+                if index == 0 {
+                    "overlay"
+                } else {
+                    "overlay-extra"
+                },
+                integrity,
+            )),
+            Err(error) => report.push(finding(
+                LockAuditReasonCode::PlatformArtifactInvalid,
+                LockAuditSeverity::Error,
+                LockAuditCategory::PlatformArtifact,
+                subject,
+                Some(&lock_path),
+                error.to_string(),
+                Some(repair("regenerate the invalid lockfile", None)),
+            )),
+        }
+    }
+    for (kind, integrity) in identities {
+        let cache_subject = format!("{subject}:{kind}:{}", integrity.canonical());
+        match verify_download_cache_integrity(pinset_home, &integrity) {
+            Ok(Some(entry)) => {
+                report.summary.cache_entries += 1;
+                if !entry.valid {
+                    report.push(finding(
+                        LockAuditReasonCode::CacheEntryCorrupt,
+                        LockAuditSeverity::Error,
+                        LockAuditCategory::Cache,
+                        &cache_subject,
+                        Some(&entry.path),
+                        format!(
+                            "cached artifact identity is {}, but its bytes hash to {}",
+                            entry.integrity, entry.actual
+                        ),
+                        Some(repair(
+                            "remove corrupt cache bytes after review and reinstall from a trusted source",
+                            Some("pinset cache repair".to_owned()),
+                        )),
+                    ));
+                }
+            }
+            Ok(None) => report.push(finding(
+                LockAuditReasonCode::CacheEntryMissing,
+                LockAuditSeverity::Info,
+                LockAuditCategory::Cache,
+                &cache_subject,
+                None,
+                "the locked artifact is not present in the optional offline cache".to_owned(),
+                Some(repair(
+                    "import a reviewed copy when offline installation readiness is required",
+                    Some(format!(
+                        "pinset cache import <archive> --integrity {}",
+                        integrity.canonical()
+                    )),
+                )),
+            )),
+            Err(Error::UnsafeDownloadCacheEntry { path }) => report.push(finding(
+                LockAuditReasonCode::CacheEntryUnsafe,
+                LockAuditSeverity::Error,
+                LockAuditCategory::Cache,
+                &cache_subject,
+                Some(&path),
+                "the cache identity resolves to a non-regular file or symbolic link".to_owned(),
+                Some(repair(
+                    "review the unsafe cache path before removing it",
+                    None,
+                )),
+            )),
+            Err(error) => report.push(finding(
+                LockAuditReasonCode::CacheEntryUnreadable,
+                LockAuditSeverity::Error,
+                LockAuditCategory::Cache,
+                &cache_subject,
+                None,
+                error.to_string(),
+                Some(repair("restore read access to the cache entry", None)),
+            )),
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn audit_install_receipt(
+    pinset_home: &Path,
+    scope: LockAuditScope,
+    config_path: &Path,
+    subject: &str,
+    locked: &crate::LockedTool,
+    target: &str,
+    artifact: &LockedArtifact,
+    report: &mut LockAuditReport,
+) {
+    let install_dir = pinset_home
+        .join("installs")
+        .join(&locked.name)
+        .join(&locked.version)
+        .join(target);
+    match validate_install_directory_chain(pinset_home, &locked.name, &locked.version, target) {
+        Ok(false) => {
+            report.push(finding(
+                LockAuditReasonCode::InstallMissing,
+                LockAuditSeverity::Warning,
+                LockAuditCategory::Ownership,
+                subject,
+                Some(&install_dir),
+                "the locked runtime is not installed for the current platform".to_owned(),
+                Some(repair(
+                    "install the exact locked runtime",
+                    Some(install_command(scope, config_path)),
+                )),
+            ));
+            return;
+        }
+        Ok(true) => {}
+        Err(path) => {
+            report.push(finding(
+                LockAuditReasonCode::InstallPathUnsafe,
+                LockAuditSeverity::Error,
+                LockAuditCategory::Ownership,
+                subject,
+                Some(&path),
+                "an installation path component is not a regular directory or is a symbolic link"
+                    .to_owned(),
+                Some(repair(
+                    "review the unsafe installation path; Pinset will not take ownership",
+                    None,
+                )),
+            ));
+            return;
+        }
+    }
+
+    let receipt_path = install_dir.join(".pinset-install.toml");
+    let receipt_metadata = match fs::symlink_metadata(&receipt_path) {
+        Ok(metadata) => metadata,
+        Err(source) if source.kind() == ErrorKind::NotFound => {
+            report.push(finding(
+                LockAuditReasonCode::ReceiptMissing,
+                LockAuditSeverity::Error,
+                LockAuditCategory::Ownership,
+                subject,
+                Some(&receipt_path),
+                "the installation has no Pinset ownership receipt".to_owned(),
+                Some(repair(
+                    "move the unowned directory aside and reinstall the locked runtime",
+                    None,
+                )),
+            ));
+            return;
+        }
+        Err(source) => {
+            report.push(finding(
+                LockAuditReasonCode::ReceiptUnreadable,
+                LockAuditSeverity::Error,
+                LockAuditCategory::InstallReceipt,
+                subject,
+                Some(&receipt_path),
+                source.to_string(),
+                Some(repair(
+                    "restore read access to the installation receipt",
+                    None,
+                )),
+            ));
+            return;
+        }
+    };
+    if !receipt_metadata.file_type().is_file() || receipt_metadata.file_type().is_symlink() {
+        report.push(finding(
+            LockAuditReasonCode::InstallPathUnsafe,
+            LockAuditSeverity::Error,
+            LockAuditCategory::Ownership,
+            subject,
+            Some(&receipt_path),
+            "the ownership receipt is not a regular file".to_owned(),
+            Some(repair(
+                "review the unsafe receipt path; Pinset will not take ownership",
+                None,
+            )),
+        ));
+        return;
+    }
+    if receipt_metadata.len() > MAX_AUDIT_RECEIPT_BYTES {
+        report.push(finding(
+            LockAuditReasonCode::ReceiptInvalid,
+            LockAuditSeverity::Error,
+            LockAuditCategory::InstallReceipt,
+            subject,
+            Some(&receipt_path),
+            format!(
+                "the ownership receipt exceeds the {} byte audit limit",
+                MAX_AUDIT_RECEIPT_BYTES
+            ),
+            Some(repair(
+                "review the oversized receipt before replacing the installation",
+                None,
+            )),
+        ));
+        return;
+    }
+    let content = match fs::read_to_string(&receipt_path) {
+        Ok(content) => content,
+        Err(source) => {
+            report.push(finding(
+                LockAuditReasonCode::ReceiptUnreadable,
+                LockAuditSeverity::Error,
+                LockAuditCategory::InstallReceipt,
+                subject,
+                Some(&receipt_path),
+                source.to_string(),
+                Some(repair(
+                    "restore read access to the installation receipt",
+                    None,
+                )),
+            ));
+            return;
+        }
+    };
+    let receipt = match toml::from_str::<AuditInstallReceipt>(&content) {
+        Ok(receipt) => receipt,
+        Err(error) => {
+            report.push(finding(
+                LockAuditReasonCode::ReceiptInvalid,
+                LockAuditSeverity::Error,
+                LockAuditCategory::InstallReceipt,
+                subject,
+                Some(&receipt_path),
+                error.to_string(),
+                Some(repair(
+                    "move the invalid installation aside and reinstall",
+                    None,
+                )),
+            ));
+            return;
+        }
+    };
+    report.summary.receipts += 1;
+    if !matches!(receipt.schema, 1 | 2) {
+        report.push(finding(
+            LockAuditReasonCode::ReceiptSchemaUnsupported,
+            LockAuditSeverity::Error,
+            LockAuditCategory::InstallReceipt,
+            subject,
+            Some(&receipt_path),
+            format!("install receipt schema {} is unsupported", receipt.schema),
+            Some(repair(
+                "move the unsupported installation aside and reinstall",
+                None,
+            )),
+        ));
+        return;
+    }
+    if receipt.schema == 1 {
+        report.push(finding(
+            LockAuditReasonCode::ReceiptSchemaLegacy,
+            LockAuditSeverity::Warning,
+            LockAuditCategory::InstallReceipt,
+            subject,
+            Some(&receipt_path),
+            "legacy receipt schema 1 proves identity but records less integrity evidence"
+                .to_owned(),
+            Some(repair(
+                "reinstall the runtime to write a schema 2 receipt",
+                None,
+            )),
+        ));
+    }
+    if !receipt.complete {
+        report.push(finding(
+            LockAuditReasonCode::ReceiptIncomplete,
+            LockAuditSeverity::Error,
+            LockAuditCategory::InstallReceipt,
+            subject,
+            Some(&receipt_path),
+            "the install receipt is not marked complete".to_owned(),
+            Some(repair(
+                "move the incomplete installation aside and reinstall",
+                None,
+            )),
+        ));
+        return;
+    }
+    if receipt.tool != locked.name || receipt.version != locked.version || receipt.target != target
+    {
+        report.push(finding(
+            LockAuditReasonCode::ReceiptIdentityMismatch,
+            LockAuditSeverity::Error,
+            LockAuditCategory::Ownership,
+            subject,
+            Some(&receipt_path),
+            format!(
+                "receipt identifies {}@{}:{}, not {subject}",
+                receipt.tool, receipt.version, receipt.target
+            ),
+            Some(repair(
+                "review the foreign installation; Pinset will not take ownership",
+                None,
+            )),
+        ));
+        return;
+    }
+    report.summary.owned_installs += 1;
+
+    if receipt.schema == 2
+        && (receipt.canonical_url.as_deref() != Some(artifact.canonical_url.as_str())
+            || receipt.selected_source.as_deref().is_none_or(str::is_empty)
+            || !matches!(
+                receipt.selected_source_kind.as_deref(),
+                Some("official" | "mirror" | "cache")
+            )
+            || receipt.selected_url.as_deref().is_none_or(str::is_empty)
+            || receipt.artifact_format.as_deref() != Some(artifact.format.as_str())
+            || receipt.bytes_downloaded.is_none())
+    {
+        report.push(finding(
+            LockAuditReasonCode::ReceiptInvalid,
+            LockAuditSeverity::Error,
+            LockAuditCategory::InstallReceipt,
+            subject,
+            Some(&receipt_path),
+            "schema 2 receipt metadata does not describe the locked artifact and selected source"
+                .to_owned(),
+            Some(repair(
+                "move the malformed installation aside and reinstall the locked runtime",
+                None,
+            )),
+        ));
+    }
+
+    let expected = match artifact.artifact_integrity() {
+        Ok(integrity) => integrity.canonical(),
+        Err(_) => return,
+    };
+    let recorded = receipt
+        .artifact_integrity
+        .as_deref()
+        .or(receipt.artifact_sha256.as_deref())
+        .and_then(|value| ArtifactIntegrity::parse(value).ok())
+        .map(|integrity| integrity.canonical());
+    let Some(recorded) = recorded else {
+        report.push(finding(
+            LockAuditReasonCode::ReceiptIntegrityMissing,
+            if receipt.schema == 1 {
+                LockAuditSeverity::Warning
+            } else {
+                LockAuditSeverity::Error
+            },
+            LockAuditCategory::InstallReceipt,
+            subject,
+            Some(&receipt_path),
+            "the receipt does not record a valid primary artifact integrity".to_owned(),
+            Some(repair(
+                "reinstall the runtime to bind its receipt to the locked artifact",
+                None,
+            )),
+        ));
+        return;
+    };
+    if recorded != expected {
+        report.push(finding(
+            LockAuditReasonCode::ReceiptIntegrityMismatch,
+            LockAuditSeverity::Error,
+            LockAuditCategory::InstallReceipt,
+            subject,
+            Some(&receipt_path),
+            format!("receipt records {recorded}, but the lock requires {expected}"),
+            Some(repair(
+                "move the mismatched installation aside and reinstall",
+                None,
+            )),
+        ));
+    }
+    let expected_overlays = artifact
+        .overlays
+        .iter()
+        .filter_map(|overlay| overlay.artifact_integrity().ok())
+        .map(|integrity| integrity.canonical())
+        .collect::<Vec<_>>();
+    let recorded_overlays = receipt
+        .base_artifact_integrities
+        .iter()
+        .map(|value| ArtifactIntegrity::parse(value).map(|integrity| integrity.canonical()))
+        .collect::<Result<Vec<_>, _>>();
+    if !recorded_overlays.is_ok_and(|recorded| recorded == expected_overlays) {
+        report.push(finding(
+            LockAuditReasonCode::ReceiptOverlayMismatch,
+            LockAuditSeverity::Error,
+            LockAuditCategory::InstallReceipt,
+            subject,
+            Some(&receipt_path),
+            "receipt overlay integrities do not match the locked platform artifact".to_owned(),
+            Some(repair(
+                "move the mismatched installation aside and reinstall",
+                None,
+            )),
+        ));
+    }
+}
+
+fn audit_python_environment(
+    config_path: &Path,
+    locked: &crate::LockedTool,
+    target: &str,
+    report: &mut LockAuditReport,
+) {
+    match load_project_python_environment(config_path, &locked.version, target) {
+        Ok(_) => {}
+        Err(Error::PythonEnvironmentMissing { path }) => report.push(finding(
+            LockAuditReasonCode::PythonEnvironmentMissing,
+            LockAuditSeverity::Warning,
+            LockAuditCategory::Ownership,
+            "python-environment",
+            Some(&path),
+            "the project Python environment has not been created".to_owned(),
+            Some(repair(
+                "create the Pinset-owned project environment",
+                Some("pinset venv create".to_owned()),
+            )),
+        )),
+        Err(
+            error @ (Error::PythonEnvironmentNotOwned { .. }
+            | Error::PythonEnvironmentMismatch { .. }
+            | Error::InvalidPythonEnvironmentMarker { .. }),
+        ) => report.push(finding(
+            LockAuditReasonCode::PythonEnvironmentOwnershipInvalid,
+            LockAuditSeverity::Error,
+            LockAuditCategory::Ownership,
+            "python-environment",
+            None,
+            error.to_string(),
+            Some(repair(
+                "review the foreign environment before recreating it",
+                None,
+            )),
+        )),
+        Err(error) => report.push(finding(
+            LockAuditReasonCode::PythonEnvironmentOwnershipInvalid,
+            LockAuditSeverity::Error,
+            LockAuditCategory::Ownership,
+            "python-environment",
+            None,
+            error.to_string(),
+            Some(repair("review the project Python environment", None)),
+        )),
+    }
+}
+
+fn validate_install_directory_chain(
+    pinset_home: &Path,
+    tool: &str,
+    version: &str,
+    target: &str,
+) -> Result<bool, PathBuf> {
+    let mut path = pinset_home.to_path_buf();
+    for segment in ["installs", tool, version, target] {
+        path.push(segment);
+        let metadata = match fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(source) if source.kind() == ErrorKind::NotFound => return Ok(false),
+            Err(_) => return Err(path),
+        };
+        if !metadata.file_type().is_dir() || metadata.file_type().is_symlink() {
+            return Err(path);
+        }
+    }
+    Ok(true)
+}
+
+fn project_config_path_for_audit(cwd: &Path) -> PathBuf {
+    match find_optional_project_config(cwd) {
+        Ok(Some(path)) => return path,
+        Ok(None) => {}
+        Err(Error::ReadProjectConfig { path, .. } | Error::ParseProjectConfig { path, .. }) => {
+            return path;
+        }
+        Err(_) => {}
+    }
+    let start = if cwd.is_file() {
+        cwd.parent().unwrap_or(cwd)
+    } else {
+        cwd
+    };
+    let git_root = start
+        .ancestors()
+        .find(|directory| {
+            let marker = directory.join(".git");
+            marker.is_file() || marker.is_dir()
+        })
+        .unwrap_or(start);
+    for directory in start
+        .ancestors()
+        .take_while(|directory| directory.starts_with(git_root))
+    {
+        let candidate = directory.join(PROJECT_CONFIG_FILENAME);
+        if fs::symlink_metadata(&candidate).is_ok() {
+            return candidate;
+        }
+    }
+    start.join(PROJECT_CONFIG_FILENAME)
+}
+
+fn config_missing(error: &Error) -> bool {
+    match error {
+        Error::GlobalConfigNotFound { .. } => true,
+        Error::ReadProjectConfig { source, .. } => source.kind() == ErrorKind::NotFound,
+        _ => false,
+    }
+}
+
+fn install_command(scope: LockAuditScope, config_path: &Path) -> String {
+    match scope {
+        LockAuditScope::Project => format!(
+            "pinset install --locked --cwd \"{}\"",
+            config_path.parent().unwrap_or(config_path).display()
+        ),
+        LockAuditScope::Global => "pinset install --locked --global".to_owned(),
+    }
+}
+
+fn migrate_command(scope: LockAuditScope, config_path: &Path) -> String {
+    match scope {
+        LockAuditScope::Project => format!(
+            "pinset migrate --cwd \"{}\"",
+            config_path.parent().unwrap_or(config_path).display()
+        ),
+        LockAuditScope::Global => "pinset migrate --global".to_owned(),
+    }
+}
+
+fn repair(action: &str, command: Option<String>) -> LockAuditRepair {
+    LockAuditRepair {
+        action: action.to_owned(),
+        command,
+    }
+}
+
+fn finding(
+    reason_code: LockAuditReasonCode,
+    severity: LockAuditSeverity,
+    category: LockAuditCategory,
+    subject: impl Into<String>,
+    path: Option<&Path>,
+    message: String,
+    repair: Option<LockAuditRepair>,
+) -> LockAuditFinding {
+    LockAuditFinding {
+        reason_code,
+        severity,
+        category,
+        subject: subject.into(),
+        path: path.map(Path::to_path_buf),
+        message,
+        repair,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        LockedArtifact, LockedArtifactFormat, MVP_NODE_TARGETS, NodeArchiveFormat, SourceConfig,
+        plan_node_artifact, save_lockfile,
+    };
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn missing_project_state_is_reported_without_creating_files() {
+        let root = tempdir().expect("temporary root");
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        fs::create_dir(&project).expect("project");
+
+        let report = audit_project_lock(&home, &project);
+
+        assert!(report.action_required());
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|finding| { finding.reason_code == LockAuditReasonCode::ConfigMissing })
+        );
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|finding| { finding.reason_code == LockAuditReasonCode::LockMissing })
+        );
+        assert!(!home.exists());
+        assert_eq!(fs::read_dir(&project).expect("project entries").count(), 0);
+    }
+
+    #[test]
+    fn reason_codes_have_stable_snake_case_serialization() {
+        assert_eq!(
+            LockAuditReasonCode::ReceiptIntegrityMismatch.as_str(),
+            "receipt_integrity_mismatch"
+        );
+    }
+
+    #[test]
+    fn selector_drift_has_a_specific_action_required_reason_code() {
+        let root = tempdir().expect("temporary root");
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        fs::create_dir(&project).expect("project");
+        fs::write(
+            project.join(PROJECT_CONFIG_FILENAME),
+            "schema = 3\n\n[policy]\ninherit-global = false\nsystem-fallback = false\nboundary = \"git\"\n\n[tools]\nnode = \"22.0.0\"\n",
+        )
+        .expect("project config");
+        save_lockfile(&project.join("pinset.lock"), &node_lockfile("24.0.0")).expect("lockfile");
+
+        let report = audit_project_lock(&home, &project);
+
+        assert!(report.action_required());
+        assert!(
+            report.findings.iter().any(|finding| {
+                finding.reason_code == LockAuditReasonCode::LockSelectorMismatch
+            })
+        );
+        assert!(!home.exists());
+    }
+
+    #[test]
+    fn matching_receipt_passes_while_an_optional_cache_miss_remains_informational() {
+        let root = tempdir().expect("temporary root");
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        fs::create_dir(&project).expect("project");
+        fs::write(
+            project.join(PROJECT_CONFIG_FILENAME),
+            "schema = 3\n\n[policy]\ninherit-global = false\nsystem-fallback = false\nboundary = \"git\"\n\n[tools]\nnode = \"24.0.0\"\n",
+        )
+        .expect("project config");
+        save_lockfile(&project.join("pinset.lock"), &node_lockfile("24.0.0")).expect("lockfile");
+
+        let target = current_target_for_tool("node");
+        let install = home
+            .join("installs")
+            .join("node")
+            .join("24.0.0")
+            .join(&target);
+        fs::create_dir_all(&install).expect("install directory");
+        let plan = plan_node_artifact(&SourceConfig::default(), "24.0.0", &target)
+            .expect("Node artifact plan");
+        let format = match plan.format {
+            NodeArchiveFormat::Zip => "zip",
+            NodeArchiveFormat::TarXz => "tar.xz",
+        };
+        fs::write(
+            install.join(".pinset-install.toml"),
+            format!(
+                "schema = 2\ncomplete = true\ntool = \"node\"\nversion = \"24.0.0\"\ntarget = \"{target}\"\ncanonical_url = \"{url}\"\nselected_source = \"fixture\"\nselected_source_kind = \"official\"\nselected_url = \"{url}\"\nartifact_integrity = \"sha256:{integrity}\"\nartifact_format = \"{format}\"\nbytes_downloaded = 0\n",
+                url = plan.canonical_url,
+                integrity = "ab".repeat(32),
+            ),
+        )
+        .expect("receipt");
+
+        let report = audit_project_lock(&home, &project);
+
+        assert!(report.passed);
+        assert_eq!(report.summary.errors, 0);
+        assert_eq!(report.summary.warnings, 0);
+        assert_eq!(report.summary.owned_installs, 1);
+        assert!(report.findings.iter().any(|finding| {
+            finding.reason_code == LockAuditReasonCode::CacheEntryMissing
+                && finding.severity == LockAuditSeverity::Info
+        }));
+    }
+
+    fn node_lockfile(version: &str) -> Lockfile {
+        let artifacts = MVP_NODE_TARGETS
+            .into_iter()
+            .map(|target| {
+                let plan = plan_node_artifact(&SourceConfig::default(), version, target)
+                    .expect("Node artifact plan");
+                LockedArtifact {
+                    target: target.to_owned(),
+                    canonical_url: plan.canonical_url,
+                    artifact_path: plan.artifact_path,
+                    sha256: "ab".repeat(32),
+                    integrity: None,
+                    format: match plan.format {
+                        NodeArchiveFormat::Zip => LockedArtifactFormat::Zip,
+                        NodeArchiveFormat::TarXz => LockedArtifactFormat::TarXz,
+                    },
+                    archive_root: plan.archive_root,
+                    verification: "nodejs-openpgp-sha256".to_owned(),
+                    overlays: Vec::new(),
+                }
+            })
+            .collect();
+        Lockfile::new_node(
+            "pinset lock audit test".to_owned(),
+            version.to_owned(),
+            "5BE8A3F6C8A5C01D106C0AD820B1A390B168D356".to_owned(),
+            "official".to_owned(),
+            artifacts,
+        )
+    }
+}

--- a/crates/pinset-core/src/project_discovery.rs
+++ b/crates/pinset-core/src/project_discovery.rs
@@ -187,7 +187,7 @@ impl Scanner {
 
     fn scan_provider_sources(&mut self, directory: &Path) {
         for provider in runtime_providers() {
-            for rule in provider.discovery {
+            for rule in provider.capabilities.discovery {
                 match rule.kind {
                     RuntimeDiscoveryKind::SimpleFile { filename } => self.scan_simple(
                         rule.source,

--- a/crates/pinset-core/src/resolver.rs
+++ b/crates/pinset-core/src/resolver.rs
@@ -563,7 +563,7 @@ pub fn selected_runtime_environment(
 ) -> Vec<RuntimeEnvironmentVariable> {
     let mut variables = Vec::new();
     for provider in runtime_providers() {
-        if provider.environment == RuntimeEnvironmentKind::None {
+        if provider.capabilities.environment == RuntimeEnvironmentKind::None {
             continue;
         }
         let Ok(selection) = resolve_tool_selection(provider.tool, cwd, pinset_home) else {
@@ -574,7 +574,7 @@ pub fn selected_runtime_environment(
             .join(provider.tool)
             .join(&selection.version)
             .join(current_target_for_tool(provider.tool));
-        if provider.environment == RuntimeEnvironmentKind::Python {
+        if provider.capabilities.environment == RuntimeEnvironmentKind::Python {
             if selection.source == SelectionSource::Project {
                 if let Ok(environment) = load_project_python_environment(
                     &selection.config_path,
@@ -598,7 +598,7 @@ pub fn runtime_environment_for_install(
     tool: &str,
     install_dir: &Path,
 ) -> Vec<RuntimeEnvironmentVariable> {
-    match runtime_provider(tool).map(|provider| provider.environment) {
+    match runtime_provider(tool).map(|provider| provider.capabilities.environment) {
         Some(RuntimeEnvironmentKind::Go) => {
             let mut variables = vec![RuntimeEnvironmentVariable {
                 name: "GOROOT",
@@ -661,7 +661,7 @@ pub fn validate_managed_runtime_invocation(
 }
 
 pub fn runtime_command_directory(tool: &str, install_dir: &Path) -> PathBuf {
-    match runtime_provider(tool).map(|provider| provider.command_layout) {
+    match runtime_provider(tool).map(|provider| provider.capabilities.command_layout) {
         Some(RuntimeCommandLayout::NodeNative) if cfg!(windows) => install_dir.to_path_buf(),
         Some(RuntimeCommandLayout::NodeNative | RuntimeCommandLayout::Bin) => {
             install_dir.join("bin")

--- a/crates/pinset-core/src/runtime_provider.rs
+++ b/crates/pinset-core/src/runtime_provider.rs
@@ -2,11 +2,22 @@
 pub struct RuntimeProvider {
     pub tool: &'static str,
     pub commands: &'static [&'static str],
+    pub capabilities: RuntimeProviderCapabilities,
+}
+
+/// The complete set of behaviors implemented by one built-in runtime Provider.
+///
+/// Keeping these declarations together prevents command routing, discovery, metadata
+/// resolution, installation, environment setup, and lock auditing from maintaining
+/// separate Provider lists that can drift apart.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RuntimeProviderCapabilities {
     pub command_layout: RuntimeCommandLayout,
     pub metadata: RuntimeMetadataKind,
     pub installer: RuntimeInstallKind,
     pub environment: RuntimeEnvironmentKind,
     pub discovery: &'static [RuntimeDiscoveryRule],
+    pub lock_audit: RuntimeLockAuditKind,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -68,6 +79,15 @@ pub enum RuntimeEnvironmentKind {
     Dotnet,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeLockAuditKind {
+    /// Audit the locked platform artifact, relevant cache entries, install receipt, and
+    /// receipt-backed ownership without contacting the Provider.
+    ArtifactReceipt,
+    /// Reserved for a future constrained Provider that cannot satisfy the shared audit contract.
+    Unsupported,
+}
+
 const NODE_COMMANDS: &[&str] = &["node", "npm", "npx", "corepack"];
 const NODE_DISCOVERY: &[RuntimeDiscoveryRule] = &[
     RuntimeDiscoveryRule {
@@ -124,67 +144,88 @@ const DOTNET_DISCOVERY: &[RuntimeDiscoveryRule] = &[RuntimeDiscoveryRule {
 const NODE_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "node",
     commands: NODE_COMMANDS,
-    command_layout: RuntimeCommandLayout::NodeNative,
-    metadata: RuntimeMetadataKind::Node,
-    installer: RuntimeInstallKind::Node,
-    environment: RuntimeEnvironmentKind::None,
-    discovery: NODE_DISCOVERY,
+    capabilities: RuntimeProviderCapabilities {
+        command_layout: RuntimeCommandLayout::NodeNative,
+        metadata: RuntimeMetadataKind::Node,
+        installer: RuntimeInstallKind::Node,
+        environment: RuntimeEnvironmentKind::None,
+        discovery: NODE_DISCOVERY,
+        lock_audit: RuntimeLockAuditKind::ArtifactReceipt,
+    },
 };
 const PNPM_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "pnpm",
     commands: &["pnpm"],
-    command_layout: RuntimeCommandLayout::Root,
-    metadata: RuntimeMetadataKind::Npm,
-    installer: RuntimeInstallKind::Npm,
-    environment: RuntimeEnvironmentKind::None,
-    discovery: &[],
+    capabilities: RuntimeProviderCapabilities {
+        command_layout: RuntimeCommandLayout::Root,
+        metadata: RuntimeMetadataKind::Npm,
+        installer: RuntimeInstallKind::Npm,
+        environment: RuntimeEnvironmentKind::None,
+        discovery: &[],
+        lock_audit: RuntimeLockAuditKind::ArtifactReceipt,
+    },
 };
 const BUN_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "bun",
     commands: &["bun", "bunx"],
-    command_layout: RuntimeCommandLayout::Bin,
-    metadata: RuntimeMetadataKind::Npm,
-    installer: RuntimeInstallKind::Npm,
-    environment: RuntimeEnvironmentKind::None,
-    discovery: BUN_DISCOVERY,
+    capabilities: RuntimeProviderCapabilities {
+        command_layout: RuntimeCommandLayout::Bin,
+        metadata: RuntimeMetadataKind::Npm,
+        installer: RuntimeInstallKind::Npm,
+        environment: RuntimeEnvironmentKind::None,
+        discovery: BUN_DISCOVERY,
+        lock_audit: RuntimeLockAuditKind::ArtifactReceipt,
+    },
 };
 const GO_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "go",
     commands: &["go", "gofmt"],
-    command_layout: RuntimeCommandLayout::Bin,
-    metadata: RuntimeMetadataKind::Go,
-    installer: RuntimeInstallKind::Go,
-    environment: RuntimeEnvironmentKind::Go,
-    discovery: GO_DISCOVERY,
+    capabilities: RuntimeProviderCapabilities {
+        command_layout: RuntimeCommandLayout::Bin,
+        metadata: RuntimeMetadataKind::Go,
+        installer: RuntimeInstallKind::Go,
+        environment: RuntimeEnvironmentKind::Go,
+        discovery: GO_DISCOVERY,
+        lock_audit: RuntimeLockAuditKind::ArtifactReceipt,
+    },
 };
 const FLUTTER_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "flutter",
     commands: &["flutter", "dart"],
-    command_layout: RuntimeCommandLayout::Bin,
-    metadata: RuntimeMetadataKind::Flutter,
-    installer: RuntimeInstallKind::Flutter,
-    environment: RuntimeEnvironmentKind::Flutter,
-    discovery: FLUTTER_DISCOVERY,
+    capabilities: RuntimeProviderCapabilities {
+        command_layout: RuntimeCommandLayout::Bin,
+        metadata: RuntimeMetadataKind::Flutter,
+        installer: RuntimeInstallKind::Flutter,
+        environment: RuntimeEnvironmentKind::Flutter,
+        discovery: FLUTTER_DISCOVERY,
+        lock_audit: RuntimeLockAuditKind::ArtifactReceipt,
+    },
 };
 const PYTHON_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "python",
     commands: &["python", "python3", "pip", "pip3"],
-    command_layout: RuntimeCommandLayout::Python,
-    metadata: RuntimeMetadataKind::Python,
-    installer: RuntimeInstallKind::Python,
-    environment: RuntimeEnvironmentKind::Python,
-    discovery: PYTHON_DISCOVERY,
+    capabilities: RuntimeProviderCapabilities {
+        command_layout: RuntimeCommandLayout::Python,
+        metadata: RuntimeMetadataKind::Python,
+        installer: RuntimeInstallKind::Python,
+        environment: RuntimeEnvironmentKind::Python,
+        discovery: PYTHON_DISCOVERY,
+        lock_audit: RuntimeLockAuditKind::ArtifactReceipt,
+    },
 };
 const JAVA_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "java",
     commands: &[
         "java", "javac", "jar", "javadoc", "javap", "keytool", "jshell",
     ],
-    command_layout: RuntimeCommandLayout::Java,
-    metadata: RuntimeMetadataKind::Java,
-    installer: RuntimeInstallKind::Java,
-    environment: RuntimeEnvironmentKind::Java,
-    discovery: JAVA_DISCOVERY,
+    capabilities: RuntimeProviderCapabilities {
+        command_layout: RuntimeCommandLayout::Java,
+        metadata: RuntimeMetadataKind::Java,
+        installer: RuntimeInstallKind::Java,
+        environment: RuntimeEnvironmentKind::Java,
+        discovery: JAVA_DISCOVERY,
+        lock_audit: RuntimeLockAuditKind::ArtifactReceipt,
+    },
 };
 const RUST_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "rust",
@@ -197,20 +238,26 @@ const RUST_PROVIDER: RuntimeProvider = RuntimeProvider {
         "clippy-driver",
         "cargo-clippy",
     ],
-    command_layout: RuntimeCommandLayout::Bin,
-    metadata: RuntimeMetadataKind::Rust,
-    installer: RuntimeInstallKind::Rust,
-    environment: RuntimeEnvironmentKind::None,
-    discovery: RUST_DISCOVERY,
+    capabilities: RuntimeProviderCapabilities {
+        command_layout: RuntimeCommandLayout::Bin,
+        metadata: RuntimeMetadataKind::Rust,
+        installer: RuntimeInstallKind::Rust,
+        environment: RuntimeEnvironmentKind::None,
+        discovery: RUST_DISCOVERY,
+        lock_audit: RuntimeLockAuditKind::ArtifactReceipt,
+    },
 };
 const DOTNET_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "dotnet",
     commands: &["dotnet"],
-    command_layout: RuntimeCommandLayout::Root,
-    metadata: RuntimeMetadataKind::Dotnet,
-    installer: RuntimeInstallKind::Dotnet,
-    environment: RuntimeEnvironmentKind::Dotnet,
-    discovery: DOTNET_DISCOVERY,
+    capabilities: RuntimeProviderCapabilities {
+        command_layout: RuntimeCommandLayout::Root,
+        metadata: RuntimeMetadataKind::Dotnet,
+        installer: RuntimeInstallKind::Dotnet,
+        environment: RuntimeEnvironmentKind::Dotnet,
+        discovery: DOTNET_DISCOVERY,
+        lock_audit: RuntimeLockAuditKind::ArtifactReceipt,
+    },
 };
 const PROVIDERS: &[RuntimeProvider] = &[
     NODE_PROVIDER,
@@ -362,16 +409,38 @@ mod tests {
     #[test]
     fn provider_specific_discovery_is_declared_in_provider_manifests() {
         assert_eq!(
-            runtime_provider("node").expect("node").discovery,
+            runtime_provider("node")
+                .expect("node")
+                .capabilities
+                .discovery,
             NODE_DISCOVERY
         );
         assert_eq!(
-            runtime_provider("python").expect("python").discovery,
+            runtime_provider("python")
+                .expect("python")
+                .capabilities
+                .discovery,
             PYTHON_DISCOVERY
         );
         assert_eq!(
-            runtime_provider("dotnet").expect("dotnet").discovery,
+            runtime_provider("dotnet")
+                .expect("dotnet")
+                .capabilities
+                .discovery,
             DOTNET_DISCOVERY
         );
+    }
+
+    #[test]
+    fn every_provider_declares_the_complete_v16_capability_model() {
+        assert_eq!(runtime_providers().len(), 9);
+        for provider in runtime_providers() {
+            assert_eq!(
+                provider.capabilities.lock_audit,
+                RuntimeLockAuditKind::ArtifactReceipt,
+                "{} must participate in the shared lock audit contract",
+                provider.tool
+            );
+        }
     }
 }

--- a/crates/pinset/src/i18n.rs
+++ b/crates/pinset/src/i18n.rs
@@ -1,6 +1,6 @@
 use std::{error::Error as StdError, fmt, path::Path, str::FromStr};
 
-use pinset_core::Error;
+use pinset_core::{Error, LockAuditSummary};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum Language {
@@ -249,7 +249,7 @@ impl Catalog {
     pub fn top_level_help(self) -> &'static str {
         match self.language {
             Language::English => {
-                "Pinset manages predictable runtime versions.\n\nUsage: pinset [--lang <en|zh-CN>] <COMMAND>\n\nCommands:\n  init         Create project configuration\n  detect       Detect traditional version files\n  import       Import traditional version selections\n  global       Show or set the global default\n  use          Select and lock a project version\n  unset        Clear a project or global selection\n  install      Install a locked or explicit version\n  uninstall    Safely uninstall an exact version\n  prune        Remove unused managed versions\n  outdated     Check selected versions for updates\n  current      Show the effective selection\n  list         List installed or available versions\n  cache        Inspect, verify or clean the download cache\n  which        Show the resolved command path\n  exec         Run with the selected version\n  doctor       Diagnose configuration and PATH\n  venv         Manage the project Python environment\n  shim         Repair or migrate command shims\n  activate     Enable provider command routing in a shell\n  completions  Generate shell completion\n  source       Manage download sources\n\nRun `pinset <command> --help` for command details."
+                "Pinset manages predictable runtime versions.\n\nUsage: pinset [--lang <en|zh-CN>] <COMMAND>\n\nCommands:\n  init         Create project configuration\n  detect       Detect traditional version files\n  import       Import traditional version selections\n  global       Show or set the global default\n  use          Select and lock a project version\n  unset        Clear a project or global selection\n  install      Install a locked or explicit version\n  uninstall    Safely uninstall an exact version\n  prune        Remove unused managed versions\n  outdated     Check selected versions for updates\n  current      Show the effective selection\n  list         List installed or available versions\n  lock         Audit lock integrity and ownership\n  cache        Inspect, verify or clean the download cache\n  which        Show the resolved command path\n  exec         Run with the selected version\n  doctor       Diagnose configuration and PATH\n  venv         Manage the project Python environment\n  shim         Repair or migrate command shims\n  activate     Enable provider command routing in a shell\n  completions  Generate shell completion\n  source       Manage download sources\n\nRun `pinset <command> --help` for command details."
             }
             Language::SimplifiedChinese => {
                 "Pinset 用于统一管理可复现的运行时版本。\n\n用法：pinset [--lang <en|zh-CN>] <命令>\n\n执行 `pinset <命令> --help` 查看命令详情。"
@@ -299,6 +299,9 @@ impl Catalog {
             Some("prune") => {
                 "清理未被全局、当前项目或显式附加项目选择引用的受管版本。\n\n用法：pinset prune [--cwd <目录>] [--project <目录>...] [--dry-run] [--json]"
             }
+            Some("lock") => {
+                "只读、离线审计配置、锁定平台制品、缓存、安装收据和所有权。\n\n用法：pinset lock audit [--global | --cwd <目录>] [--json]"
+            }
             Some("cache") => {
                 "统计、验证、修复、清理或离线导入运行时下载缓存。\n\n用法：pinset cache <list|info|verify|repair|clean|import> [参数...]"
             }
@@ -324,7 +327,7 @@ impl Catalog {
                 "管理并测试本机下载源。\n\n用法：pinset source <list|add|use|fallback|remove|test> [参数...]"
             }
             _ => {
-                "Pinset 用于统一管理可复现的运行时版本。\n\n用法：pinset [--lang <en|zh-CN>] <命令>\n\n命令：\n  init         创建项目配置\n  detect       检测传统版本配置\n  import       导入传统版本选择\n  global       查看或设置全局默认版本\n  use          选择并锁定项目版本\n  unset        清除项目或全局选择\n  install      安装锁定或指定版本\n  uninstall    安全卸载精确版本\n  prune        清理未引用的受管版本\n  outdated     检查已选版本更新\n  current      显示当前生效选择\n  list         列出已安装或可用版本\n  cache        统计、验证或清理下载缓存\n  which        显示实际命令路径\n  exec         使用当前选择执行命令\n  doctor       诊断配置与 PATH\n  venv         管理项目 Python 虚拟环境\n  shim         管理和迁移命令 shim\n  activate     为当前 Shell 启用命令路由\n  completions  生成 Shell 命令补全\n  source       管理下载源\n\n执行 `pinset --lang zh-CN <命令> --help` 查看详情。"
+                "Pinset 用于统一管理可复现的运行时版本。\n\n用法：pinset [--lang <en|zh-CN>] <命令>\n\n命令：\n  init         创建项目配置\n  detect       检测传统版本配置\n  import       导入传统版本选择\n  global       查看或设置全局默认版本\n  use          选择并锁定项目版本\n  unset        清除项目或全局选择\n  install      安装锁定或指定版本\n  uninstall    安全卸载精确版本\n  prune        清理未引用的受管版本\n  outdated     检查已选版本更新\n  current      显示当前生效选择\n  list         列出已安装或可用版本\n  lock         审计锁完整性与所有权\n  cache        统计、验证或清理下载缓存\n  which        显示实际命令路径\n  exec         使用当前选择执行命令\n  doctor       诊断配置与 PATH\n  venv         管理项目 Python 虚拟环境\n  shim         管理和迁移命令 shim\n  activate     为当前 Shell 启用命令路由\n  completions  生成 Shell 命令补全\n  source       管理下载源\n\n执行 `pinset --lang zh-CN <命令> --help` 查看详情。"
             }
         }
     }
@@ -510,6 +513,100 @@ impl Catalog {
             Language::SimplifiedChinese => format!(
                 "已导入校验通过的缓存归档：完整性={integrity}；字节数={size}；路径={}",
                 path.display()
+            ),
+        }
+    }
+
+    pub fn lock_audit_header(
+        self,
+        scope: &str,
+        config: &Path,
+        lockfile: &Path,
+        passed: bool,
+    ) -> String {
+        match self.language {
+            Language::English => format!(
+                "lock audit scope={scope} mode=offline/read-only status={} config={} lock={}",
+                if passed { "passed" } else { "action-required" },
+                config.display(),
+                lockfile.display()
+            ),
+            Language::SimplifiedChinese => format!(
+                "锁审计 范围={} 模式=离线/只读 状态={} 配置={} 锁文件={}",
+                if scope == "project" {
+                    "项目"
+                } else {
+                    "全局"
+                },
+                if passed { "通过" } else { "需要处理" },
+                config.display(),
+                lockfile.display()
+            ),
+        }
+    }
+
+    pub fn lock_audit_finding(
+        self,
+        severity: &str,
+        reason_code: &str,
+        subject: &str,
+        path: Option<&Path>,
+        message: &str,
+    ) -> String {
+        let path = path
+            .map(|path| format!(" path={}", path.display()))
+            .unwrap_or_default();
+        match self.language {
+            Language::English => {
+                format!("[{severity}] {reason_code} subject={subject}{path}: {message}")
+            }
+            Language::SimplifiedChinese => {
+                let severity = match severity {
+                    "error" => "错误",
+                    "warning" => "警告",
+                    _ => "信息",
+                };
+                format!("[{severity}] {reason_code} 对象={subject}{path}：{message}")
+            }
+        }
+    }
+
+    pub fn lock_audit_repair(self, action: &str, command: Option<&str>) -> String {
+        match (self.language, command) {
+            (Language::English, Some(command)) => {
+                format!("  repair: {action}; command={command}")
+            }
+            (Language::English, None) => format!("  repair: {action}"),
+            (Language::SimplifiedChinese, Some(command)) => {
+                format!("  修复计划：{action}；命令={command}")
+            }
+            (Language::SimplifiedChinese, None) => format!("  修复计划：{action}"),
+        }
+    }
+
+    pub fn lock_audit_summary(self, summary: &LockAuditSummary) -> String {
+        match self.language {
+            Language::English => format!(
+                "summary tools={} platform_artifacts={} cache_entries={} receipts={} owned_installs={} errors={} warnings={} info={}",
+                summary.tools,
+                summary.platform_artifacts,
+                summary.cache_entries,
+                summary.receipts,
+                summary.owned_installs,
+                summary.errors,
+                summary.warnings,
+                summary.info
+            ),
+            Language::SimplifiedChinese => format!(
+                "汇总 工具={} 平台制品={} 缓存项={} 收据={} 已确认归属安装={} 错误={} 警告={} 信息={}",
+                summary.tools,
+                summary.platform_artifacts,
+                summary.cache_entries,
+                summary.receipts,
+                summary.owned_installs,
+                summary.errors,
+                summary.warnings,
+                summary.info
             ),
         }
     }

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -19,31 +19,32 @@ use clap::{Parser, Subcommand, ValueEnum, error::ErrorKind};
 use pinset_core::{
     ArtifactIntegrity, DiscoveryReport, DiscoveryStatus, DotnetMetadataClient,
     DownloadProgressEvent, Error, FlutterMetadataClient, GlobalConfig, GoMetadataClient,
-    InstallLimits, Installer, JavaMetadataClient, LockedTool, Lockfile, NodeMetadataClient,
-    NpmMetadataClient, PROJECT_CONFIG_SCHEMA, ProjectConfig, PythonMetadataClient,
-    RuntimeInstallKind, RuntimeMetadataKind, RustMetadataClient, SUPPORTED_SOURCE_PROVIDERS,
-    ShimInstallMethod, SourceView, clean_download_cache, command_tool, create_project_config,
-    create_project_python_environment, current_target_for_tool, download_cache_info, ensure_shims,
-    find_optional_project_config, find_project_config, find_project_context, global_config_path,
-    global_lockfile_path, import_download_cache, import_download_cache_with_integrity,
-    install_locked_dotnet, install_locked_flutter, install_locked_go, install_locked_java,
-    install_locked_node, install_locked_npm_tool, install_locked_python, install_locked_rust,
-    is_managed_command_shim, list_all_installed_tool_versions, list_download_cache,
-    list_installed_tool_versions, load_global_config, load_lockfile, load_optional_global_config,
-    load_optional_lockfile, load_project_config, load_project_python_environment,
-    load_source_config, load_user_settings, lockfile_path, managed_runtime_arguments,
-    path_with_selected_tools, pinset_home, plan_prune_tool_versions, plan_uninstall_tool_version,
-    project_python_environment_path, repair_download_cache, resolve_command,
-    resolve_project_python_command, resolve_tool_selection, runtime_command_candidates,
-    runtime_command_directory, runtime_environment_for_install, runtime_provider,
-    save_global_config, save_global_state, save_lockfile, save_project_config, save_project_state,
-    save_source_config, save_user_settings, scan_project_sources, selected_runtime_environment,
-    source_config_path, uninstall_node_version, uninstall_tool_version, user_settings_path,
-    validate_exact_dotnet_version, validate_exact_flutter_version, validate_exact_go_version,
-    validate_exact_java_version, validate_exact_node_version, validate_exact_npm_tool_version,
-    validate_exact_python_version, validate_exact_rust_version, validate_lock_matches_selection,
-    validate_lock_matches_tool, validate_lock_matches_tools, validate_managed_runtime_invocation,
-    verify_download_cache,
+    InstallLimits, Installer, JavaMetadataClient, LockAuditReport, LockAuditScope,
+    LockAuditSeverity, LockedTool, Lockfile, NodeMetadataClient, NpmMetadataClient,
+    PROJECT_CONFIG_SCHEMA, ProjectConfig, PythonMetadataClient, RuntimeInstallKind,
+    RuntimeMetadataKind, RustMetadataClient, SUPPORTED_SOURCE_PROVIDERS, ShimInstallMethod,
+    SourceView, audit_global_lock, audit_project_lock, clean_download_cache, command_tool,
+    create_project_config, create_project_python_environment, current_target_for_tool,
+    download_cache_info, ensure_shims, find_optional_project_config, find_project_config,
+    find_project_context, global_config_path, global_lockfile_path, import_download_cache,
+    import_download_cache_with_integrity, install_locked_dotnet, install_locked_flutter,
+    install_locked_go, install_locked_java, install_locked_node, install_locked_npm_tool,
+    install_locked_python, install_locked_rust, is_managed_command_shim,
+    list_all_installed_tool_versions, list_download_cache, list_installed_tool_versions,
+    load_global_config, load_lockfile, load_optional_global_config, load_optional_lockfile,
+    load_project_config, load_project_python_environment, load_source_config, load_user_settings,
+    lockfile_path, managed_runtime_arguments, path_with_selected_tools, pinset_home,
+    plan_prune_tool_versions, plan_uninstall_tool_version, project_python_environment_path,
+    repair_download_cache, resolve_command, resolve_project_python_command, resolve_tool_selection,
+    runtime_command_candidates, runtime_command_directory, runtime_environment_for_install,
+    runtime_provider, save_global_config, save_global_state, save_lockfile, save_project_config,
+    save_project_state, save_source_config, save_user_settings, scan_project_sources,
+    selected_runtime_environment, source_config_path, uninstall_node_version,
+    uninstall_tool_version, user_settings_path, validate_exact_dotnet_version,
+    validate_exact_flutter_version, validate_exact_go_version, validate_exact_java_version,
+    validate_exact_node_version, validate_exact_npm_tool_version, validate_exact_python_version,
+    validate_exact_rust_version, validate_lock_matches_selection, validate_lock_matches_tool,
+    validate_lock_matches_tools, validate_managed_runtime_invocation, verify_download_cache,
 };
 use serde::Serialize;
 use terminal_size::{Width, terminal_size_of};
@@ -248,6 +249,11 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Audit configuration, locks, cached artifacts, receipts, and ownership without writes.
+    Lock {
+        #[command(subcommand)]
+        command: LockCommands,
+    },
     /// Inspect or clean verified runtime download archives.
     Cache {
         #[command(subcommand)]
@@ -396,6 +402,22 @@ enum CacheCommands {
 }
 
 #[derive(Debug, Subcommand)]
+enum LockCommands {
+    /// Audit one project or global lock without network access or state changes.
+    Audit {
+        /// Audit the global selection instead of the nearest project.
+        #[arg(long, conflicts_with = "cwd")]
+        global: bool,
+        /// Project directory whose nearest Pinset configuration is audited.
+        #[arg(long, conflicts_with = "global")]
+        cwd: Option<PathBuf>,
+        /// Emit stable reason codes in the JSON schema 1 envelope.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Debug, Subcommand)]
 enum SourceCommands {
     /// List built-in and custom sources.
     List {
@@ -451,7 +473,17 @@ impl Commands {
             Self::Uninstall { json: true, .. } => Some("uninstall"),
             Self::Prune { json: true, .. } => Some("prune"),
             Self::Doctor { json: true, .. } => Some("doctor"),
+            Self::Lock { command } => command.json_command(),
             Self::Cache { command } => command.json_command(),
+            _ => None,
+        }
+    }
+}
+
+impl LockCommands {
+    fn json_command(&self) -> Option<&'static str> {
+        match self {
+            Self::Audit { json: true, .. } => Some("lock.audit"),
             _ => None,
         }
     }
@@ -553,24 +585,28 @@ fn requested_json_command(arguments: &[OsString]) -> Option<String> {
                 | "uninstall"
                 | "prune"
                 | "doctor"
+                | "lock"
                 | "cache"
         )
     });
     let Some(index) = top_level else {
         return Some("pinset".to_owned());
     };
-    if values[index] != "cache" {
+    if values[index] != "cache" && values[index] != "lock" {
         return Some(values[index].as_ref().to_owned());
     }
-    let subcommand = values[index + 1..].iter().find(|value| {
-        matches!(
+    let group = values[index].as_ref();
+    let subcommand = values[index + 1..].iter().find(|value| match group {
+        "cache" => matches!(
             value.as_ref(),
             "list" | "info" | "verify" | "repair" | "clean"
-        )
+        ),
+        "lock" => value.as_ref() == "audit",
+        _ => false,
     });
     Some(match subcommand {
-        Some(subcommand) => format!("cache.{subcommand}"),
-        None => "cache".to_owned(),
+        Some(subcommand) => format!("{group}.{subcommand}"),
+        None => group.to_owned(),
     })
 }
 
@@ -1001,6 +1037,7 @@ fn run(cli: Cli, catalog: Catalog) -> Result<i32, Box<dyn std::error::Error>> {
             dry_run,
             json,
         } => run_prune(cwd, &project, dry_run, json)?,
+        Commands::Lock { command } => return run_lock_command(command, catalog),
         Commands::Cache { command } => run_cache(command, catalog)?,
         Commands::Exec { cwd, command } => {
             let cwd = effective_cwd(cwd)?;
@@ -1539,7 +1576,7 @@ fn available_version_reports(
 ) -> Result<Vec<AvailableVersionReport>, Box<dyn std::error::Error>> {
     let provider = runtime_provider(tool).expect("required provider exists");
     let mut reports = Vec::new();
-    match provider.metadata {
+    match provider.capabilities.metadata {
         RuntimeMetadataKind::Node => {
             for release in node_metadata_client(&pinset_home()?)?.available_releases()? {
                 let mut details = BTreeMap::new();
@@ -1933,6 +1970,64 @@ fn run_prune(
     Ok(())
 }
 
+fn run_lock_command(
+    command: LockCommands,
+    catalog: Catalog,
+) -> Result<i32, Box<dyn std::error::Error>> {
+    match command {
+        LockCommands::Audit { global, cwd, json } => {
+            let home = pinset_home()?;
+            let report = if global {
+                audit_global_lock(&home)
+            } else {
+                audit_project_lock(&home, &effective_cwd(cwd)?)
+            };
+            let action_required = report.action_required();
+            if json {
+                print_json_success("lock.audit", report)?;
+            } else {
+                print_lock_audit_report(&report, catalog);
+            }
+            Ok(if action_required { 1 } else { 0 })
+        }
+    }
+}
+
+fn print_lock_audit_report(report: &LockAuditReport, catalog: Catalog) {
+    let scope = match report.scope {
+        LockAuditScope::Project => "project",
+        LockAuditScope::Global => "global",
+    };
+    println!(
+        "{}",
+        catalog.lock_audit_header(scope, &report.config, &report.lockfile, report.passed)
+    );
+    for finding in &report.findings {
+        let severity = match finding.severity {
+            LockAuditSeverity::Error => "error",
+            LockAuditSeverity::Warning => "warning",
+            LockAuditSeverity::Info => "info",
+        };
+        println!(
+            "{}",
+            catalog.lock_audit_finding(
+                severity,
+                finding.reason_code.as_str(),
+                &finding.subject,
+                finding.path.as_deref(),
+                &finding.message,
+            )
+        );
+        if let Some(repair) = &finding.repair {
+            println!(
+                "{}",
+                catalog.lock_audit_repair(&repair.action, repair.command.as_deref())
+            );
+        }
+    }
+    println!("{}", catalog.lock_audit_summary(&report.summary));
+}
+
 fn run_cache(command: CacheCommands, catalog: Catalog) -> Result<(), Box<dyn std::error::Error>> {
     let home = pinset_home()?;
     match command {
@@ -2085,8 +2180,9 @@ fn run_cache(command: CacheCommands, catalog: Catalog) -> Result<(), Box<dyn std
     Ok(())
 }
 
-const COMPLETION_COMMANDS: &str = "init detect import global use unset install which current list outdated update migrate uninstall prune cache exec doctor venv shim activate completions source";
+const COMPLETION_COMMANDS: &str = "init detect import global use unset install which current list outdated update migrate uninstall prune lock cache exec doctor venv shim activate completions source";
 const COMPLETION_SHELLS: &str = "bash zsh fish powershell";
+const COMPLETION_LOCK_COMMANDS: &str = "audit";
 const COMPLETION_CACHE_COMMANDS: &str = "list info verify repair clean import";
 const COMPLETION_VENV_COMMANDS: &str = "create status recreate";
 const COMPLETION_SHIM_COMMANDS: &str = "path install migrate";
@@ -2133,6 +2229,7 @@ fn completion_script(shell: ActivationShell) -> String {
             prune) values="--cwd --project --dry-run --json --lang --help" ;;
             which) values="--cwd --explain --json --lang --help" ;;
             doctor) values="--cwd --json --lang --help" ;;
+            lock) values="__LOCK_COMMANDS__ --global --cwd --json --lang --help" ;;
             cache) values="__CACHE_COMMANDS__ --lang --help" ;;
             venv) values="__VENV_COMMANDS__ --lang --help" ;;
             shim) values="__SHIM_COMMANDS__ __PROVIDERS__ --provider --binary --dir --lang --help" ;;
@@ -2169,6 +2266,7 @@ _pinset_completion() {
             prune) values="--cwd --project --dry-run --json --lang --help" ;;
             which) values="--cwd --explain --json --lang --help" ;;
             doctor) values="--cwd --json --lang --help" ;;
+            lock) values="__LOCK_COMMANDS__ --global --cwd --json --lang --help" ;;
             cache) values="__CACHE_COMMANDS__ --lang --help" ;;
             venv) values="__VENV_COMMANDS__ --lang --help" ;;
             shim) values="__SHIM_COMMANDS__ __PROVIDERS__ --provider --binary --dir --lang --help" ;;
@@ -2186,15 +2284,16 @@ compdef _pinset_completion pinset"#
 complete -c pinset -f -n '__fish_seen_subcommand_from global use install uninstall' -a '__SELECTIONS__'
 complete -c pinset -f -n '__fish_seen_subcommand_from unset list current outdated update' -a '__PROVIDERS__'
 complete -c pinset -f -n '__fish_seen_subcommand_from cache' -a '__CACHE_COMMANDS__'
+complete -c pinset -f -n '__fish_seen_subcommand_from lock' -a '__LOCK_COMMANDS__'
 complete -c pinset -f -n '__fish_seen_subcommand_from venv' -a '__VENV_COMMANDS__'
 complete -c pinset -f -n '__fish_seen_subcommand_from shim' -a '__SHIM_COMMANDS__ __PROVIDERS__'
 complete -c pinset -f -n '__fish_seen_subcommand_from activate completions' -a '__SHELLS__'
 complete -c pinset -f -n '__fish_seen_subcommand_from source' -a '__SOURCE_COMMANDS__ __SOURCE_PROVIDERS__'
-complete -c pinset -f -n '__fish_seen_subcommand_from detect which current list outdated update migrate uninstall prune doctor cache' -a '--json'
+complete -c pinset -f -n '__fish_seen_subcommand_from detect which current list outdated update migrate uninstall prune doctor lock cache' -a '--json'
 complete -c pinset -f -n '__fish_seen_subcommand_from which current' -a '--explain'
-complete -c pinset -f -n '__fish_seen_subcommand_from detect import install which current outdated update migrate uninstall prune doctor' -a '--cwd'
+complete -c pinset -f -n '__fish_seen_subcommand_from detect import install which current outdated update migrate uninstall prune doctor lock' -a '--cwd'
 complete -c pinset -f -n '__fish_seen_subcommand_from import' -a '--force --no-install'
-complete -c pinset -f -n '__fish_seen_subcommand_from use unset install outdated update migrate' -a '--global'
+complete -c pinset -f -n '__fish_seen_subcommand_from use unset install outdated update migrate lock' -a '--global'
 complete -c pinset -f -n '__fish_seen_subcommand_from update migrate uninstall prune cache' -a '--dry-run'
 complete -c pinset -f -a '--help --lang'"#
         }
@@ -2219,6 +2318,7 @@ complete -c pinset -f -a '--help --lang'"#
         'prune' { '--cwd --project --dry-run --json --lang --help' -split ' ' }
         'which' { '--cwd --explain --json --lang --help' -split ' ' }
         'doctor' { '--cwd --json --lang --help' -split ' ' }
+        'lock' { '__LOCK_COMMANDS__ --global --cwd --json --lang --help' -split ' ' }
         'cache' { '__CACHE_COMMANDS__ --lang --help' -split ' ' }
         'venv' { '__VENV_COMMANDS__ --lang --help' -split ' ' }
         'shim' { '__SHIM_COMMANDS__ __PROVIDERS__ --provider --binary --dir --lang --help' -split ' ' }
@@ -2237,6 +2337,7 @@ complete -c pinset -f -a '--help --lang'"#
         .replace("__PROVIDERS__", &providers)
         .replace("__SELECTIONS__", &selections)
         .replace("__SHELLS__", COMPLETION_SHELLS)
+        .replace("__LOCK_COMMANDS__", COMPLETION_LOCK_COMMANDS)
         .replace("__CACHE_COMMANDS__", COMPLETION_CACHE_COMMANDS)
         .replace("__VENV_COMMANDS__", COMPLETION_VENV_COMMANDS)
         .replace("__SHIM_COMMANDS__", COMPLETION_SHIM_COMMANDS)
@@ -2269,7 +2370,7 @@ fn validate_exact_tool_version(
     version: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let provider = runtime_provider(tool).expect("validated provider");
-    match provider.metadata {
+    match provider.capabilities.metadata {
         RuntimeMetadataKind::Node => validate_exact_node_version(version)?,
         RuntimeMetadataKind::Npm => validate_exact_npm_tool_version(tool, version)?,
         RuntimeMetadataKind::Go => {
@@ -2299,7 +2400,7 @@ fn resolve_locked_tool(
     selector: &str,
 ) -> Result<LockedTool, Box<dyn std::error::Error>> {
     let provider = runtime_provider(tool).expect("validated provider");
-    let mut locked = match provider.metadata {
+    let mut locked = match provider.capabilities.metadata {
         RuntimeMetadataKind::Node => {
             let lockfile = node_metadata_client(&pinset_home()?)?
                 .resolve_lock(selector, &format!("pinset {}", env!("CARGO_PKG_VERSION")))?;
@@ -3027,7 +3128,7 @@ fn requested_help_command(arguments: &[OsString]) -> Option<Option<&str>> {
 }
 
 fn command_from_arguments(arguments: &[OsString]) -> Option<&str> {
-    const COMMANDS: [&str; 23] = [
+    const COMMANDS: [&str; 24] = [
         "init",
         "detect",
         "import",
@@ -3049,6 +3150,7 @@ fn command_from_arguments(arguments: &[OsString]) -> Option<&str> {
         "list",
         "uninstall",
         "prune",
+        "lock",
         "cache",
         "venv",
     ];
@@ -3227,7 +3329,7 @@ fn install_tool_from_lock(
         .with_progress_reporter(download_progress_reporter(catalog));
     let target = current_target_for_tool(tool);
     let provider = runtime_provider(tool).expect("locked tool provider exists");
-    let outcome = match provider.installer {
+    let outcome = match provider.capabilities.installer {
         RuntimeInstallKind::Node => {
             let sources = load_source_config(&source_config_path(home))?;
             install_locked_node(&installer, home, &sources, locked_tool, &target)?
@@ -4630,7 +4732,9 @@ fn run_source_command(
         }
         SourceCommands::Test { provider, alias } => {
             let source = config.source(&provider, alias.as_deref())?;
-            let releases = match runtime_provider(&provider).map(|provider| provider.metadata) {
+            let releases = match runtime_provider(&provider)
+                .map(|provider| provider.capabilities.metadata)
+            {
                 Some(RuntimeMetadataKind::Node) => {
                     let client = NodeMetadataClient::for_base_url(&source.base_url)?;
                     let releases = client.available_releases()?;
@@ -5176,7 +5280,8 @@ mod tests {
         ] {
             let script = completion_script(shell);
             for expected in [
-                "pinset", "detect", "import", "node@", "dotnet", "verify", "recreate", "--json",
+                "pinset", "detect", "import", "node@", "dotnet", "lock", "audit", "verify",
+                "recreate", "--json",
             ] {
                 assert!(
                     script.contains(expected),
@@ -5283,6 +5388,32 @@ mod tests {
                 global: true,
                 dry_run: true,
                 ..
+            })
+        ));
+    }
+
+    #[test]
+    fn parses_v16_read_only_lock_audit_options() {
+        let project =
+            Cli::try_parse_from(["pinset", "lock", "audit", "--cwd", "project", "--json"])
+                .expect("project lock audit");
+        assert!(matches!(
+            project.command,
+            Some(Commands::Lock {
+                command: LockCommands::Audit {
+                    global: false,
+                    json: true,
+                    ..
+                }
+            })
+        ));
+
+        let global = Cli::try_parse_from(["pinset", "lock", "audit", "--global"])
+            .expect("global lock audit");
+        assert!(matches!(
+            global.command,
+            Some(Commands::Lock {
+                command: LockCommands::Audit { global: true, .. }
             })
         ));
     }

--- a/crates/pinset/tests/lock_audit_cli.rs
+++ b/crates/pinset/tests/lock_audit_cli.rs
@@ -1,0 +1,161 @@
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::Path,
+    process::{Command, Output},
+};
+
+use pinset_core::{
+    LockedArtifact, LockedArtifactFormat, Lockfile, MVP_NODE_TARGETS, NodeArchiveFormat,
+    ProjectConfig, SourceConfig, current_target_for_tool, plan_node_artifact, save_lockfile,
+    save_project_config,
+};
+use tempfile::tempdir;
+
+#[test]
+fn lock_audit_json_passes_with_a_matching_receipt_and_stable_info_code() {
+    let root = tempdir().expect("temporary root");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    fs::create_dir(&project).expect("project");
+    write_project(&project, "24.0.0");
+    write_receipt(&home, "24.0.0");
+
+    let output = pinset(
+        &project,
+        &home,
+        &["lock", "audit", "--cwd", path_text(&project), "--json"],
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("audit JSON");
+    assert_eq!(json["schema"], 1);
+    assert_eq!(json["command"], "lock.audit");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["data"]["offline"], true);
+    assert_eq!(json["data"]["passed"], true);
+    assert_eq!(json["data"]["summary"]["errors"], 0);
+    assert_eq!(json["data"]["summary"]["warnings"], 0);
+    assert!(
+        json["data"]["findings"]
+            .as_array()
+            .expect("findings")
+            .iter()
+            .any(|finding| finding["reason_code"] == "cache_entry_missing")
+    );
+}
+
+#[test]
+fn lock_audit_uses_exit_one_for_findings_and_does_not_repair_state() {
+    let root = tempdir().expect("temporary root");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    fs::create_dir(&project).expect("project");
+    write_project(&project, "24.0.0");
+    let install = home
+        .join("installs")
+        .join("node")
+        .join("24.0.0")
+        .join(current_target_for_tool("node"));
+    fs::create_dir_all(&install).expect("unowned install");
+
+    let output = pinset(&project, &home, &["lock", "audit", "--json"]);
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("audit JSON");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["data"]["passed"], false);
+    assert!(
+        json["data"]["findings"]
+            .as_array()
+            .expect("findings")
+            .iter()
+            .any(|finding| finding["reason_code"] == "receipt_missing")
+    );
+    assert!(!install.join(".pinset-install.toml").exists());
+}
+
+fn write_project(project: &Path, version: &str) {
+    let config = ProjectConfig {
+        schema: 3,
+        policy: Default::default(),
+        tools: BTreeMap::from([("node".to_owned(), version.to_owned())]),
+    };
+    save_project_config(&project.join("pinset.toml"), &config).expect("project config");
+    save_lockfile(&project.join("pinset.lock"), &node_lockfile(version)).expect("lockfile");
+}
+
+fn write_receipt(home: &Path, version: &str) {
+    let target = current_target_for_tool("node");
+    let plan =
+        plan_node_artifact(&SourceConfig::default(), version, &target).expect("Node artifact plan");
+    let format = match plan.format {
+        NodeArchiveFormat::Zip => "zip",
+        NodeArchiveFormat::TarXz => "tar.xz",
+    };
+    let install = home
+        .join("installs")
+        .join("node")
+        .join(version)
+        .join(&target);
+    fs::create_dir_all(&install).expect("install");
+    fs::write(
+        install.join(".pinset-install.toml"),
+        format!(
+            "schema = 2\ncomplete = true\ntool = \"node\"\nversion = \"{version}\"\ntarget = \"{target}\"\ncanonical_url = \"{url}\"\nselected_source = \"fixture\"\nselected_source_kind = \"official\"\nselected_url = \"{url}\"\nartifact_integrity = \"sha256:{integrity}\"\nartifact_format = \"{format}\"\nbytes_downloaded = 0\n",
+            url = plan.canonical_url,
+            integrity = "ab".repeat(32),
+        ),
+    )
+    .expect("receipt");
+}
+
+fn node_lockfile(version: &str) -> Lockfile {
+    let artifacts = MVP_NODE_TARGETS
+        .into_iter()
+        .map(|target| {
+            let plan = plan_node_artifact(&SourceConfig::default(), version, target)
+                .expect("Node artifact plan");
+            LockedArtifact {
+                target: target.to_owned(),
+                canonical_url: plan.canonical_url,
+                artifact_path: plan.artifact_path,
+                sha256: "ab".repeat(32),
+                integrity: None,
+                format: match plan.format {
+                    NodeArchiveFormat::Zip => LockedArtifactFormat::Zip,
+                    NodeArchiveFormat::TarXz => LockedArtifactFormat::TarXz,
+                },
+                archive_root: plan.archive_root,
+                verification: "nodejs-openpgp-sha256".to_owned(),
+                overlays: Vec::new(),
+            }
+        })
+        .collect();
+    Lockfile::new_node(
+        "pinset lock audit integration test".to_owned(),
+        version.to_owned(),
+        "5BE8A3F6C8A5C01D106C0AD820B1A390B168D356".to_owned(),
+        "official".to_owned(),
+        artifacts,
+    )
+}
+
+fn pinset(project: &Path, home: &Path, arguments: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_pinset"))
+        .args(arguments)
+        .current_dir(project)
+        .env("PINSET_HOME", home)
+        .env("HTTP_PROXY", "http://127.0.0.1:1")
+        .env("HTTPS_PROXY", "http://127.0.0.1:1")
+        .output()
+        .expect("run pinset")
+}
+
+fn path_text(path: &Path) -> &str {
+    path.to_str().expect("UTF-8 test path")
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2,7 +2,7 @@
 
 [English](commands.md) | [简体中文](commands.zh-CN.md) · [README](../README.md)
 
-This document describes the Pinset v1.5 command-line contract. Run `pinset <command> --help` for the exact parser help shipped with your binary.
+This document describes the Pinset v1.6 command-line contract. Run `pinset <command> --help` for the exact parser help shipped with your binary.
 
 ## Conventions
 
@@ -39,6 +39,7 @@ Only commands marked **Yes** below accept `--json`. They write one JSON document
 ### Exit codes
 
 - `0`: Pinset completed successfully.
+- `1`: `pinset lock audit` completed and found one or more errors or warnings that require action. Informational findings alone still return `0`.
 - `2`: Pinset usage, configuration, metadata, integrity, or installation failure.
 - `pinset exec`: returns the exact child-process exit code after a successful launch; Pinset failures before launch return `2`.
 
@@ -207,6 +208,25 @@ Import never reads installed state from another runtime manager, executes manage
 | JSON | **Yes**; command name `migrate`, including source and target schemas. |
 | Exit | `0` after validation/migration; `2` when config and lock cannot be proven consistent. |
 | Key errors | Missing config/lock, unsupported schema, config-lock mismatch, or write failure. |
+
+### `lock audit`
+
+| Field | Description |
+| --- | --- |
+| Purpose | Audit one project or global configuration/lock pair, its current-platform artifacts, relevant content-addressed cache entries, install receipts, and receipt-backed ownership. Project Python selections also audit the `.venv` ownership marker. |
+| Syntax and arguments | `pinset lock audit [--global | --cwd <path>] [--json]`. Project scope is the default and follows normal repository-bounded discovery. |
+| Modifies state | **No.** The command is always read-only, never runs a repair plan, and never contacts Provider metadata or archive services. Cache checks hash only entries referenced by the selected current-platform artifacts. |
+| Example | `pinset lock audit --cwd ./app --json` |
+| JSON | **Yes**; command name `lock.audit`. A completed audit uses `ok: true` even when `data.passed` is false. Stable `reason_code`, `severity`, `category`, `subject`, optional `path`, and optional `repair` fields are returned under `data.findings`. |
+| Exit | `0` when there are no errors or warnings; `1` when the audit completes with action-required errors/warnings; `2` only when command parsing or audit startup itself fails. An optional cache miss is informational and does not cause exit `1`. |
+| Key findings | Missing/invalid/legacy configuration or lock state, selector drift, unsupported Providers, missing current-platform artifacts, missing/corrupt/unsafe cache entries, missing/unsafe installations, invalid or mismatched receipts, and invalid Python environment ownership. |
+
+Stable reason codes are grouped as follows:
+
+- Configuration and lock: `config_missing`, `config_invalid`, `config_schema_legacy`, `lock_missing`, `lock_invalid`, `lock_schema_legacy`, `lock_tool_missing`, `lock_tool_unconfigured`, `lock_selector_mismatch`.
+- Provider and platform: `provider_unsupported`, `provider_audit_unsupported`, `platform_artifact_missing`, `platform_artifact_invalid`.
+- Cache: `cache_entry_missing`, `cache_entry_corrupt`, `cache_entry_unsafe`, `cache_entry_unreadable`.
+- Receipt and ownership: `install_missing`, `install_path_unsafe`, `receipt_missing`, `receipt_unreadable`, `receipt_invalid`, `receipt_schema_legacy`, `receipt_schema_unsupported`, `receipt_incomplete`, `receipt_identity_mismatch`, `receipt_integrity_missing`, `receipt_integrity_mismatch`, `receipt_overlay_mismatch`, `python_environment_missing`, `python_environment_ownership_invalid`.
 
 ### `uninstall`
 
@@ -560,4 +580,6 @@ Custom source configuration currently applies to Node.js, Go, Python, and Flutte
 
 ## Stable protocol boundary
 
-Pinset v1.5 writes schema 3 for project/global configuration and lockfiles. Schema 1/2 remains readable; `pinset migrate` validates and upgrades existing config-lock pairs. Schema 3 deliberately separates the requested selector from the exact resolved lock version and introduces explicit project fallback/boundary policy. Direct downgrade from schema 3 is not supported. Installation receipts retain their own independent schema. A pre-v1 Node lock that records only an HTTPS checksum is rejected with instructions to run `pinset use` again, because it lacks the v1 OpenPGP verification evidence.
+Pinset v1.6 writes schema 3 for project/global configuration and lockfiles. Schema 1/2 remains readable; `pinset migrate` validates and upgrades existing config-lock pairs. Schema 3 deliberately separates the requested selector from the exact resolved lock version and introduces explicit project fallback/boundary policy. Direct downgrade from schema 3 is not supported. Installation receipts retain their own independent schema. A pre-v1 Node lock that records only an HTTPS checksum is rejected with instructions to run `pinset use` again, because it lacks the v1 OpenPGP verification evidence.
+
+The JSON schema 1 envelope remains unchanged in v1.6. `lock.audit` adds a versioned data report within that envelope: automation should branch on stable `reason_code`, `severity`, `data.passed`, and `summary.action_required`, not on human-facing messages or repair prose.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](commands.md) | [简体中文](commands.zh-CN.md) · [README](../README.zh-CN.md)
 
-本文档描述 Pinset v1.5 命令行协议。可以运行 `pinset <command> --help` 查看当前二进制附带的精确参数帮助。
+本文档描述 Pinset v1.6 命令行协议。可以运行 `pinset <command> --help` 查看当前二进制附带的精确参数帮助。
 
 ## 通用约定
 
@@ -39,6 +39,7 @@
 ### 退出码
 
 - `0`：Pinset 成功完成。
+- `1`：`pinset lock audit` 已完成，但发现一个或多个需要处理的错误或警告。只有信息级发现时仍返回 `0`。
 - `2`：Pinset 使用、配置、元数据、完整性或安装失败。
 - `pinset exec`：成功启动子进程后，透传子进程的精确退出码；启动前的 Pinset 错误返回 `2`。
 
@@ -207,6 +208,25 @@
 | JSON | **支持**；命令名为 `migrate`，包含来源与目标 schema。 |
 | 退出码 | 验证/迁移完成为 `0`；无法证明配置与锁一致时为 `2`。 |
 | 关键错误 | 配置/锁缺失、schema 不支持、配置与锁不匹配或写入失败。 |
+
+### `lock audit`
+
+| 字段 | 说明 |
+| --- | --- |
+| 用途 | 审计一组项目或全局配置/锁、当前平台制品、相关内容寻址缓存、安装收据与由收据证明的所有权。项目选择 Python 时还会审计 `.venv` 所有权标记。 |
+| 语法与参数 | `pinset lock audit [--global | --cwd <path>] [--json]`。默认使用项目作用域，并遵循正常的仓库边界发现规则。 |
+| 修改状态 | **否。** 命令始终只读，不会执行修复计划，也不会访问 Provider 元数据或归档服务。缓存检查只散列当前选择、当前平台制品所引用的缓存项。 |
+| 示例 | `pinset lock audit --cwd ./app --json` |
+| JSON | **支持**；命令名为 `lock.audit`。审计正常完成时，即使 `data.passed` 为 false，外层仍为 `ok: true`。`data.findings` 中返回稳定的 `reason_code`、`severity`、`category`、`subject`，以及可选的 `path` 和 `repair`。 |
+| 退出码 | 没有错误或警告时为 `0`；审计完成但存在需处理错误/警告时为 `1`；只有命令解析或审计启动本身失败时才为 `2`。可选缓存缺失属于信息，不会导致退出码 `1`。 |
+| 关键发现 | 配置/锁缺失、无效或过旧，选择器漂移，Provider 不受支持，当前平台制品缺失，缓存缺失/损坏/不安全，安装缺失/不安全，收据无效或不匹配，以及 Python 环境所有权无效。 |
+
+稳定 reason code 按类别如下：
+
+- 配置与锁：`config_missing`、`config_invalid`、`config_schema_legacy`、`lock_missing`、`lock_invalid`、`lock_schema_legacy`、`lock_tool_missing`、`lock_tool_unconfigured`、`lock_selector_mismatch`。
+- Provider 与平台：`provider_unsupported`、`provider_audit_unsupported`、`platform_artifact_missing`、`platform_artifact_invalid`。
+- 缓存：`cache_entry_missing`、`cache_entry_corrupt`、`cache_entry_unsafe`、`cache_entry_unreadable`。
+- 收据与所有权：`install_missing`、`install_path_unsafe`、`receipt_missing`、`receipt_unreadable`、`receipt_invalid`、`receipt_schema_legacy`、`receipt_schema_unsupported`、`receipt_incomplete`、`receipt_identity_mismatch`、`receipt_integrity_missing`、`receipt_integrity_mismatch`、`receipt_overlay_mismatch`、`python_environment_missing`、`python_environment_ownership_invalid`。
 
 ### `uninstall`
 
@@ -560,4 +580,6 @@
 
 ## 稳定协议边界
 
-Pinset v1.5 为项目/全局配置与锁文件写入 schema 3。schema 1/2 仍可读取；`pinset migrate` 会验证并升级现有配置与锁。schema 3 明确区分请求选择器和锁中的精确解析版本，并引入显式项目回退/边界策略；不支持从 schema 3 直接降级。安装收据继续使用自身独立的 schema。仅记录 HTTPS 摘要的 v1 前 Node 锁会被拒绝，并提示重新运行 `pinset use`，因为它缺少 v1 OpenPGP 验证证据。
+Pinset v1.6 为项目/全局配置与锁文件写入 schema 3。schema 1/2 仍可读取；`pinset migrate` 会验证并升级现有配置与锁。schema 3 明确区分请求选择器和锁中的精确解析版本，并引入显式项目回退/边界策略；不支持从 schema 3 直接降级。安装收据继续使用自身独立的 schema。仅记录 HTTPS 摘要的 v1 前 Node 锁会被拒绝，并提示重新运行 `pinset use`，因为它缺少 v1 OpenPGP 验证证据。
+
+v1.6 不修改 JSON schema 1 外层结构。`lock.audit` 只是在该外层内增加一份带版本边界的数据报告：自动化应依据稳定的 `reason_code`、`severity`、`data.passed` 与 `summary.action_required` 分支，不应匹配面向用户的消息或修复说明。

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="1.5.1"
+DEFAULT_VERSION="1.6.0"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -18,7 +18,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 1.5.1.
+  --version VERSION       Install an exact release, for example 1.6.0.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.


### PR DESCRIPTION
## Summary

- add read-only, offline `pinset lock audit` for project and global state
- expose stable audit reason codes, repair plans, JSON output, and exit semantics
- consolidate all nine built-in providers behind a shared capability model
- update CLI completions, tests, command docs, changelog, and release metadata for 1.6.0

## Validation

- `cargo fmt --all -- --check` with the repository-pinned Rust 1.88.0 toolchain
- full build, Clippy, tests, dependency audit, and platform validation delegated to the required GitHub Actions `CI Gate`