### PR TITLE
feat: release Pinset v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.7.0 - 2026-08-20
+
+- Add a common provenance verifier contract and one verification vocabulary for HTTPS checksums, OpenPGP/Minisign signed checksums, npm registry signatures, Sigstore bundles, GitHub Attestations, and SLSA provenance. Node.js OpenPGP validation now runs behind that contract.
+- Add optional project-wide `verification-strength = "checksum" | "signed-checksum" | "provenance"` and `minimum-release-age = "<n>d|h|m|s"` policy fields. Selection, import, update, project install, and lock audit fail closed when the lock cannot satisfy them.
+- Record upstream release timestamps in new locks when the consumed Provider metadata supplies one. Go deliberately reports release age as unavailable because its official downloads JSON has no release timestamp.
+- Reject silent verification downgrades when replacing an existing tool lock, while keeping schema 3 and legacy schema 1/2 reads compatible.
+- Extend Provider capabilities and lock-audit findings with provenance methods, release-time availability, and stable `verification_below_policy`, `release_age_unavailable`, and `release_too_new` reason codes.
+
+No schema migration is required. The optional `released-at` lock field and project policy keys are schema-3-compatible; existing locks remain valid until a project explicitly enables a policy they cannot satisfy.
+
 ## 1.6.0 - 2026-08-20
 
 - Add `pinset lock audit` for project or global scope. It is always read-only and offline, checks config/lock consistency, current-platform artifacts, referenced cache bytes, install receipts, receipt-backed ownership, and project Python environment ownership.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,7 +1976,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "clap",
  "hex",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "atomic-write-file",
  "base64",
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "1.6.0"
+version = "1.7.0"
 authors = ["Future Element"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It manages Node.js, pnpm, Bun, Go, Python, Java, Rust, .NET, and Flutter/Dart th
 - Strict project routing by default, with explicit global inheritance and system fallback policies.
 - Explainable resolution through `current --explain`, `which --explain`, and `doctor`.
 - Direct command routing through one small, runtime-independent shim.
-- Node.js release manifests verified with embedded OpenPGP trust roots before checksums are parsed.
+- Common provenance classification with Node.js OpenPGP and npm registry signatures verified before checksums or integrity values are trusted.
 - Provider integrity checks, safe extraction, atomic installs, ownership-aware uninstall, and a content-addressed download cache.
 - First-class English and Simplified Chinese output, JSON schema 1 for automation, and shell completion.
 - Project-owned Python `.venv` support without requiring shell activation.
@@ -43,7 +43,7 @@ export PATH="$HOME/.local/bin:$PATH"
 Run the same installer again to upgrade. To install an exact release or another absolute directory:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.6.0
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.7.0
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -140,9 +140,12 @@ Schema 3 projects are strict by default: once `pinset.toml` exists, an undeclare
 inherit-global = true
 system-fallback = false
 boundary = "git"
+# Optional, project-wide supply-chain policy:
+verification-strength = "checksum"
+minimum-release-age = "7d"
 ```
 
-Resolution stops at the nearest Git root by default; it crosses that boundary only when the parent configuration itself explicitly sets `boundary = "filesystem"`. Use `pinset current node --explain` or `pinset which node --explain` to inspect every candidate and any traditional files that remain explicit migration inputs only. Existing schema 1/2 state remains readable; preview and perform its schema-only upgrade with `pinset migrate --dry-run` and `pinset migrate`.
+The optional verification policy applies to every selected tool. Strength is ordered as `checksum < signed-checksum < provenance`; Pinset rejects a lock below the configured minimum and refuses to replace an existing lock with weaker evidence. Release age accepts positive `d`, `h`, `m`, or `s` durations and fails closed when an upstream does not publish a usable timestamp. Resolution stops at the nearest Git root by default; it crosses that boundary only when the parent configuration itself explicitly sets `boundary = "filesystem"`.
 
 To migrate an existing repository, inspect traditional files locally first, then import and install their unambiguous selections:
 
@@ -186,7 +189,7 @@ pinset list
 
 Flutter does not publish an official Linux ARM64 SDK archive that matches Pinset's install model, so Pinset returns an explicit unsupported-target error instead of falling back to x64. macOS Intel is not a Pinset v1.0 release target.
 
-All nine built-in Providers declare command layout, metadata resolution, installation, environment, traditional-file discovery, and lock-audit support through one capability model. Resolver, installer, discovery, routing, and audit code consume that shared declaration instead of maintaining separate Provider lists.
+All nine built-in Providers declare command layout, metadata resolution, installation, environment, traditional-file discovery, lock-audit support, verification methods, and release-time availability through one capability model. Node locks currently reach `signed-checksum` through embedded OpenPGP trust roots; pnpm and Bun reach it through npm registry ECDSA signatures. The other built-in Providers currently reach `checksum`. Minisign, Sigstore, GitHub Attestation, and SLSA are distinct recognized methods, but Pinset reports `provenance` only after a Provider actually verifies the corresponding bundle and identity policy.
 
 ## Command reference
 
@@ -194,9 +197,9 @@ See the complete [English command reference](docs/commands.md) or [Chinese comma
 
 For product positioning and trade-offs, see the sourced [Pinset comparison (Chinese)](docs/comparison.zh-CN.md).
 
-## v1.6
+## v1.7
 
-v1.6 delivers the first lock-audit and security-foundation release: the offline/read-only `pinset lock audit`, stable automation reason codes, explicit repair plans, and one capability model covering all nine built-in Providers. It deliberately reports state drift without changing it; provenance policy and automatic remediation remain outside this release.
+v1.7 delivers general provenance policy: a common verifier contract, explicit proof strengths, release-age enforcement, Provider capability declarations, stable audit findings, and downgrade protection. It keeps schema 3 and does not treat an HTTPS checksum or an advertised signature URL as verified provenance.
 
 ## Future Roadmap
 
@@ -204,7 +207,6 @@ The roadmap describes direction, not promised versions or dates.
 
 | Version | Theme | Planned work |
 | --- | --- | --- |
-| v1.7 | General provenance verification | Move the existing Node.js OpenPGP verification behind a common verifier interface, then add signed checksums, Minisign, Sigstore, GitHub Attestations, and SLSA provenance where upstreams actually provide them. Add optional verification-strength and `minimum-release-age` policies, and reject silent verification downgrades. |
 | v1.8 | Constrained Provider Registry | Preview declarative Provider manifests and a signed Registry. Third-party Providers must reuse Pinset's HTTPS, integrity, safe extraction, path, and ownership rules and cannot run arbitrary Shell/Lua or post-install scripts. Add toolchain dependency graphs, a composite `PATH`, and cycle detection so tools such as pnpm run with the correct runtime. |
 | v1.9 | Developer experience and distribution | Add `pinset x <tool>@<selector> -- <command>` for verified one-shot execution without modifying project state. Provide a GitHub Action, Renovate integration, VS Code schemas, Dev Container examples, and official Winget, Scoop, and Homebrew distribution. |
 | Ongoing | Platforms and quality | Add platforms and architectures when upstreams publish suitable artifacts. Continue cross-platform CI, security audits, malicious-input regressions, signed tags, `SHA256SUMS`, SBOMs, and build-provenance verification. |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,7 +17,7 @@ Pinset 是一个行为可预测、理解项目边界的多语言运行时版本�
 - 项目内默认严格路由，只有显式策略才允许继承全局版本或回退系统命令。
 - 通过 `current --explain`、`which --explain` 与 `doctor` 解释完整解析过程。
 - 通过一个轻量、与运行时无关的 shim 路由命令。
-- 解析摘要之前，先使用内嵌 OpenPGP 信任根验证 Node.js 发布清单。
+- 使用统一的来源证明分级；在信任摘要或完整性值之前，先验证 Node.js OpenPGP 与 npm registry 签名。
 - Provider 完整性校验、安全解压、原子安装、带所有权检查的卸载，以及内容寻址下载缓存。
 - 原生支持英文和简体中文输出、自动化用 JSON schema 1 与 Shell 补全。
 - 支持项目所有的 Python `.venv`，无需激活 Shell 环境。
@@ -43,7 +43,7 @@ export PATH="$HOME/.local/bin:$PATH"
 再次运行同一安装脚本即可升级。也可以安装指定版本或使用其他绝对目录：
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.6.0
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.7.0
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -140,9 +140,12 @@ schema 3 项目默认严格：只要存在 `pinset.toml`，未声明的工具就
 inherit-global = true
 system-fallback = false
 boundary = "git"
+# 可选的项目级供应链策略：
+verification-strength = "checksum"
+minimum-release-age = "7d"
 ```
 
-默认解析边界是最近的 Git 根目录；只有父级配置自身明确设置 `boundary = "filesystem"` 时，才允许跨过 Git 边界。使用 `pinset current node --explain` 或 `pinset which node --explain` 可以查看每个候选，以及那些只作为显式迁移输入的传统配置文件。schema 1/2 状态仍可读取；可通过 `pinset migrate --dry-run` 预览，再运行 `pinset migrate` 完成仅格式层面的升级。
+可选验证策略会应用到项目选择的每个工具，强度顺序为 `checksum < signed-checksum < provenance`。Pinset 会拒绝低于最低强度的锁，也不会用更弱证据静默替换已有锁。发布年龄支持正数 `d`、`h`、`m`、`s` 时长；上游没有提供可用时间时会失败关闭。默认解析边界仍是最近的 Git 根目录，只有父级配置明确设置 `boundary = "filesystem"` 才跨越该边界。
 
 迁移现有仓库时，先在本地检查传统配置，再导入并安装其中无歧义的选择：
 
@@ -186,7 +189,7 @@ pinset list
 
 Flutter 没有发布符合 Pinset 安装模型的官方 Linux ARM64 SDK 归档，因此 Pinset 会返回明确的不支持目标错误，不会回退到 x64。macOS Intel 不是 Pinset v1.0 的发布目标。
 
-9 个内置 Provider 都通过同一 capability model 声明命令布局、元数据解析、安装、环境、传统文件发现与锁审计支持。解析器、安装器、发现、路由与审计逻辑共同消费这份声明，不再分别维护 Provider 列表。
+9 个内置 Provider 都通过同一 capability model 声明命令布局、元数据解析、安装、环境、传统文件发现、锁审计、验证方法与发布时间能力。Node 通过内嵌 OpenPGP 信任根达到 `signed-checksum`，pnpm 与 Bun 通过 npm registry ECDSA 签名达到该等级；其他内置 Provider 当前为 `checksum`。Minisign、Sigstore、GitHub Attestation 与 SLSA 是彼此独立的已识别方法，但只有 Provider 真正验证对应 bundle 和身份策略后，Pinset 才会报告 `provenance`。
 
 ## 命令文档
 
@@ -194,9 +197,9 @@ Flutter 没有发布符合 Pinset 安装模型的官方 Linux ARM64 SDK 归档�
 
 产品定位与取舍见带官方来源的 [Pinset 横向对比](docs/comparison.zh-CN.md)。
 
-## v1.6
+## v1.7
 
-v1.6 交付第一阶段锁审计与安全基础：离线/只读的 `pinset lock audit`、稳定的自动化 reason code、明确但不自动执行的修复计划，以及覆盖全部 9 个内置 Provider 的统一 capability model。来源证明策略与自动修复不属于本版本范围。
+v1.7 交付通用来源证明策略：统一 verifier 接口、明确的证明强度、发布年龄约束、Provider 能力声明、稳定审计发现与降级保护。它继续使用 schema 3，也不会把 HTTPS 摘要或仅声明了签名链接的制品包装成已验证 provenance。
 
 ## 未来规划
 
@@ -204,7 +207,6 @@ v1.6 交付第一阶段锁审计与安全基础：离线/只读的 `pinset lock 
 
 | 版本 | 主题 | 计划内容 |
 | --- | --- | --- |
-| v1.7 | 通用来源证明 | 把 Node.js 已有的 OpenPGP 验证迁移到统一验证接口，并按上游实际能力逐步支持 signed checksum、Minisign、Sigstore、GitHub Attestation 与 SLSA provenance；增加可选的验证强度和 `minimum-release-age` 策略，禁止静默降低验证能力。 |
 | v1.8 | 受约束的 Provider Registry | 预览纯声明式 Provider manifest 与签名 Registry；第三方 Provider 必须复用 Pinset 的 HTTPS、完整性、安全解压、路径和所有权规则，不能执行任意 Shell/Lua 或 post-install 脚本；增加工具链依赖图、composite `PATH` 与循环检测，支持 pnpm 等工具与正确运行时组合。 |
 | v1.9 | 开发者体验与正式分发 | 增加不修改项目状态的 `pinset x <tool>@<selector> -- <command>`；补齐 GitHub Action、Renovate、VS Code schema、Dev Container 示例，以及 Winget、Scoop、Homebrew 等官方分发渠道。 |
 | 持续进行 | 平台与质量 | 在上游提供合适制品时扩展平台和架构；持续执行跨平台 CI、安全审计、恶意输入回归、签名标签、`SHA256SUMS`、SBOM 与构建来源证明验证。 |

--- a/crates/pinset-core/src/config.rs
+++ b/crates/pinset-core/src/config.rs
@@ -13,10 +13,12 @@ use std::sync::Mutex;
 use atomic_write_file::AtomicWriteFile;
 use serde::{Deserialize, Serialize};
 
-use crate::{Error, Result};
+use crate::{Error, MinimumReleaseAge, Result, VerificationStrength};
 
+#[cfg(feature = "lockfile")]
+use crate::Lockfile;
 #[cfg(all(feature = "project-write", feature = "lockfile"))]
-use crate::{Lockfile, lockfile_path, save_lockfile, validate_lock_matches_tools};
+use crate::{lockfile_path, save_lockfile, validate_lock_matches_tools};
 
 pub const PROJECT_CONFIG_FILENAME: &str = "pinset.toml";
 pub const PROJECT_CONFIG_SCHEMA: u32 = 3;
@@ -54,6 +56,10 @@ pub struct ProjectPolicy {
     pub inherit_global: bool,
     pub system_fallback: bool,
     pub boundary: ProjectBoundary,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification_strength: Option<VerificationStrength>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minimum_release_age: Option<MinimumReleaseAge>,
 }
 
 impl Default for ProjectPolicy {
@@ -62,6 +68,8 @@ impl Default for ProjectPolicy {
             inherit_global: false,
             system_fallback: false,
             boundary: ProjectBoundary::Git,
+            verification_strength: None,
+            minimum_release_age: None,
         }
     }
 }
@@ -263,6 +271,7 @@ pub fn save_project_config(path: &Path, config: &ProjectConfig) -> Result<()> {
 #[cfg(all(feature = "project-write", feature = "lockfile"))]
 pub fn save_project_state(path: &Path, config: &ProjectConfig, lockfile: &Lockfile) -> Result<()> {
     validate_lock_matches_tools(lockfile, &config.tools, path)?;
+    validate_project_lock_policy(config, lockfile, std::time::SystemTime::now())?;
     let _guard = PROJECT_STATE_WRITE_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -271,6 +280,23 @@ pub fn save_project_state(path: &Path, config: &ProjectConfig, lockfile: &Lockfi
     // selection remains active and lock-dependent operations fail until this is retried.
     save_lockfile(&lockfile_path(path), lockfile)?;
     save_project_config(path, config)
+}
+
+#[cfg(feature = "lockfile")]
+pub fn validate_project_lock_policy(
+    config: &ProjectConfig,
+    lockfile: &Lockfile,
+    now: std::time::SystemTime,
+) -> Result<()> {
+    for tool in &lockfile.tools {
+        crate::validate_tool_policy(
+            tool,
+            config.policy.verification_strength,
+            config.policy.minimum_release_age,
+            now,
+        )?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -461,6 +487,41 @@ mod tests {
                 .map(String::as_str),
             Some("24.0.0")
         );
+    }
+
+    #[test]
+    fn parses_optional_provenance_policy_without_changing_schema_three() {
+        let root = tempdir().expect("project");
+        let path = root.path().join(PROJECT_CONFIG_FILENAME);
+        fs::write(
+            &path,
+            "schema = 3\n[policy]\nverification-strength = \"signed-checksum\"\nminimum-release-age = \"7d\"\n[tools]\nnode = \"24\"\n",
+        )
+        .expect("policy config");
+
+        let config = load_project_config(&path).expect("load policy");
+        assert_eq!(
+            config.policy.verification_strength,
+            Some(VerificationStrength::SignedChecksum)
+        );
+        assert_eq!(
+            config
+                .policy
+                .minimum_release_age
+                .expect("minimum age")
+                .as_duration(),
+            std::time::Duration::from_secs(7 * 86_400)
+        );
+
+        fs::write(
+            &path,
+            "schema = 3\n[policy]\nminimum-release-age = \"0d\"\n[tools]\n",
+        )
+        .expect("invalid policy config");
+        assert!(matches!(
+            load_project_config(&path),
+            Err(Error::ParseProjectConfig { .. })
+        ));
     }
 
     #[cfg(all(feature = "project-write", feature = "lockfile"))]

--- a/crates/pinset-core/src/dotnet_metadata.rs
+++ b/crates/pinset-core/src/dotnet_metadata.rs
@@ -178,6 +178,7 @@ impl DotnetMetadataClient {
             requested: version.clone(),
             version,
             provider: "microsoft-dotnet-sdk".to_owned(),
+            released_at: Some(release.date.clone()),
             metadata: BTreeMap::from([
                 ("channel".to_owned(), release.channel),
                 ("release_date".to_owned(), release.date),

--- a/crates/pinset-core/src/error.rs
+++ b/crates/pinset-core/src/error.rs
@@ -825,6 +825,38 @@ pub enum Error {
         reason: String,
     },
 
+    #[error(
+        "verification policy for {tool} requires {required}, but the lock provides only {actual}"
+    )]
+    VerificationPolicyViolation {
+        tool: String,
+        required: String,
+        actual: String,
+    },
+
+    #[error(
+        "refusing to downgrade {tool} verification from {previous} to {next}; keep the stronger evidence or create a fresh lock explicitly"
+    )]
+    VerificationDowngrade {
+        tool: String,
+        previous: String,
+        next: String,
+    },
+
+    #[error(
+        "minimum release age cannot be enforced for {tool}: the Provider supplied no release timestamp"
+    )]
+    ReleaseAgeUnavailable { tool: String },
+
+    #[error(
+        "{tool} release {released_at} is newer than the required minimum release age {required}"
+    )]
+    ReleaseTooNew {
+        tool: String,
+        released_at: String,
+        required: String,
+    },
+
     #[error("failed to create shim directory {path}: {source}")]
     CreateShimDirectory {
         path: PathBuf,

--- a/crates/pinset-core/src/flutter_metadata.rs
+++ b/crates/pinset-core/src/flutter_metadata.rs
@@ -48,6 +48,8 @@ struct FlutterIndexRelease {
     archive: String,
     #[serde(default)]
     sha256: String,
+    #[serde(default)]
+    release_date: String,
 }
 
 #[derive(Debug)]
@@ -55,6 +57,7 @@ struct SupportedFlutterRelease {
     version: String,
     dart_version: String,
     release_hash: String,
+    release_date: Option<String>,
     artifacts: Vec<(String, FlutterIndexRelease)>,
 }
 
@@ -138,6 +141,7 @@ impl FlutterMetadataClient {
             requested: release.version.clone(),
             version: release.version,
             provider: "flutter-official".to_owned(),
+            released_at: release.release_date,
             metadata,
             artifacts,
         })
@@ -271,12 +275,16 @@ fn parse_indexes(
             .next()
             .expect("four required Flutter artifacts");
         if artifacts.values().any(|artifact| {
-            artifact.hash != first.hash || artifact.dart_sdk_version != first.dart_sdk_version
+            artifact.hash != first.hash
+                || artifact.dart_sdk_version != first.dart_sdk_version
+                || artifact.release_date != first.release_date
         }) {
             continue;
         }
         let release_hash = first.hash.clone();
         let dart_version = first.dart_sdk_version.clone();
+        let release_date =
+            crate::valid_release_time(&first.release_date).then(|| first.release_date.clone());
         let artifacts = FLUTTER_TARGETS
             .iter()
             .map(|target| {
@@ -290,6 +298,7 @@ fn parse_indexes(
             version,
             dart_version,
             release_hash,
+            release_date,
             artifacts,
         });
     }
@@ -408,6 +417,7 @@ mod tests {
         assert_eq!(locked.version, "3.47.0");
         assert_eq!(locked.metadata["channel"], "stable");
         assert_eq!(locked.metadata["dart_version"], "3.13.0");
+        assert_eq!(locked.released_at.as_deref(), Some("2026-08-05T12:00:00Z"));
         assert_eq!(locked.artifacts.len(), FLUTTER_TARGETS.len());
         assert!(locked.artifacts.iter().all(|artifact| {
             artifact.sha256 == "ab".repeat(32)
@@ -446,7 +456,8 @@ mod tests {
                 "dart_sdk_version": "3.13.0",
                 "dart_sdk_arch": plan.dart_arch,
                 "archive": plan.release_path,
-                "sha256": sha256
+                "sha256": sha256,
+                "release_date": "2026-08-05T12:00:00Z"
             })
         };
         let linux = serde_json::json!({"releases": [entry("linux-x86_64")]}).to_string();

--- a/crates/pinset-core/src/go_metadata.rs
+++ b/crates/pinset-core/src/go_metadata.rs
@@ -122,6 +122,8 @@ impl GoMetadataClient {
             requested: release.version.clone(),
             version: release.version,
             provider: "go-official".to_owned(),
+            // The official Go downloads JSON does not publish a release timestamp.
+            released_at: None,
             metadata: BTreeMap::new(),
             artifacts,
         })

--- a/crates/pinset-core/src/integrity.rs
+++ b/crates/pinset-core/src/integrity.rs
@@ -90,7 +90,6 @@ impl ArtifactIntegrity {
         self.canonical_digest(&self.bytes)
     }
 
-    #[cfg(feature = "installer")]
     pub(crate) fn canonical_digest(&self, bytes: &[u8]) -> String {
         match self.algorithm {
             IntegrityAlgorithm::Sha256 => format!("sha256:{}", hex::encode(bytes)),

--- a/crates/pinset-core/src/java_metadata.rs
+++ b/crates/pinset-core/src/java_metadata.rs
@@ -207,6 +207,7 @@ impl JavaMetadataClient {
             requested: version.clone(),
             version,
             provider: "adoptium-temurin".to_owned(),
+            released_at: Some(release.date),
             metadata,
             artifacts,
         })

--- a/crates/pinset-core/src/lib.rs
+++ b/crates/pinset-core/src/lib.rs
@@ -59,6 +59,7 @@ mod npm_metadata;
 mod npm_runtime;
 #[cfg(feature = "project-discovery")]
 mod project_discovery;
+mod provenance;
 #[cfg(feature = "python-metadata")]
 mod python_metadata;
 #[cfg(feature = "python-provider")]
@@ -87,6 +88,8 @@ mod user_settings;
 
 #[cfg(all(feature = "project-write", feature = "lockfile"))]
 pub use config::save_project_state;
+#[cfg(feature = "lockfile")]
+pub use config::validate_project_lock_policy;
 pub use config::{
     PROJECT_CONFIG_FILENAME, PROJECT_CONFIG_SCHEMA, ProjectBoundary, ProjectConfig, ProjectContext,
     ProjectPolicy, find_optional_project_config, find_project_config, find_project_context,
@@ -197,6 +200,11 @@ pub use npm_runtime::install_locked_npm_tool;
 pub use project_discovery::{
     DiscoveryFinding, DiscoveryKind, DiscoveryReport, DiscoveryStatus, scan_project_sources,
 };
+pub use provenance::{
+    MinimumReleaseAge, VerificationMethod, VerificationStrength, tool_verification_strength,
+    valid_release_time, validate_tool_policy, validate_verification_transition,
+    verification_method,
+};
 #[cfg(feature = "python-metadata")]
 pub use python_metadata::{PythonMetadataClient, PythonRelease};
 #[cfg(feature = "python-provider")]
@@ -233,8 +241,9 @@ pub use runtime_lifecycle::{
 };
 pub use runtime_provider::{
     RuntimeCommandLayout, RuntimeDiscoveryKind, RuntimeDiscoveryRule, RuntimeEnvironmentKind,
-    RuntimeInstallKind, RuntimeLockAuditKind, RuntimeMetadataKind, RuntimeProvider,
-    RuntimeProviderCapabilities, runtime_provider, runtime_provider_for_command, runtime_providers,
+    RuntimeInstallKind, RuntimeLockAuditKind, RuntimeMetadataKind, RuntimeProvenanceCapabilities,
+    RuntimeProvider, RuntimeProviderCapabilities, runtime_provider, runtime_provider_for_command,
+    runtime_providers,
 };
 #[cfg(feature = "rust-metadata")]
 pub use rust_metadata::{RustMetadataClient, RustRelease};

--- a/crates/pinset-core/src/lock_audit.rs
+++ b/crates/pinset-core/src/lock_audit.rs
@@ -8,16 +8,18 @@ use std::{
     fs,
     io::ErrorKind,
     path::{Path, PathBuf},
+    time::SystemTime,
 };
 
 use serde::{Deserialize, Serialize};
 
 use crate::{
     ArtifactIntegrity, Error, GLOBAL_STATE_SCHEMA, LOCKFILE_SCHEMA, LockedArtifact, Lockfile,
-    PROJECT_CONFIG_FILENAME, PROJECT_CONFIG_SCHEMA, RuntimeLockAuditKind, current_target_for_tool,
-    download_cache::verify_download_cache_integrity, find_optional_project_config,
-    global_config_path, global_lockfile_path, load_global_config, load_lockfile,
-    load_project_config, load_project_python_environment, lockfile_path, runtime_provider,
+    MinimumReleaseAge, PROJECT_CONFIG_FILENAME, PROJECT_CONFIG_SCHEMA, RuntimeLockAuditKind,
+    VerificationStrength, current_target_for_tool, download_cache::verify_download_cache_integrity,
+    find_optional_project_config, global_config_path, global_lockfile_path, load_global_config,
+    load_lockfile, load_project_config, load_project_python_environment, lockfile_path,
+    runtime_provider,
 };
 
 const MAX_AUDIT_RECEIPT_BYTES: u64 = 64 * 1024;
@@ -46,6 +48,7 @@ pub enum LockAuditCategory {
     Cache,
     InstallReceipt,
     Ownership,
+    Provenance,
 }
 
 /// Stable identifiers intended for scripts and policy checks. Messages and repair text are
@@ -84,6 +87,9 @@ pub enum LockAuditReasonCode {
     ReceiptOverlayMismatch,
     PythonEnvironmentMissing,
     PythonEnvironmentOwnershipInvalid,
+    VerificationBelowPolicy,
+    ReleaseAgeUnavailable,
+    ReleaseTooNew,
 }
 
 impl LockAuditReasonCode {
@@ -120,6 +126,9 @@ impl LockAuditReasonCode {
             Self::ReceiptOverlayMismatch => "receipt_overlay_mismatch",
             Self::PythonEnvironmentMissing => "python_environment_missing",
             Self::PythonEnvironmentOwnershipInvalid => "python_environment_ownership_invalid",
+            Self::VerificationBelowPolicy => "verification_below_policy",
+            Self::ReleaseAgeUnavailable => "release_age_unavailable",
+            Self::ReleaseTooNew => "release_too_new",
         }
     }
 }
@@ -192,6 +201,8 @@ impl LockAuditReport {
 struct ConfigSelection {
     schema: u32,
     tools: BTreeMap<String, String>,
+    verification_strength: Option<VerificationStrength>,
+    minimum_release_age: Option<MinimumReleaseAge>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -279,10 +290,14 @@ fn load_config_selection(
         LockAuditScope::Project => load_project_config(path).map(|config| ConfigSelection {
             schema: config.schema,
             tools: config.tools,
+            verification_strength: config.policy.verification_strength,
+            minimum_release_age: config.policy.minimum_release_age,
         }),
         LockAuditScope::Global => load_global_config(path).map(|config| ConfigSelection {
             schema: config.schema,
             tools: config.tools,
+            verification_strength: None,
+            minimum_release_age: None,
         }),
     };
     match result {
@@ -489,6 +504,40 @@ fn audit_config_lock_pair(
                 Some(repair("regenerate the lockfile from configuration", None)),
             ));
             continue;
+        }
+        if let Err(error) = crate::validate_tool_policy(
+            locked,
+            config.verification_strength,
+            config.minimum_release_age,
+            SystemTime::now(),
+        ) {
+            let (reason_code, action) = match error {
+                Error::VerificationPolicyViolation { .. } => (
+                    LockAuditReasonCode::VerificationBelowPolicy,
+                    "select a release with stronger verification evidence or lower the explicit policy",
+                ),
+                Error::ReleaseAgeUnavailable { .. } => (
+                    LockAuditReasonCode::ReleaseAgeUnavailable,
+                    "remove the minimum release age policy or select a Provider that publishes release time",
+                ),
+                Error::ReleaseTooNew { .. } => (
+                    LockAuditReasonCode::ReleaseTooNew,
+                    "wait until the release satisfies the configured minimum age or select an older release",
+                ),
+                _ => (
+                    LockAuditReasonCode::LockInvalid,
+                    "regenerate the lockfile from trusted metadata",
+                ),
+            };
+            report.push(finding(
+                reason_code,
+                LockAuditSeverity::Error,
+                LockAuditCategory::Provenance,
+                tool,
+                Some(&lock_path),
+                error.to_string(),
+                Some(repair(action, None)),
+            ));
         }
         audit_locked_tool(pinset_home, scope, config_path, locked, report);
     }
@@ -1200,6 +1249,27 @@ mod tests {
             })
         );
         assert!(!home.exists());
+    }
+
+    #[test]
+    fn provenance_policy_has_a_stable_audit_reason_code() {
+        let root = tempdir().expect("temporary root");
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        fs::create_dir(&project).expect("project");
+        fs::write(
+            project.join(PROJECT_CONFIG_FILENAME),
+            "schema = 3\n\n[policy]\nverification-strength = \"provenance\"\n\n[tools]\nnode = \"24.0.0\"\n",
+        )
+        .expect("project config");
+        save_lockfile(&project.join("pinset.lock"), &node_lockfile("24.0.0")).expect("lockfile");
+
+        let report = audit_project_lock(&home, &project);
+
+        assert!(report.findings.iter().any(|finding| {
+            finding.reason_code == LockAuditReasonCode::VerificationBelowPolicy
+                && finding.category == LockAuditCategory::Provenance
+        }));
     }
 
     #[test]

--- a/crates/pinset-core/src/lockfile.rs
+++ b/crates/pinset-core/src/lockfile.rs
@@ -43,6 +43,12 @@ pub struct LockedTool {
     pub requested: String,
     pub version: String,
     pub provider: String,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "released-at"
+    )]
+    pub released_at: Option<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub metadata: BTreeMap<String, String>,
     #[serde(rename = "artifact")]
@@ -113,6 +119,7 @@ impl Lockfile {
                 requested: version.clone(),
                 version,
                 provider: "nodejs-official".to_owned(),
+                released_at: None,
                 metadata: BTreeMap::from([
                     (
                         "signature_primary_fingerprint".to_owned(),
@@ -133,13 +140,15 @@ impl Lockfile {
         self.tools.iter().find(|tool| tool.name == name)
     }
 
-    pub fn upsert_tool(&mut self, tool: LockedTool) {
+    pub fn upsert_tool(&mut self, tool: LockedTool) -> Result<()> {
         if let Some(existing) = self.tools.iter_mut().find(|item| item.name == tool.name) {
+            crate::validate_verification_transition(existing, &tool)?;
             *existing = tool;
         } else {
             self.tools.push(tool);
         }
         self.schema = LOCKFILE_SCHEMA;
+        Ok(())
     }
 
     pub fn remove_tool(&mut self, name: &str) {
@@ -325,6 +334,15 @@ fn validate_lockfile(lockfile: &Lockfile) -> Result<()> {
 }
 
 fn validate_locked_tool(tool: &LockedTool) -> Result<()> {
+    if tool
+        .released_at
+        .as_deref()
+        .is_some_and(|value| !crate::valid_release_time(value))
+    {
+        return Err(Error::InvalidLockfile {
+            reason: format!("{} has an invalid released-at timestamp", tool.name),
+        });
+    }
     let provider_supported = matches!(
         (tool.name.as_str(), tool.provider.as_str()),
         ("node", "nodejs-official")
@@ -1310,6 +1328,7 @@ mod tests {
             requested: "1.25.1".to_owned(),
             version: "1.25.1".to_owned(),
             provider: "go-official".to_owned(),
+            released_at: None,
             metadata: BTreeMap::new(),
             artifacts: artifacts.clone(),
         };
@@ -1327,6 +1346,7 @@ mod tests {
             requested: "1.25.1".to_owned(),
             version: "1.25.1".to_owned(),
             provider: "go-official".to_owned(),
+            released_at: None,
             metadata: BTreeMap::new(),
             artifacts: artifacts.into_iter().skip(1).collect(),
         };
@@ -1351,6 +1371,7 @@ mod tests {
             requested: "3.47.0".to_owned(),
             version: "3.47.0".to_owned(),
             provider: "flutter-official".to_owned(),
+            released_at: None,
             metadata,
             artifacts: artifacts.clone(),
         };
@@ -1403,6 +1424,7 @@ mod tests {
             requested: distribution.to_owned(),
             version: distribution.to_owned(),
             provider: "python-build-standalone".to_owned(),
+            released_at: None,
             metadata,
             artifacts: artifacts.clone(),
         };
@@ -1455,6 +1477,7 @@ mod tests {
             requested: version.to_owned(),
             version: version.to_owned(),
             provider: "adoptium-temurin".to_owned(),
+            released_at: None,
             metadata,
             artifacts: artifacts.clone(),
         };
@@ -1491,6 +1514,7 @@ mod tests {
             requested: version.to_owned(),
             version: version.to_owned(),
             provider: "rust-official".to_owned(),
+            released_at: None,
             metadata: BTreeMap::from([
                 ("channel".to_owned(), "stable".to_owned()),
                 ("components".to_owned(), RUST_COMPONENTS.to_owned()),
@@ -1529,6 +1553,7 @@ mod tests {
             requested: version.to_owned(),
             version: version.to_owned(),
             provider: "microsoft-dotnet-sdk".to_owned(),
+            released_at: None,
             metadata: BTreeMap::from([
                 ("channel".to_owned(), "10.0".to_owned()),
                 ("release_date".to_owned(), "2026-08-11".to_owned()),
@@ -1581,6 +1606,7 @@ mod tests {
             requested: version.to_owned(),
             version: version.to_owned(),
             provider: "pnpm-npm".to_owned(),
+            released_at: None,
             metadata: BTreeMap::new(),
             artifacts: vec![artifact],
         }

--- a/crates/pinset-core/src/node_metadata.rs
+++ b/crates/pinset-core/src/node_metadata.rs
@@ -157,14 +157,25 @@ impl NodeMetadataClient {
     }
 
     pub fn resolve_lock(&self, selector: &str, generated_by: &str) -> Result<Lockfile> {
-        let version = self.resolve_version_selector(selector)?;
-        self.resolve_exact_lock(&version, generated_by)
+        let release = self.resolve_release(selector)?;
+        let mut lockfile = self.resolve_exact_lock(&release.version, generated_by)?;
+        lockfile
+            .tools
+            .first_mut()
+            .expect("generated Node lock contains node")
+            .released_at = Some(release.date);
+        Ok(lockfile)
     }
 
     pub fn resolve_version_selector(&self, selector: &str) -> Result<String> {
         if crate::validate_exact_node_version(selector).is_ok() {
             return Ok(selector.to_owned());
         }
+        Ok(self.resolve_release(selector)?.version)
+    }
+
+    fn resolve_release(&self, selector: &str) -> Result<NodeRelease> {
+        let exact = crate::validate_exact_node_version(selector).is_ok();
 
         let normalized = selector.trim().to_ascii_lowercase();
         let numeric_parts = normalized.split('.').collect::<Vec<_>>();
@@ -172,7 +183,7 @@ impl NodeMetadataClient {
             && numeric_parts
                 .iter()
                 .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()));
-        if normalized != "current" && normalized != "lts" && !numeric_selector {
+        if normalized != "current" && normalized != "lts" && !numeric_selector && !exact {
             return Err(Error::InvalidNodeSelector {
                 selector: selector.to_owned(),
             });
@@ -192,6 +203,9 @@ impl NodeMetadataClient {
         self.available_releases()?
             .into_iter()
             .find(|release| {
+                if exact {
+                    return release.version == selector;
+                }
                 if normalized == "current" {
                     return true;
                 }
@@ -205,7 +219,6 @@ impl NodeMetadataClient {
                     .expect("numeric selector has parsed parts");
                 tuple.0 == requested[0] && (requested.len() == 1 || tuple.1 == requested[1])
             })
-            .map(|release| release.version)
             .ok_or_else(|| Error::NodeSelectorNotFound {
                 selector: selector.to_owned(),
             })
@@ -469,6 +482,28 @@ mod tests {
     }
 
     #[test]
+    fn generated_locks_record_the_indexed_release_date() {
+        let index = format!(
+            r#"[{{"version":"v24.19.0","date":"2026-07-28","files":{REQUIRED_FILES_JSON},"lts":"Krypton","security":false}}]"#
+        );
+        let manifest =
+            include_str!("../tests/fixtures/node-v24.19.0-SHASUMS256.txt.asc").to_owned();
+        let (base_url, server) = serve_responses(vec![index, manifest]);
+
+        let lockfile = test_client(&base_url)
+            .resolve_lock("24.19.0", "pinset test")
+            .expect("dated signed lock");
+        server.join().expect("server").expect("responses");
+
+        assert_eq!(
+            lockfile
+                .tool("node")
+                .and_then(|tool| tool.released_at.as_deref()),
+            Some("2026-07-28")
+        );
+    }
+
+    #[test]
     fn available_releases_are_sorted_and_expose_lts_and_security_metadata() {
         let index = format!(
             r#"[
@@ -627,6 +662,26 @@ mod tests {
                 body.len(),
                 body
             )?;
+            Ok(())
+        });
+        (format!("http://{address}/"), handle)
+    }
+
+    fn serve_responses(bodies: Vec<String>) -> (String, thread::JoinHandle<std::io::Result<()>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind server");
+        let address = listener.local_addr().expect("server address");
+        let handle = thread::spawn(move || -> std::io::Result<()> {
+            for body in bodies {
+                let (mut stream, _) = listener.accept()?;
+                let mut request = [0_u8; 4096];
+                let _ = stream.read(&mut request)?;
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                )?;
+            }
             Ok(())
         });
         (format!("http://{address}/"), handle)

--- a/crates/pinset-core/src/node_trust.rs
+++ b/crates/pinset-core/src/node_trust.rs
@@ -7,7 +7,10 @@ use pgp::{
     types::KeyDetails,
 };
 
-use crate::{Error, Result};
+use crate::{
+    Error, Result,
+    provenance::{ProvenanceVerifier, VerifiedPayload},
+};
 
 const NODE_RELEASE_KEYS: &str = include_str!("../assets/node-release-keys.asc");
 const NODE_RELEASE_KEYS_SOURCE: &str =
@@ -60,6 +63,42 @@ pub(crate) struct VerifiedNodeManifest {
 }
 
 pub(crate) fn verify_node_manifest(armored: &str) -> Result<VerifiedNodeManifest> {
+    let verifier = NodeOpenPgpVerifier;
+    debug_assert_eq!(
+        verifier.method(),
+        crate::VerificationMethod::OpenPgpSignedChecksum
+    );
+    let verified = verifier.verify(armored.as_bytes())?;
+    Ok(VerifiedNodeManifest {
+        text: String::from_utf8(verified.payload).map_err(|_| Error::NodeSignatureInvalid {
+            reason: "verified manifest is not UTF-8".to_owned(),
+        })?,
+        signer_fingerprint: verified.signer.ok_or_else(|| Error::NodeSignatureInvalid {
+            reason: "verified manifest did not identify its signer".to_owned(),
+        })?,
+    })
+}
+
+struct NodeOpenPgpVerifier;
+
+impl ProvenanceVerifier for NodeOpenPgpVerifier {
+    fn method(&self) -> crate::VerificationMethod {
+        crate::VerificationMethod::OpenPgpSignedChecksum
+    }
+
+    fn verify(&self, input: &[u8]) -> Result<VerifiedPayload> {
+        let armored = std::str::from_utf8(input).map_err(|_| Error::NodeSignatureInvalid {
+            reason: "clear-signed manifest is not UTF-8".to_owned(),
+        })?;
+        let verified = verify_node_openpgp_manifest(armored)?;
+        Ok(VerifiedPayload {
+            payload: verified.text.into_bytes(),
+            signer: Some(verified.signer_fingerprint),
+        })
+    }
+}
+
+fn verify_node_openpgp_manifest(armored: &str) -> Result<VerifiedNodeManifest> {
     if armored.len() > MAX_NODE_MANIFEST_BYTES {
         return Err(Error::NodeSignatureInvalid {
             reason: format!(

--- a/crates/pinset-core/src/npm_metadata.rs
+++ b/crates/pinset-core/src/npm_metadata.rs
@@ -96,6 +96,8 @@ pub struct NpmMetadataClient {
 struct PackageDocument {
     #[serde(default)]
     versions: BTreeMap<String, PackageVersion>,
+    #[serde(default)]
+    time: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -261,6 +263,7 @@ impl NpmMetadataClient {
             });
         }
         let wrapper = wrapper_package(tool)?;
+        let released_at = self.package_release_time(wrapper, version)?;
         let manifest = self.package_version(wrapper, version)?;
         validate_manifest_identity(wrapper, version, &manifest)?;
         let keys = self.registry_keys()?;
@@ -317,6 +320,7 @@ impl NpmMetadataClient {
             requested: version.to_owned(),
             version: version.to_owned(),
             provider: format!("{tool}-npm"),
+            released_at,
             metadata: std::collections::BTreeMap::new(),
             artifacts,
         })
@@ -328,6 +332,15 @@ impl NpmMetadataClient {
             .join(version)
             .expect("validated semver is a safe URL segment");
         self.download_json(url)
+    }
+
+    fn package_release_time(&self, package: &str, version: &str) -> Result<Option<String>> {
+        let document: PackageDocument = self.download_json(self.package_url(package)?)?;
+        Ok(document
+            .time
+            .get(version)
+            .filter(|value| crate::valid_release_time(value))
+            .cloned())
     }
 
     fn registry_keys(&self) -> Result<RegistryKeys> {

--- a/crates/pinset-core/src/provenance.rs
+++ b/crates/pinset-core/src/provenance.rs
@@ -1,0 +1,487 @@
+//! Shared supply-chain verification vocabulary and policy enforcement.
+//!
+//! Providers keep ownership of their protocol-specific cryptography, while this module defines
+//! the common result contract used by locks, policy checks, audits, and downgrade protection.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+use crate::{Error, LockedTool, Result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum VerificationStrength {
+    Checksum,
+    SignedChecksum,
+    Provenance,
+}
+
+impl VerificationStrength {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Checksum => "checksum",
+            Self::SignedChecksum => "signed-checksum",
+            Self::Provenance => "provenance",
+        }
+    }
+}
+
+impl std::fmt::Display for VerificationStrength {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum VerificationMethod {
+    HttpsChecksum,
+    OpenPgpSignedChecksum,
+    NpmRegistrySignature,
+    MinisignSignedChecksum,
+    SigstoreBundle,
+    GitHubAttestation,
+    SlsaProvenance,
+}
+
+impl VerificationMethod {
+    pub const fn strength(self) -> VerificationStrength {
+        match self {
+            Self::HttpsChecksum => VerificationStrength::Checksum,
+            Self::OpenPgpSignedChecksum
+            | Self::NpmRegistrySignature
+            | Self::MinisignSignedChecksum => VerificationStrength::SignedChecksum,
+            Self::SigstoreBundle | Self::GitHubAttestation | Self::SlsaProvenance => {
+                VerificationStrength::Provenance
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg(feature = "node-metadata")]
+pub(crate) struct VerifiedPayload {
+    pub payload: Vec<u8>,
+    pub signer: Option<String>,
+}
+
+/// Protocol-specific verifiers implement this interface instead of exposing bespoke success
+/// values to Provider metadata code.
+#[cfg(feature = "node-metadata")]
+pub(crate) trait ProvenanceVerifier {
+    fn method(&self) -> VerificationMethod;
+    fn verify(&self, input: &[u8]) -> Result<VerifiedPayload>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MinimumReleaseAge(Duration);
+
+impl MinimumReleaseAge {
+    pub const fn as_duration(self) -> Duration {
+        self.0
+    }
+
+    fn parse(input: &str) -> std::result::Result<Self, String> {
+        let input = input.trim();
+        let (digits, unit) = input.split_at(
+            input
+                .find(|character: char| !character.is_ascii_digit())
+                .unwrap_or(input.len()),
+        );
+        if digits.is_empty() || unit.len() != 1 {
+            return Err("expected a duration such as 7d, 24h, 30m, or 60s".to_owned());
+        }
+        let value = digits
+            .parse::<u64>()
+            .map_err(|_| "duration value is too large".to_owned())?;
+        if value == 0 {
+            return Err("duration must be greater than zero".to_owned());
+        }
+        let seconds = match unit {
+            "d" => value.checked_mul(86_400),
+            "h" => value.checked_mul(3_600),
+            "m" => value.checked_mul(60),
+            "s" => Some(value),
+            _ => None,
+        }
+        .ok_or_else(|| "duration is too large or uses an unsupported unit".to_owned())?;
+        Ok(Self(Duration::from_secs(seconds)))
+    }
+}
+
+impl Serialize for MinimumReleaseAge {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let seconds = self.0.as_secs();
+        let value = if seconds.is_multiple_of(86_400) {
+            format!("{}d", seconds / 86_400)
+        } else if seconds.is_multiple_of(3_600) {
+            format!("{}h", seconds / 3_600)
+        } else if seconds.is_multiple_of(60) {
+            format!("{}m", seconds / 60)
+        } else {
+            format!("{seconds}s")
+        };
+        serializer.serialize_str(&value)
+    }
+}
+
+impl<'de> Deserialize<'de> for MinimumReleaseAge {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse(&value).map_err(de::Error::custom)
+    }
+}
+
+pub fn verification_method(value: &str) -> Option<VerificationMethod> {
+    let base = value.split_once("-source:").map_or(value, |(base, _)| base);
+    match base {
+        "nodejs-openpgp-sha256" | "openpgp-signed-checksum-sha256" => {
+            Some(VerificationMethod::OpenPgpSignedChecksum)
+        }
+        "npm-registry-signature-sha512" => Some(VerificationMethod::NpmRegistrySignature),
+        "minisign-signed-checksum-sha256" => Some(VerificationMethod::MinisignSignedChecksum),
+        "sigstore-bundle-sha256" => Some(VerificationMethod::SigstoreBundle),
+        "github-attestation-sha256" => Some(VerificationMethod::GitHubAttestation),
+        "slsa-provenance-v1-sha256" => Some(VerificationMethod::SlsaProvenance),
+        "go-download-json-sha256"
+        | "flutter-release-json-sha256"
+        | "python-build-standalone-versions-sha256"
+        | "adoptium-api-sha256"
+        | "rust-v2-manifest-sha256"
+        | "dotnet-release-metadata-sha512" => Some(VerificationMethod::HttpsChecksum),
+        _ => None,
+    }
+}
+
+pub fn tool_verification_strength(tool: &LockedTool) -> Result<VerificationStrength> {
+    tool.artifacts
+        .iter()
+        .flat_map(|artifact| {
+            std::iter::once(artifact.verification.as_str()).chain(
+                artifact
+                    .overlays
+                    .iter()
+                    .map(|overlay| overlay.verification.as_str()),
+            )
+        })
+        .map(|verification| {
+            verification_method(verification)
+                .map(VerificationMethod::strength)
+                .ok_or_else(|| Error::InvalidLockfile {
+                    reason: format!("unsupported verification method {verification:?}"),
+                })
+        })
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .min()
+        .ok_or_else(|| Error::InvalidLockfile {
+            reason: format!("{} has no verification evidence", tool.name),
+        })
+}
+
+pub fn validate_verification_transition(previous: &LockedTool, next: &LockedTool) -> Result<()> {
+    let previous_strength = tool_verification_strength(previous)?;
+    let next_strength = tool_verification_strength(next)?;
+    if next_strength < previous_strength {
+        return Err(Error::VerificationDowngrade {
+            tool: next.name.clone(),
+            previous: previous_strength.to_string(),
+            next: next_strength.to_string(),
+        });
+    }
+    Ok(())
+}
+
+pub fn validate_tool_policy(
+    tool: &LockedTool,
+    minimum_verification: Option<VerificationStrength>,
+    minimum_release_age: Option<MinimumReleaseAge>,
+    now: SystemTime,
+) -> Result<()> {
+    if let Some(required) = minimum_verification {
+        let actual = tool_verification_strength(tool)?;
+        if actual < required {
+            return Err(Error::VerificationPolicyViolation {
+                tool: tool.name.clone(),
+                required: required.to_string(),
+                actual: actual.to_string(),
+            });
+        }
+    }
+    if let Some(required_age) = minimum_release_age {
+        let released_at =
+            tool.released_at
+                .as_deref()
+                .ok_or_else(|| Error::ReleaseAgeUnavailable {
+                    tool: tool.name.clone(),
+                })?;
+        let release_time =
+            parse_release_time(released_at).ok_or_else(|| Error::InvalidLockfile {
+                reason: format!(
+                    "{} has invalid released-at value {released_at:?}",
+                    tool.name
+                ),
+            })?;
+        let actual = now
+            .duration_since(release_time)
+            .map_err(|_| Error::ReleaseTooNew {
+                tool: tool.name.clone(),
+                released_at: released_at.to_owned(),
+                required: format_duration(required_age.as_duration()),
+            })?;
+        if actual < required_age.as_duration() {
+            return Err(Error::ReleaseTooNew {
+                tool: tool.name.clone(),
+                released_at: released_at.to_owned(),
+                required: format_duration(required_age.as_duration()),
+            });
+        }
+    }
+    Ok(())
+}
+
+pub fn valid_release_time(value: &str) -> bool {
+    parse_release_time(value).is_some()
+}
+
+fn parse_release_time(value: &str) -> Option<SystemTime> {
+    let date = value.get(..10)?;
+    let bytes = date.as_bytes();
+    if bytes.len() != 10 || bytes[4] != b'-' || bytes[7] != b'-' {
+        return None;
+    }
+    if value.len() > 10 && !valid_time_suffix(&value[10..]) {
+        return None;
+    }
+    let year = date[0..4].parse::<i64>().ok()?;
+    let month = date[5..7].parse::<u32>().ok()?;
+    let day = date[8..10].parse::<u32>().ok()?;
+    if !(1..=12).contains(&month) || day == 0 || day > days_in_month(year, month) {
+        return None;
+    }
+    let days = days_from_civil(year, month, day);
+    let within_day = if value.len() == 10 {
+        // A date-only record does not identify the publication instant. Treat it as the end of
+        // that UTC day so a minimum-age policy never becomes eligible prematurely.
+        86_399_i64
+    } else {
+        parse_time_suffix(&value[10..])?
+    };
+    let seconds = days.checked_mul(86_400)?.checked_add(within_day)?;
+    if seconds < 0 {
+        return None;
+    }
+    UNIX_EPOCH.checked_add(Duration::from_secs(seconds as u64))
+}
+
+fn valid_time_suffix(value: &str) -> bool {
+    parse_time_suffix(value).is_some()
+}
+
+fn parse_time_suffix(value: &str) -> Option<i64> {
+    let bytes = value.as_bytes();
+    if bytes.len() < 9
+        || bytes[0] != b'T'
+        || bytes[3] != b':'
+        || bytes[6] != b':'
+        || !bytes[1..3].iter().all(u8::is_ascii_digit)
+        || !bytes[4..6].iter().all(u8::is_ascii_digit)
+        || !bytes[7..9].iter().all(u8::is_ascii_digit)
+    {
+        return None;
+    }
+    let hour = value[1..3].parse::<u32>().ok();
+    let minute = value[4..6].parse::<u32>().ok();
+    let second = value[7..9].parse::<u32>().ok();
+    if hour.is_none_or(|value| value > 23)
+        || minute.is_none_or(|value| value > 59)
+        || second.is_none_or(|value| value > 60)
+    {
+        return None;
+    }
+    let local_seconds = i64::from(hour?) * 3_600 + i64::from(minute?) * 60 + i64::from(second?);
+    let zone = &value[9..];
+    if zone == "Z" {
+        return Some(local_seconds);
+    }
+    if let Some(fraction) = zone.strip_prefix('.') {
+        return fraction
+            .strip_suffix('Z')
+            .filter(|digits| !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit()))
+            .map(|_| local_seconds);
+    }
+    let (sign, offset) = zone.split_at_checked(1)?;
+    if !matches!(sign, "+" | "-") || offset.len() != 5 || offset.as_bytes()[2] != b':' {
+        return None;
+    }
+    let hours = offset[0..2]
+        .parse::<i64>()
+        .ok()
+        .filter(|value| *value <= 23)?;
+    let minutes = offset[3..5]
+        .parse::<i64>()
+        .ok()
+        .filter(|value| *value <= 59)?;
+    let offset_seconds = hours * 3_600 + minutes * 60;
+    Some(if sign == "+" {
+        local_seconds - offset_seconds
+    } else {
+        local_seconds + offset_seconds
+    })
+}
+
+fn days_in_month(year: i64, month: u32) -> u32 {
+    match month {
+        4 | 6 | 9 | 11 => 30,
+        2 if year % 4 == 0 && (year % 100 != 0 || year % 400 == 0) => 29,
+        2 => 28,
+        _ => 31,
+    }
+}
+
+// Days since 1970-01-01, based on Howard Hinnant's civil calendar algorithm.
+fn days_from_civil(year: i64, month: u32, day: u32) -> i64 {
+    let year = year - i64::from(month <= 2);
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let year_of_era = year - era * 400;
+    let adjusted_month = i64::from(month) + if month > 2 { -3 } else { 9 };
+    let day_of_year = (153 * adjusted_month + 2) / 5 + i64::from(day) - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    era * 146_097 + day_of_era - 719_468
+}
+
+fn format_duration(duration: Duration) -> String {
+    let seconds = duration.as_secs();
+    if seconds.is_multiple_of(86_400) {
+        format!("{}d", seconds / 86_400)
+    } else if seconds.is_multiple_of(3_600) {
+        format!("{}h", seconds / 3_600)
+    } else if seconds.is_multiple_of(60) {
+        format!("{}m", seconds / 60)
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::{LockedArtifact, LockedArtifactFormat};
+
+    use super::*;
+
+    fn locked_tool(verification: &str, released_at: Option<&str>) -> LockedTool {
+        LockedTool {
+            name: "example".to_owned(),
+            requested: "1.0.0".to_owned(),
+            version: "1.0.0".to_owned(),
+            provider: "test".to_owned(),
+            released_at: released_at.map(str::to_owned),
+            metadata: BTreeMap::new(),
+            artifacts: vec![LockedArtifact {
+                target: "test".to_owned(),
+                canonical_url: "https://example.test/archive.tar.gz".to_owned(),
+                artifact_path: "archive.tar.gz".to_owned(),
+                sha256: "a".repeat(64),
+                integrity: None,
+                format: LockedArtifactFormat::TarGz,
+                archive_root: "example".to_owned(),
+                verification: verification.to_owned(),
+                overlays: Vec::new(),
+            }],
+        }
+    }
+
+    #[test]
+    fn classifies_existing_and_future_verification_methods() {
+        assert_eq!(
+            verification_method("nodejs-openpgp-sha256-source:mirror")
+                .map(VerificationMethod::strength),
+            Some(VerificationStrength::SignedChecksum)
+        );
+        assert_eq!(
+            verification_method("github-attestation-sha256").map(VerificationMethod::strength),
+            Some(VerificationStrength::Provenance)
+        );
+        assert_eq!(
+            verification_method("go-download-json-sha256-source:mirror")
+                .map(VerificationMethod::strength),
+            Some(VerificationStrength::Checksum)
+        );
+    }
+
+    #[test]
+    fn rejects_verification_downgrades() {
+        let previous = locked_tool("github-attestation-sha256", Some("2026-01-01"));
+        let next = locked_tool("nodejs-openpgp-sha256", Some("2026-01-01"));
+        assert!(matches!(
+            validate_verification_transition(&previous, &next),
+            Err(Error::VerificationDowngrade { .. })
+        ));
+    }
+
+    #[test]
+    fn enforces_strength_and_release_age_without_network_access() {
+        let tool = locked_tool("nodejs-openpgp-sha256", Some("2026-08-01"));
+        let now = UNIX_EPOCH + Duration::from_secs(days_from_civil(2026, 8, 20) as u64 * 86_400);
+        assert!(
+            validate_tool_policy(
+                &tool,
+                Some(VerificationStrength::SignedChecksum),
+                Some(MinimumReleaseAge::parse("7d").expect("duration")),
+                now,
+            )
+            .is_ok()
+        );
+        assert!(matches!(
+            validate_tool_policy(&tool, Some(VerificationStrength::Provenance), None, now,),
+            Err(Error::VerificationPolicyViolation { .. })
+        ));
+
+        let unknown_age = locked_tool("go-download-json-sha256", None);
+        assert!(matches!(
+            validate_tool_policy(
+                &unknown_age,
+                None,
+                Some(MinimumReleaseAge::parse("1d").expect("duration")),
+                now,
+            ),
+            Err(Error::ReleaseAgeUnavailable { .. })
+        ));
+    }
+
+    #[test]
+    fn duration_and_release_time_parsing_are_strict() {
+        assert_eq!(
+            MinimumReleaseAge::parse("48h")
+                .expect("duration")
+                .as_duration(),
+            Duration::from_secs(172_800)
+        );
+        assert!(MinimumReleaseAge::parse("0d").is_err());
+        assert!(MinimumReleaseAge::parse("1w").is_err());
+        assert!(!valid_release_time("2026-02-29"));
+        assert!(valid_release_time("2024-02-29T12:00:00Z"));
+        assert!(!valid_release_time("2024-02-29T25:00:00Z"));
+        let start_of_next_day =
+            UNIX_EPOCH + Duration::from_secs(days_from_civil(2026, 8, 21) as u64 * 86_400);
+        let dated = locked_tool("go-download-json-sha256", Some("2026-08-20"));
+        assert!(matches!(
+            validate_tool_policy(
+                &dated,
+                None,
+                Some(MinimumReleaseAge::parse("1d").expect("duration")),
+                start_of_next_day,
+            ),
+            Err(Error::ReleaseTooNew { .. })
+        ));
+    }
+}

--- a/crates/pinset-core/src/python_metadata.rs
+++ b/crates/pinset-core/src/python_metadata.rs
@@ -131,6 +131,7 @@ impl PythonMetadataClient {
             requested: release.distribution.clone(),
             version: release.distribution,
             provider: "python-build-standalone".to_owned(),
+            released_at: Some(release.date),
             metadata,
             artifacts,
         })

--- a/crates/pinset-core/src/runtime_provider.rs
+++ b/crates/pinset-core/src/runtime_provider.rs
@@ -18,6 +18,15 @@ pub struct RuntimeProviderCapabilities {
     pub environment: RuntimeEnvironmentKind,
     pub discovery: &'static [RuntimeDiscoveryRule],
     pub lock_audit: RuntimeLockAuditKind,
+    pub provenance: RuntimeProvenanceCapabilities,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RuntimeProvenanceCapabilities {
+    pub methods: &'static [crate::VerificationMethod],
+    /// Whether the consumed upstream metadata supplies a release timestamp that can enforce
+    /// `minimum-release-age` without guessing from a version or local file time.
+    pub release_time: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -141,6 +150,11 @@ const DOTNET_DISCOVERY: &[RuntimeDiscoveryRule] = &[RuntimeDiscoveryRule {
     source: "global-json",
     kind: RuntimeDiscoveryKind::DotnetGlobalJson,
 }];
+const CHECKSUM_METHODS: &[crate::VerificationMethod] = &[crate::VerificationMethod::HttpsChecksum];
+const NODE_METHODS: &[crate::VerificationMethod] =
+    &[crate::VerificationMethod::OpenPgpSignedChecksum];
+const NPM_METHODS: &[crate::VerificationMethod] =
+    &[crate::VerificationMethod::NpmRegistrySignature];
 const NODE_PROVIDER: RuntimeProvider = RuntimeProvider {
     tool: "node",
     commands: NODE_COMMANDS,
@@ -151,6 +165,10 @@ const NODE_PROVIDER: RuntimeProvider = RuntimeProvider {
         environment: RuntimeEnvironmentKind::None,
         discovery: NODE_DISCOVERY,
         lock_audit: RuntimeLockAuditKind::ArtifactReceipt,
+        provenance: RuntimeProvenanceCapabilities {
+            methods: NODE_METHODS,
+            release_time: true,
+        },
     },
 };
 const PNPM_PROVIDER: RuntimeProvider = RuntimeProvider {
@@ -163,6 +181,10 @@ const PNPM_PROVIDER: RuntimeProvider = RuntimeProvider {
         environment: RuntimeEnvironmentKind::None,
         discovery: &[],
         lock_audit: RuntimeLockAuditKind::ArtifactReceipt,
+        provenance: RuntimeProvenanceCapabilities {
+            methods: NPM_METHODS,
+            release_time: true,
+        },
     },
 };
 const BUN_PROVIDER: RuntimeProvider = RuntimeProvider {
@@ -175,6 +197,10 @@ const BUN_PROVIDER: RuntimeProvider = RuntimeProvider {
         environment: RuntimeEnvironmentKind::None,
         discovery: BUN_DISCOVERY,
         lock_audit: RuntimeLockAuditKind::ArtifactReceipt,
+        provenance: RuntimeProvenanceCapabilities {
+            methods: NPM_METHODS,
+            release_time: true,
+        },
     },
 };
 const GO_PROVIDER: RuntimeProvider = RuntimeProvider {
@@ -187,6 +213,10 @@ const GO_PROVIDER: RuntimeProvider = RuntimeProvider {
         environment: RuntimeEnvironmentKind::Go,
         discovery: GO_DISCOVERY,
         lock_audit: RuntimeLockAuditKind::ArtifactReceipt,
+        provenance: RuntimeProvenanceCapabilities {
+            methods: CHECKSUM_METHODS,
+            release_time: false,
+        },
     },
 };
 const FLUTTER_PROVIDER: RuntimeProvider = RuntimeProvider {
@@ -199,6 +229,10 @@ const FLUTTER_PROVIDER: RuntimeProvider = RuntimeProvider {
         environment: RuntimeEnvironmentKind::Flutter,
         discovery: FLUTTER_DISCOVERY,
         lock_audit: RuntimeLockAuditKind::ArtifactReceipt,
+        provenance: RuntimeProvenanceCapabilities {
+            methods: CHECKSUM_METHODS,
+            release_time: true,
+        },
     },
 };
 const PYTHON_PROVIDER: RuntimeProvider = RuntimeProvider {
@@ -211,6 +245,10 @@ const PYTHON_PROVIDER: RuntimeProvider = RuntimeProvider {
         environment: RuntimeEnvironmentKind::Python,
         discovery: PYTHON_DISCOVERY,
         lock_audit: RuntimeLockAuditKind::ArtifactReceipt,
+        provenance: RuntimeProvenanceCapabilities {
+            methods: CHECKSUM_METHODS,
+            release_time: true,
+        },
     },
 };
 const JAVA_PROVIDER: RuntimeProvider = RuntimeProvider {
@@ -225,6 +263,10 @@ const JAVA_PROVIDER: RuntimeProvider = RuntimeProvider {
         environment: RuntimeEnvironmentKind::Java,
         discovery: JAVA_DISCOVERY,
         lock_audit: RuntimeLockAuditKind::ArtifactReceipt,
+        provenance: RuntimeProvenanceCapabilities {
+            methods: CHECKSUM_METHODS,
+            release_time: true,
+        },
     },
 };
 const RUST_PROVIDER: RuntimeProvider = RuntimeProvider {
@@ -245,6 +287,10 @@ const RUST_PROVIDER: RuntimeProvider = RuntimeProvider {
         environment: RuntimeEnvironmentKind::None,
         discovery: RUST_DISCOVERY,
         lock_audit: RuntimeLockAuditKind::ArtifactReceipt,
+        provenance: RuntimeProvenanceCapabilities {
+            methods: CHECKSUM_METHODS,
+            release_time: true,
+        },
     },
 };
 const DOTNET_PROVIDER: RuntimeProvider = RuntimeProvider {
@@ -257,6 +303,10 @@ const DOTNET_PROVIDER: RuntimeProvider = RuntimeProvider {
         environment: RuntimeEnvironmentKind::Dotnet,
         discovery: DOTNET_DISCOVERY,
         lock_audit: RuntimeLockAuditKind::ArtifactReceipt,
+        provenance: RuntimeProvenanceCapabilities {
+            methods: CHECKSUM_METHODS,
+            release_time: true,
+        },
     },
 };
 const PROVIDERS: &[RuntimeProvider] = &[
@@ -432,7 +482,7 @@ mod tests {
     }
 
     #[test]
-    fn every_provider_declares_the_complete_v16_capability_model() {
+    fn every_provider_declares_the_complete_v17_capability_model() {
         assert_eq!(runtime_providers().len(), 9);
         for provider in runtime_providers() {
             assert_eq!(
@@ -441,6 +491,25 @@ mod tests {
                 "{} must participate in the shared lock audit contract",
                 provider.tool
             );
+            assert!(
+                !provider.capabilities.provenance.methods.is_empty(),
+                "{} must declare its verification method",
+                provider.tool
+            );
         }
+        assert!(
+            !runtime_provider("go")
+                .expect("Go")
+                .capabilities
+                .provenance
+                .release_time
+        );
+        assert!(
+            runtime_provider("node")
+                .expect("Node")
+                .capabilities
+                .provenance
+                .release_time
+        );
     }
 }

--- a/crates/pinset-core/src/rust_metadata.rs
+++ b/crates/pinset-core/src/rust_metadata.rs
@@ -341,6 +341,7 @@ fn resolve_manifest_tool(
         requested: requested_version.to_owned(),
         version: requested_version.to_owned(),
         provider: "rust-official".to_owned(),
+        released_at: Some(manifest.date.clone()),
         metadata: BTreeMap::from([
             ("channel".to_owned(), "stable".to_owned()),
             ("components".to_owned(), RUST_COMPONENTS.to_owned()),

--- a/crates/pinset/src/i18n.rs
+++ b/crates/pinset/src/i18n.rs
@@ -229,6 +229,26 @@ impl Catalog {
             Error::InvalidSourceBaseUrl { url, reason } => {
                 format!("错误：安装源地址 {url:?} 无效：{reason}")
             }
+            Error::VerificationPolicyViolation {
+                tool,
+                required,
+                actual,
+            } => format!("错误：{tool} 的验证强度为 {actual}，低于项目要求的 {required}"),
+            Error::VerificationDowngrade {
+                tool,
+                previous,
+                next,
+            } => format!(
+                "错误：拒绝把 {tool} 的验证强度从 {previous} 降为 {next}；请保留更强证据或显式创建全新锁"
+            ),
+            Error::ReleaseAgeUnavailable { tool } => format!(
+                "错误：{tool} 的 Provider 没有提供发布时间，无法执行 minimum-release-age 策略"
+            ),
+            Error::ReleaseTooNew {
+                tool,
+                released_at,
+                required,
+            } => format!("错误：{tool} 发布于 {released_at}，尚未满足最短发布年龄 {required}"),
             _ => format!("错误：操作失败：{error}"),
         }
     }

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -44,7 +44,8 @@ use pinset_core::{
     validate_exact_flutter_version, validate_exact_go_version, validate_exact_java_version,
     validate_exact_node_version, validate_exact_npm_tool_version, validate_exact_python_version,
     validate_exact_rust_version, validate_lock_matches_selection, validate_lock_matches_tool,
-    validate_lock_matches_tools, validate_managed_runtime_invocation, verify_download_cache,
+    validate_lock_matches_tools, validate_managed_runtime_invocation, validate_project_lock_policy,
+    verify_download_cache,
 };
 use serde::Serialize;
 use terminal_size::{Width, terminal_size_of};
@@ -721,6 +722,11 @@ fn json_error(error: &(dyn std::error::Error + 'static)) -> (&'static str, serde
         | Error::NodeTrustStoreInvalid { .. }
         | Error::NpmSignatureVerification { .. } => "signature_invalid",
         Error::NodeSignerUntrusted { .. } => "signature_untrusted",
+        Error::VerificationPolicyViolation { .. } => "verification_policy_failed",
+        Error::VerificationDowngrade { .. } => "verification_downgrade",
+        Error::ReleaseAgeUnavailable { .. } | Error::ReleaseTooNew { .. } => {
+            "release_age_policy_failed"
+        }
         Error::InvalidSha256 { .. }
         | Error::InvalidArtifactIntegrity { .. }
         | Error::ChecksumMismatch { .. } => "artifact_integrity_failed",
@@ -2456,7 +2462,7 @@ fn select_tool(
         let lock_path = global_lockfile_path(&home);
         let mut lockfile = load_optional_lockfile(&lock_path)?.unwrap_or_else(new_lockfile);
         lockfile.generated_by = format!("pinset {}", env!("CARGO_PKG_VERSION"));
-        lockfile.upsert_tool(locked_tool.clone());
+        lockfile.upsert_tool(locked_tool.clone())?;
         config.set_tool(&tool, &selector);
         validate_lock_matches_tools(&lockfile, &config.tools, &config_path)?;
         save_global_state(&home, &config, &lockfile)?;
@@ -2471,7 +2477,7 @@ fn select_tool(
         let lock_path = lockfile_path(&config_path);
         let mut lockfile = load_optional_lockfile(&lock_path)?.unwrap_or_else(new_lockfile);
         lockfile.generated_by = format!("pinset {}", env!("CARGO_PKG_VERSION"));
-        lockfile.upsert_tool(locked_tool.clone());
+        lockfile.upsert_tool(locked_tool.clone())?;
         project.set_tool(&tool, &selector);
         save_project_state(&config_path, &project, &lockfile)?;
         ("project", lock_path)
@@ -2770,7 +2776,7 @@ fn run_project_import(
             );
         }
         project.set_tool(tool, selector);
-        lockfile.upsert_tool(locked_tool.clone());
+        lockfile.upsert_tool(locked_tool.clone())?;
     }
     save_project_state(&config_path, &project, &lockfile)?;
 
@@ -2879,16 +2885,21 @@ fn run_update(
             previous,
             resolved: resolved.version.clone(),
         };
-        lockfile.upsert_tool(resolved);
+        lockfile.upsert_tool(resolved)?;
         reports.push(report);
     }
-    if tool.is_some() && reports.is_empty() {
+    if let (Some(tool), true) = (tool, reports.is_empty()) {
         return Err(format!(
             "{} does not declare runtime provider {:?}",
             config_path.display(),
-            tool.expect("checked")
+            tool
         )
         .into());
+    }
+
+    if !global {
+        let config = load_project_config(&config_path)?;
+        validate_project_lock_policy(&config, &lockfile, std::time::SystemTime::now())?;
     }
 
     if !dry_run {
@@ -3009,7 +3020,7 @@ fn install_tool_selection(
         );
     }
     let mut lockfile = new_lockfile();
-    lockfile.upsert_tool(locked_tool);
+    lockfile.upsert_tool(locked_tool)?;
     install_tool_from_lock(&pinset_home()?, &lockfile, &tool, catalog)
 }
 
@@ -3192,6 +3203,8 @@ fn install_project_with_venv(
     let project = load_project_config(&config_path)?;
     let lock_path = lockfile_path(&config_path);
     let home = pinset_home()?;
+    let policy_lock = load_lockfile(&lock_path)?;
+    validate_project_lock_policy(&project, &policy_lock, std::time::SystemTime::now())?;
     install_locked_selection(&home, &project.tools, &config_path, &lock_path, catalog)?;
     if let Some(requested) = project.tools.get("python") {
         let distribution = selected_version_from_lock(
@@ -5312,6 +5325,7 @@ mod tests {
             requested: "24.0.0".to_owned(),
             version: "24.0.0".to_owned(),
             provider: "nodejs-official".to_owned(),
+            released_at: None,
             metadata: BTreeMap::new(),
             artifacts: Vec::new(),
         };

--- a/crates/pinset/tests/lock_audit_cli.rs
+++ b/crates/pinset/tests/lock_audit_cli.rs
@@ -7,8 +7,8 @@ use std::{
 
 use pinset_core::{
     LockedArtifact, LockedArtifactFormat, Lockfile, MVP_NODE_TARGETS, NodeArchiveFormat,
-    ProjectConfig, SourceConfig, current_target_for_tool, plan_node_artifact, save_lockfile,
-    save_project_config,
+    ProjectConfig, SourceConfig, VerificationStrength, current_target_for_tool, plan_node_artifact,
+    save_lockfile, save_project_config,
 };
 use tempfile::tempdir;
 
@@ -77,6 +77,37 @@ fn lock_audit_uses_exit_one_for_findings_and_does_not_repair_state() {
             .any(|finding| finding["reason_code"] == "receipt_missing")
     );
     assert!(!install.join(".pinset-install.toml").exists());
+}
+
+#[test]
+fn lock_audit_json_exposes_provenance_policy_reason_codes() {
+    let root = tempdir().expect("temporary root");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    fs::create_dir(&project).expect("project");
+    let mut config = ProjectConfig {
+        schema: 3,
+        policy: Default::default(),
+        tools: BTreeMap::from([("node".to_owned(), "24.0.0".to_owned())]),
+    };
+    config.policy.verification_strength = Some(VerificationStrength::Provenance);
+    save_project_config(&project.join("pinset.toml"), &config).expect("project config");
+    save_lockfile(&project.join("pinset.lock"), &node_lockfile("24.0.0")).expect("lockfile");
+
+    let output = pinset(&project, &home, &["lock", "audit", "--json"]);
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("audit JSON");
+    assert!(
+        json["data"]["findings"]
+            .as_array()
+            .expect("findings")
+            .iter()
+            .any(|finding| {
+                finding["reason_code"] == "verification_below_policy"
+                    && finding["category"] == "provenance"
+            })
+    );
 }
 
 fn write_project(project: &Path, version: &str) {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2,7 +2,7 @@
 
 [English](commands.md) | [简体中文](commands.zh-CN.md) · [README](../README.md)
 
-This document describes the Pinset v1.6 command-line contract. Run `pinset <command> --help` for the exact parser help shipped with your binary.
+This document describes the Pinset v1.7 command-line contract. Run `pinset <command> --help` for the exact parser help shipped with your binary.
 
 ## Conventions
 
@@ -580,6 +580,6 @@ Custom source configuration currently applies to Node.js, Go, Python, and Flutte
 
 ## Stable protocol boundary
 
-Pinset v1.6 writes schema 3 for project/global configuration and lockfiles. Schema 1/2 remains readable; `pinset migrate` validates and upgrades existing config-lock pairs. Schema 3 deliberately separates the requested selector from the exact resolved lock version and introduces explicit project fallback/boundary policy. Direct downgrade from schema 3 is not supported. Installation receipts retain their own independent schema. A pre-v1 Node lock that records only an HTTPS checksum is rejected with instructions to run `pinset use` again, because it lacks the v1 OpenPGP verification evidence.
+Pinset v1.7 writes schema 3 for project/global configuration and lockfiles. Schema 1/2 remains readable. Schema 3 project `[policy]` accepts optional `verification-strength = "checksum" | "signed-checksum" | "provenance"` and `minimum-release-age = "<positive integer><d|h|m|s>"`. New locks may record the optional upstream `released-at` timestamp. A configured policy is enforced during state writes, project installation, updates including dry runs, and lock audits; unavailable release time fails closed, and replacing an existing tool lock with weaker verification is rejected. Installation receipts retain their independent schema.
 
-The JSON schema 1 envelope remains unchanged in v1.6. `lock.audit` adds a versioned data report within that envelope: automation should branch on stable `reason_code`, `severity`, `data.passed`, and `summary.action_required`, not on human-facing messages or repair prose.
+The JSON schema 1 envelope remains unchanged in v1.7. `lock.audit` exposes provenance policy failures through stable `verification_below_policy`, `release_age_unavailable`, and `release_too_new` reason codes. Automation should branch on reason codes and report state, not human-facing messages.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](commands.md) | [简体中文](commands.zh-CN.md) · [README](../README.zh-CN.md)
 
-本文档描述 Pinset v1.6 命令行协议。可以运行 `pinset <command> --help` 查看当前二进制附带的精确参数帮助。
+本文档描述 Pinset v1.7 命令行协议。可以运行 `pinset <command> --help` 查看当前二进制附带的精确参数帮助。
 
 ## 通用约定
 
@@ -580,6 +580,6 @@
 
 ## 稳定协议边界
 
-Pinset v1.6 为项目/全局配置与锁文件写入 schema 3。schema 1/2 仍可读取；`pinset migrate` 会验证并升级现有配置与锁。schema 3 明确区分请求选择器和锁中的精确解析版本，并引入显式项目回退/边界策略；不支持从 schema 3 直接降级。安装收据继续使用自身独立的 schema。仅记录 HTTPS 摘要的 v1 前 Node 锁会被拒绝，并提示重新运行 `pinset use`，因为它缺少 v1 OpenPGP 验证证据。
+Pinset v1.7 继续为项目/全局配置与锁文件写入 schema 3，并读取 schema 1/2。schema 3 项目 `[policy]` 新增可选的 `verification-strength = "checksum" | "signed-checksum" | "provenance"` 和 `minimum-release-age = "<正整数><d|h|m|s>"`；新锁可以记录可选的上游 `released-at`。配置策略会在状态写入、项目安装、包括 dry-run 在内的更新和锁审计中执行；缺少发布时间会失败关闭，已有工具锁也不允许被更弱验证静默替换。安装收据继续使用独立 schema。
 
-v1.6 不修改 JSON schema 1 外层结构。`lock.audit` 只是在该外层内增加一份带版本边界的数据报告：自动化应依据稳定的 `reason_code`、`severity`、`data.passed` 与 `summary.action_required` 分支，不应匹配面向用户的消息或修复说明。
+v1.7 不修改 JSON schema 1 外层结构。`lock.audit` 通过稳定的 `verification_below_policy`、`release_age_unavailable` 与 `release_too_new` reason code 报告来源证明策略失败；自动化应依据 reason code 与报告状态分支，不要匹配面向用户的消息。

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="1.6.0"
+DEFAULT_VERSION="1.7.0"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -18,7 +18,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 1.6.0.
+  --version VERSION       Install an exact release, for example 1.7.0.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.


### PR DESCRIPTION
## Summary
- add common provenance verification vocabulary and Provider capability declarations
- enforce optional verification-strength and minimum-release-age project policies
- record release timestamps, reject verification downgrades, and extend lock audit reason codes
- update version metadata and bilingual documentation for v1.7.0

## Validation
- cargo test --workspace --all-features
- cargo fmt --all -- --check
- cargo check -p pinset-shim
- cargo clippy with Rust 1.97 baseline-only lint allowances; repository CI runs pinned Rust 1.88
- git diff --check

The pre-existing deletion of docs/comparison.zh-CN.md is intentionally excluded.