### PR TITLE
feat: release Pinset v1.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Smoke test the local composite action
+        uses: ./
+        with:
+          version: 1.8.0
+          install: "false"
+
+      - name: Verify the action-installed CLI
+        shell: bash
+        run: pinset --version | grep -F "pinset 1.8.0"
+
       - name: Prepare pinned Rust toolchain
         run: |
           rustup show active-toolchain
@@ -200,19 +210,26 @@ jobs:
         continue-on-error: true
         run: cargo test --workspace --all-features --locked
 
+      - name: Validate integration contracts
+        id: integrations
+        continue-on-error: true
+        run: python3 scripts/tests/integrations_test.py
+
       - name: Enforce all workspace checks
         if: always()
         shell: bash
         env:
           CLIPPY_OUTCOME: ${{ steps.clippy.outcome }}
           FORMATTING_OUTCOME: ${{ steps.formatting.outcome }}
+          INTEGRATIONS_OUTCOME: ${{ steps.integrations.outcome }}
           TESTS_OUTCOME: ${{ steps.tests.outcome }}
         run: |
           failed=0
           for result in \
             "formatting=${FORMATTING_OUTCOME}" \
             "clippy=${CLIPPY_OUTCOME}" \
-            "tests=${TESTS_OUTCOME}"; do
+            "tests=${TESTS_OUTCOME}" \
+            "integrations=${INTEGRATIONS_OUTCOME}"; do
             if [[ "${result#*=}" != "success" ]]; then
               echo "${result%%=*} failed" >&2
               failed=1

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -31,6 +31,11 @@ jobs:
             echo "install.sh default ${installer_version} does not match workspace version ${workspace_version}" >&2
             exit 1
           fi
+          action_version="$(awk '/^  version:/{seen=1} seen && /^    default:/{print $2; exit}' action.yml)"
+          if [[ "${action_version}" != "${workspace_version}" ]]; then
+            echo "action.yml default ${action_version} does not match workspace version ${workspace_version}" >&2
+            exit 1
+          fi
           if ! grep -F "## ${workspace_version} " CHANGELOG.md >/dev/null; then
             echo "CHANGELOG.md does not contain a ${workspace_version} release heading" >&2
             exit 1
@@ -81,6 +86,11 @@ jobs:
         continue-on-error: true
         run: cargo test --workspace --all-features --locked
 
+      - name: Validate integration contracts
+        id: integrations
+        continue-on-error: true
+        run: python3 scripts/tests/integrations_test.py
+
       - name: Test curl installer without network or runtime installation
         id: installer
         continue-on-error: true
@@ -110,6 +120,7 @@ jobs:
           CLIPPY_OUTCOME: ${{ steps.clippy.outcome }}
           FORMATTING_OUTCOME: ${{ steps.formatting.outcome }}
           INSTALLER_OUTCOME: ${{ steps.installer.outcome }}
+          INTEGRATIONS_OUTCOME: ${{ steps.integrations.outcome }}
           SHIM_OUTCOME: ${{ steps.shim_dependencies.outcome }}
           TESTS_OUTCOME: ${{ steps.tests.outcome }}
           UNINSTALLER_OUTCOME: ${{ steps.uninstaller.outcome }}
@@ -120,6 +131,7 @@ jobs:
             "formatting=${FORMATTING_OUTCOME}" \
             "clippy=${CLIPPY_OUTCOME}" \
             "tests=${TESTS_OUTCOME}" \
+            "integrations=${INTEGRATIONS_OUTCOME}" \
             "installer=${INSTALLER_OUTCOME}" \
             "uninstaller=${UNINSTALLER_OUTCOME}" \
             "shim_dependencies=${SHIM_OUTCOME}"; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,11 @@ jobs:
             echo "install.sh default ${installer_version} does not match workspace version ${workspace_version}" >&2
             exit 1
           fi
+          action_version="$(awk '/^  version:/{seen=1} seen && /^    default:/{print $2; exit}' action.yml)"
+          if [[ "${action_version}" != "${workspace_version}" ]]; then
+            echo "action.yml default ${action_version} does not match workspace version ${workspace_version}" >&2
+            exit 1
+          fi
 
       - name: Require a recent successful release preflight
         shell: bash
@@ -263,6 +268,19 @@ jobs:
               > SHA256SUMS
           )
 
+      - name: Generate package-manager manifests
+        shell: bash
+        run: |
+          release_version="${GITHUB_REF_NAME#v}"
+          python3 scripts/generate_package_manifests.py \
+            --version "${release_version}" \
+            --checksums dist/SHA256SUMS \
+            --output dist
+          (
+            cd dist
+            sha256sum pinset-winget.yaml pinset-scoop.json pinset.rb >> SHA256SUMS
+          )
+
       - name: Attest release metadata provenance
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
@@ -274,6 +292,9 @@ jobs:
             dist/pinset-cli.cdx.json
             dist/pinset-core.cdx.json
             dist/pinset-shim.cdx.json
+            dist/pinset-winget.yaml
+            dist/pinset-scoop.json
+            dist/pinset.rb
 
       - name: Create or update GitHub Release
         shell: bash
@@ -291,6 +312,9 @@ jobs:
             dist/pinset-cli.cdx.json
             dist/pinset-core.cdx.json
             dist/pinset-shim.cdx.json
+            dist/pinset-winget.yaml
+            dist/pinset-scoop.json
+            dist/pinset.rb
             dist/SHA256SUMS
           )
           if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.9.0 - 2026-08-20
+
+- Add `pinset x <tool>@<selector> -- <command>` for verified one-shot execution. It resolves and installs the requested runtime in Pinset-owned storage, preserves the child exit code, and never creates or modifies project/global selection or lock state.
+- Resolve declared Provider dependencies before one-shot installation. A pnpm one-shot uses the project/global Node.js selection and fails explicitly when that dependency is unavailable.
+- Add a checksum-verifying composite GitHub Action, a Renovate custom-manager preset, JSON Schemas for `pinset.toml` and `pinset.lock`, and a verified Dev Container example.
+- Generate ready-to-consume Winget, Scoop, and Homebrew manifests from the exact release archive hashes. The manifests are checksummed, attested, and published alongside every release.
+- Add static integration-contract tests to CI and release preflight so action, schema, container, Renovate, and package-manifest drift blocks publication.
+
+No configuration or lock schema migration is required. v1.9 continues to write schema 3 and read schema 1/2. One-shot installation may populate Pinset-owned download/cache/install directories, but selection state remains unchanged.
+
 ## 1.8.0 - 2026-08-20
 
 - Add a constrained, clear-signed Provider Registry preview with a pinned OpenPGP signer. `pinset provider list` and `pinset provider verify [REGISTRY]` validate declarative manifests without installing, activating, or executing third-party code.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,7 +1976,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "clap",
  "hex",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "atomic-write-file",
  "base64",
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "1.8.0"
+version = "1.9.0"
 authors = ["Future Element"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It manages Node.js, pnpm, Bun, Go, Python, Java, Rust, .NET, and Flutter/Dart th
 - Project-owned Python `.venv` support without requiring shell activation.
 - Read-only detection and explicit import of repository-local traditional version files.
 - Read-only, offline lock auditing with stable reason codes and repair plans that never run automatically.
+- Verified one-shot execution plus maintained CI, editor, container, and package-manager integrations.
 
 ## Install and upgrade
 
@@ -43,7 +44,7 @@ export PATH="$HOME/.local/bin:$PATH"
 Run the same installer again to upgrade. To install an exact release or another absolute directory:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.8.0
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.9.0
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -131,6 +132,14 @@ pinset lock audit
 pinset exec -- node --version
 ```
 
+Run a verified tool once without changing project or global selection state:
+
+```sh
+pinset x node@24 -- node --version
+```
+
+The resolved archive is still checksum/signature verified and may be cached or installed under `PINSET_HOME`; `pinset.toml`, `pinset.lock`, `global.toml`, and `global.lock` are not written. Provider dependencies remain explicit: `pinset x pnpm@11 -- pnpm --version` requires a valid project/global Node.js selection.
+
 Commit `pinset.toml` and `pinset.lock`. Selectors such as `latest`, `lts`, `stable`, or version prefixes remain visible in `pinset.toml`; their exact resolved versions are recorded in the lockfile. `pinset outdated` distinguishes a compatible lock refresh from a selector-changing upgrade, and `pinset update --dry-run` previews compatible lock changes.
 
 Schema 3 projects are strict by default: once `pinset.toml` exists, an undeclared tool does not inherit a global selection or use the system `PATH`. Opt in deliberately when needed:
@@ -206,9 +215,9 @@ See the complete [English command reference](docs/commands.md) or [Chinese comma
 
 For product positioning and trade-offs, see the sourced [Pinset comparison (Chinese)](docs/comparison.zh-CN.md).
 
-## v1.8
+## v1.9
 
-v1.8 delivers a constrained Provider Registry preview and dependency graph. Registry manifests are clear-signed by a pinned OpenPGP key, strictly declarative, bounded, and deny unknown capabilities; verification never installs or executes them. Built-in dependencies are cycle-checked and produce deterministic install/environment order, including pnpm's explicit Node.js runtime dependency. It keeps schema 3 and the v1 JSON envelope.
+v1.9 delivers verified one-shot execution and maintained integration artifacts. The repository includes a checksum-verifying composite GitHub Action, Renovate preset, project/lock JSON Schemas, and a Dev Container example. Every release generates checksummed and attested Winget, Scoop, and Homebrew manifests from its actual archive hashes. See [Integrations and distribution](docs/integrations.md).
 
 ## Future Roadmap
 
@@ -216,7 +225,6 @@ The roadmap describes direction, not promised versions or dates.
 
 | Version | Theme | Planned work |
 | --- | --- | --- |
-| v1.9 | Developer experience and distribution | Add `pinset x <tool>@<selector> -- <command>` for verified one-shot execution without modifying project state. Provide a GitHub Action, Renovate integration, VS Code schemas, Dev Container examples, and official Winget, Scoop, and Homebrew distribution. |
 | Ongoing | Platforms and quality | Add platforms and architectures when upstreams publish suitable artifacts. Continue cross-platform CI, security audits, malicious-input regressions, signed tags, `SHA256SUMS`, SBOMs, and build-provenance verification. |
 
 The roadmap preserves Pinset's explicit boundaries: traditional version files remain opt-in `detect` / `import` inputs; strict projects do not download and execute missing tools by default; and the core will not absorb tasks, hooks, `.env`, secrets, service management, Nix/Conda solving, or arbitrary-code plugins. These releases will continue using schema 3 and prefer backward-compatible optional fields.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,6 +23,7 @@ Pinset 是一个行为可预测、理解项目边界的多语言运行时版本�
 - 支持项目所有的 Python `.venv`，无需激活 Shell 环境。
 - 支持只读检测和显式导入仓库内的传统版本配置。
 - 支持带稳定 reason code 的只读离线锁审计；修复计划只报告、不自动执行。
+- 支持经过验证的一次性执行，以及持续维护的 CI、编辑器、容器和包管理器集成。
 
 ## 安装与升级
 
@@ -43,7 +44,7 @@ export PATH="$HOME/.local/bin:$PATH"
 再次运行同一安装脚本即可升级。也可以安装指定版本或使用其他绝对目录：
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.8.0
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 1.9.0
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -131,6 +132,14 @@ pinset lock audit
 pinset exec -- node --version
 ```
 
+不修改项目或全局选择状态，临时验证并运行一个工具：
+
+```sh
+pinset x node@24 -- node --version
+```
+
+解析出的归档仍会经过 checksum/签名验证，也可能缓存在 `PINSET_HOME` 或安装到其中；但不会写入 `pinset.toml`、`pinset.lock`、`global.toml` 或 `global.lock`。Provider 依赖仍保持显式：`pinset x pnpm@11 -- pnpm --version` 需要有效的项目/全局 Node.js 选择。
+
 请提交 `pinset.toml` 和 `pinset.lock`。`latest`、`lts`、`stable` 或版本前缀等选择器会保留在 `pinset.toml`，锁文件则记录其精确解析版本。`pinset outdated` 会区分“兼容选择器内可更新”与“必须修改选择器才能升级”，`pinset update --dry-run` 可预览兼容的锁更新。
 
 schema 3 项目默认严格：只要存在 `pinset.toml`，未声明的工具就不会继承全局选择，也不会使用系统 `PATH`。需要时必须明确选择：
@@ -206,9 +215,9 @@ Registry 验证刻意保持只读。未知字段、任意脚本/hooks、不支�
 
 产品定位与取舍见带官方来源的 [Pinset 横向对比](docs/comparison.zh-CN.md)。
 
-## v1.8
+## v1.9
 
-v1.8 交付受约束的 Provider Registry 预览与依赖图。Registry manifest 由固定 OpenPGP 公钥验证 clear-signature，严格保持纯声明式、输入有界并拒绝未知 capability；验证不会安装或执行 manifest。内置依赖会检查循环并生成确定的安装和环境顺序，包括 pnpm 对 Node.js 的显式运行时依赖。它继续使用 schema 3 与 v1 JSON 外层协议。
+v1.9 交付经过验证的一次性执行和可维护的生态集成。仓库提供验证 checksum 的 composite GitHub Action、Renovate preset、项目/锁文件 JSON Schema 与 Dev Container 示例。每次 release 都会用真实归档哈希生成 Winget、Scoop、Homebrew manifest，并为它们提供 checksum 与构建证明。详见[集成与分发](docs/integrations.zh-CN.md)。
 
 ## 未来规划
 
@@ -216,7 +225,6 @@ v1.8 交付受约束的 Provider Registry 预览与依赖图。Registry manifest
 
 | 版本 | 主题 | 计划内容 |
 | --- | --- | --- |
-| v1.9 | 开发者体验与正式分发 | 增加不修改项目状态的 `pinset x <tool>@<selector> -- <command>`；补齐 GitHub Action、Renovate、VS Code schema、Dev Container 示例，以及 Winget、Scoop、Homebrew 等官方分发渠道。 |
 | 持续进行 | 平台与质量 | 在上游提供合适制品时扩展平台和架构；持续执行跨平台 CI、安全审计、恶意输入回归、签名标签、`SHA256SUMS`、SBOM 与构建来源证明验证。 |
 
 路线图会保持 Pinset 的明确边界：传统版本文件仍只由 `detect` / `import` 显式读取；严格项目不默认自动下载并执行缺失工具；核心不加入任务、hooks、`.env`、Secrets、服务管理、Nix/Conda 求解或任意代码插件。上述路线继续使用 schema 3，并优先采用向后兼容的可选字段。

--- a/action.yml
+++ b/action.yml
@@ -35,8 +35,8 @@ runs:
         release="https://github.com/Future-Element/pinset/releases/download/v${PINSET_VERSION}"
         root="${RUNNER_TEMP}/pinset-action-${PINSET_VERSION}"
         mkdir -p "${root}/bin"
-        curl --fail --location --silent --show-error "${release}/${archive}" --output "${root}/${archive}"
-        curl --fail --location --silent --show-error "${release}/SHA256SUMS" --output "${root}/SHA256SUMS"
+        curl --fail --location --silent --show-error --retry 4 --retry-all-errors --retry-delay 2 "${release}/${archive}" --output "${root}/${archive}"
+        curl --fail --location --silent --show-error --retry 4 --retry-all-errors --retry-delay 2 "${release}/SHA256SUMS" --output "${root}/SHA256SUMS"
         expected="$(awk -v name="${archive}" '$2 == name { print $1 }' "${root}/SHA256SUMS")"
         [[ "${expected}" =~ ^[0-9a-fA-F]{64}$ ]] || { echo "Missing checksum for ${archive}" >&2; exit 1; }
         actual="$(sha256sum "${root}/${archive}" | awk '{ print $1 }')"
@@ -56,8 +56,19 @@ runs:
         $root = Join-Path $env:RUNNER_TEMP "pinset-action-$env:PINSET_VERSION"
         $bin = Join-Path $root 'bin'
         New-Item -ItemType Directory -Force -Path $bin | Out-Null
-        Invoke-WebRequest -Uri "$release/$archive" -OutFile (Join-Path $root $archive)
-        Invoke-WebRequest -Uri "$release/SHA256SUMS" -OutFile (Join-Path $root 'SHA256SUMS')
+        function Invoke-PinsetDownload([string] $Uri, [string] $OutFile) {
+          for ($attempt = 1; $attempt -le 4; $attempt++) {
+            try {
+              Invoke-WebRequest -Uri $Uri -OutFile $OutFile
+              return
+            } catch {
+              if ($attempt -eq 4) { throw }
+              Start-Sleep -Seconds 2
+            }
+          }
+        }
+        Invoke-PinsetDownload -Uri "$release/$archive" -OutFile (Join-Path $root $archive)
+        Invoke-PinsetDownload -Uri "$release/SHA256SUMS" -OutFile (Join-Path $root 'SHA256SUMS')
         $line = Get-Content (Join-Path $root 'SHA256SUMS') | Where-Object { $_ -match "^[0-9a-fA-F]{64}\s+$([regex]::Escape($archive))$" } | Select-Object -First 1
         if (-not $line) { throw "Missing checksum for $archive" }
         $expected = ($line -split '\s+')[0]

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,77 @@
+name: Setup Pinset
+description: Install an exact, checksum-verified Pinset release and optionally install the locked project runtimes.
+author: Future Element
+
+inputs:
+  version:
+    description: Exact Pinset release version without the leading v.
+    required: false
+    default: 1.9.0
+  install:
+    description: Run pinset install --locked after Pinset is available.
+    required: false
+    default: "true"
+  working-directory:
+    description: Directory containing pinset.toml and pinset.lock.
+    required: false
+    default: .
+
+runs:
+  using: composite
+  steps:
+    - name: Install Pinset on Unix
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        PINSET_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        case "${RUNNER_OS}-$(uname -m)" in
+          Linux-x86_64) archive="pinset-linux-x86_64.tar.gz" ;;
+          Linux-aarch64|Linux-arm64) archive="pinset-linux-aarch64.tar.gz" ;;
+          macOS-arm64) archive="pinset-macos-aarch64.tar.gz" ;;
+          *) echo "Unsupported Pinset Action runner: ${RUNNER_OS}-$(uname -m)" >&2; exit 1 ;;
+        esac
+        release="https://github.com/Future-Element/pinset/releases/download/v${PINSET_VERSION}"
+        root="${RUNNER_TEMP}/pinset-action-${PINSET_VERSION}"
+        mkdir -p "${root}/bin"
+        curl --fail --location --silent --show-error "${release}/${archive}" --output "${root}/${archive}"
+        curl --fail --location --silent --show-error "${release}/SHA256SUMS" --output "${root}/SHA256SUMS"
+        expected="$(awk -v name="${archive}" '$2 == name { print $1 }' "${root}/SHA256SUMS")"
+        [[ "${expected}" =~ ^[0-9a-fA-F]{64}$ ]] || { echo "Missing checksum for ${archive}" >&2; exit 1; }
+        actual="$(sha256sum "${root}/${archive}" | awk '{ print $1 }')"
+        [[ "${actual,,}" == "${expected,,}" ]] || { echo "Checksum mismatch for ${archive}" >&2; exit 1; }
+        tar -xzf "${root}/${archive}" -C "${root}/bin"
+        printf '%s\n' "${root}/bin" >> "${GITHUB_PATH}"
+
+    - name: Install Pinset on Windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        PINSET_VERSION: ${{ inputs.version }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $archive = 'pinset-windows-x86_64.zip'
+        $release = "https://github.com/Future-Element/pinset/releases/download/v$env:PINSET_VERSION"
+        $root = Join-Path $env:RUNNER_TEMP "pinset-action-$env:PINSET_VERSION"
+        $bin = Join-Path $root 'bin'
+        New-Item -ItemType Directory -Force -Path $bin | Out-Null
+        Invoke-WebRequest -Uri "$release/$archive" -OutFile (Join-Path $root $archive)
+        Invoke-WebRequest -Uri "$release/SHA256SUMS" -OutFile (Join-Path $root 'SHA256SUMS')
+        $line = Get-Content (Join-Path $root 'SHA256SUMS') | Where-Object { $_ -match "^[0-9a-fA-F]{64}\s+$([regex]::Escape($archive))$" } | Select-Object -First 1
+        if (-not $line) { throw "Missing checksum for $archive" }
+        $expected = ($line -split '\s+')[0]
+        $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $root $archive)).Hash
+        if ($actual -ne $expected) { throw "Checksum mismatch for $archive" }
+        Expand-Archive -LiteralPath (Join-Path $root $archive) -DestinationPath $bin -Force
+        Add-Content -LiteralPath $env:GITHUB_PATH -Value $bin
+
+    - name: Install locked runtimes
+      if: inputs.install == 'true'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: pinset install --locked
+
+branding:
+  icon: check-circle
+  color: blue

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -35,17 +35,17 @@ use pinset_core::{
     load_project_config, load_project_python_environment, load_source_config, load_user_settings,
     lockfile_path, managed_runtime_arguments, path_with_selected_tools, pinset_home,
     plan_prune_tool_versions, plan_uninstall_tool_version, project_python_environment_path,
-    repair_download_cache, resolve_command, resolve_project_python_command, resolve_tool_selection,
-    runtime_command_candidates, runtime_command_directory, runtime_environment_for_install,
-    runtime_provider, save_global_config, save_global_state, save_lockfile, save_project_config,
-    save_project_state, save_source_config, save_user_settings, scan_project_sources,
-    selected_runtime_environment, source_config_path, uninstall_node_version,
-    uninstall_tool_version, user_settings_path, validate_exact_dotnet_version,
-    validate_exact_flutter_version, validate_exact_go_version, validate_exact_java_version,
-    validate_exact_node_version, validate_exact_npm_tool_version, validate_exact_python_version,
-    validate_exact_rust_version, validate_lock_matches_selection, validate_lock_matches_tool,
-    validate_lock_matches_tools, validate_managed_runtime_invocation, validate_project_lock_policy,
-    verify_download_cache,
+    provider_dependency_order, repair_download_cache, resolve_command,
+    resolve_project_python_command, resolve_tool_selection, runtime_command_candidates,
+    runtime_command_directory, runtime_environment_for_install, runtime_provider,
+    save_global_config, save_global_state, save_lockfile, save_project_config, save_project_state,
+    save_source_config, save_user_settings, scan_project_sources, selected_runtime_environment,
+    source_config_path, uninstall_node_version, uninstall_tool_version, user_settings_path,
+    validate_exact_dotnet_version, validate_exact_flutter_version, validate_exact_go_version,
+    validate_exact_java_version, validate_exact_node_version, validate_exact_npm_tool_version,
+    validate_exact_python_version, validate_exact_rust_version, validate_lock_matches_selection,
+    validate_lock_matches_tool, validate_lock_matches_tools, validate_managed_runtime_invocation,
+    validate_project_lock_policy, verify_download_cache,
 };
 use serde::Serialize;
 use terminal_size::{Width, terminal_size_of};
@@ -264,6 +264,17 @@ enum Commands {
     Exec {
         #[arg(long)]
         cwd: Option<PathBuf>,
+        #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
+        command: Vec<OsString>,
+    },
+    /// Install and execute one verified runtime selection without changing project state.
+    X {
+        /// Selection such as node@24, pnpm@11, bun@1.3, go@1.25, python@3.14, java@21, rust@stable or dotnet@lts.
+        selection: String,
+        /// Directory used for dependency selection and command execution.
+        #[arg(long)]
+        cwd: Option<PathBuf>,
+        /// Runtime command and arguments, normally separated with `--`.
         #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
         command: Vec<OsString>,
     },
@@ -1090,7 +1101,18 @@ fn run(cli: Cli, catalog: Catalog) -> Result<i32, Box<dyn std::error::Error>> {
         Commands::Cache { command } => run_cache(command, catalog)?,
         Commands::Exec { cwd, command } => {
             let cwd = effective_cwd(cwd)?;
-            return execute_selected(&cwd, &command, catalog);
+            return execute_selected(&cwd, &command, false, catalog);
+        }
+        Commands::X {
+            selection,
+            cwd,
+            command,
+        } => {
+            let cwd = effective_cwd(cwd)?;
+            let mut selected_command = Vec::with_capacity(command.len() + 1);
+            selected_command.push(OsString::from(selection));
+            selected_command.extend(command);
+            return execute_selected(&cwd, &selected_command, true, catalog);
         }
         Commands::Doctor { cwd, json } => {
             let cwd = effective_cwd(cwd)?;
@@ -3071,7 +3093,7 @@ fn install_tool_selection(
     }
     let mut lockfile = new_lockfile();
     lockfile.upsert_tool(locked_tool)?;
-    install_tool_from_lock(&pinset_home()?, &lockfile, &tool, catalog)
+    install_tool_from_lock(&pinset_home()?, &lockfile, &tool, true, catalog)
 }
 
 fn unset_tool(
@@ -3370,7 +3392,7 @@ fn install_locked_selection(
     let lockfile = load_lockfile(lock_path)?;
     validate_lock_matches_tools(&lockfile, configured, config_path)?;
     for provider in pinset_core::selected_provider_order(configured)? {
-        install_tool_from_lock(home, &lockfile, provider.tool, catalog)?;
+        install_tool_from_lock(home, &lockfile, provider.tool, true, catalog)?;
     }
     Ok(())
 }
@@ -3379,6 +3401,7 @@ fn install_tool_from_lock(
     home: &Path,
     lockfile: &Lockfile,
     tool: &str,
+    register_shims: bool,
     catalog: Catalog,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let locked_tool = lockfile
@@ -3445,11 +3468,13 @@ fn install_tool_from_lock(
             outcome.install_dir.display()
         );
     }
-    if let Err(error) = register_provider_commands(home, tool, catalog) {
-        eprintln!(
-            "{}",
-            catalog.shim_auto_registration_failed(&error.to_string())
-        );
+    if register_shims {
+        if let Err(error) = register_provider_commands(home, tool, catalog) {
+            eprintln!(
+                "{}",
+                catalog.shim_auto_registration_failed(&error.to_string())
+            );
+        }
     }
     Ok(())
 }
@@ -3870,6 +3895,7 @@ fn print_current(
 fn execute_selected(
     cwd: &Path,
     command: &[OsString],
+    install_ephemeral: bool,
     catalog: Catalog,
 ) -> Result<i32, Box<dyn std::error::Error>> {
     let (ephemeral_selection, mut command) = command
@@ -3894,16 +3920,19 @@ fn execute_selected(
     let (executable, tool, version, source, config_path, ephemeral_environment) =
         if let Some(selection) = ephemeral_selection {
             let (tool, selector) = parse_tool_selection(selection, catalog)?;
-            let locked_tool = resolve_locked_tool(&tool, &selector)?;
-            let version = locked_tool.version;
-            if selector != version {
-                println!("{tool}@{selector} resolved to {tool}@{version}");
-            }
             if command_tool(command_name) != Some(tool.as_str()) {
                 return Err(Error::UnsupportedCommand {
                     command: command_name.to_owned(),
                 }
                 .into());
+            }
+            let locked_tool = resolve_locked_tool(&tool, &selector)?;
+            let version = locked_tool.version.clone();
+            if selector != version {
+                println!("{tool}@{selector} resolved to {tool}@{version}");
+            }
+            if install_ephemeral {
+                install_ephemeral_selection(&home, cwd, &tool, locked_tool, catalog)?;
             }
             let install_dir = home
                 .join("installs")
@@ -3926,7 +3955,18 @@ fn execute_selected(
                         .join(", "),
                 })?;
             let environment = runtime_environment_for_install(&tool, &install_dir);
-            (executable, tool, version, "ephemeral", None, environment)
+            (
+                executable,
+                tool,
+                version,
+                if install_ephemeral {
+                    "one-shot"
+                } else {
+                    "ephemeral"
+                },
+                None,
+                environment,
+            )
         } else {
             let resolution = if command_tool(command_name).is_some() {
                 resolve_command(command_name, cwd, &home)?
@@ -3980,6 +4020,68 @@ fn execute_selected(
     // INVARIANT: exec is transparent after launch. Keep the platform's full i32 exit value
     // instead of narrowing it to Pinset's own small exit-code range.
     Ok(status.code().unwrap_or(1))
+}
+
+fn install_ephemeral_selection(
+    home: &Path,
+    cwd: &Path,
+    tool: &str,
+    selected: LockedTool,
+    catalog: Catalog,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let providers = provider_dependency_order(tool)?;
+    let mut lockfile = new_lockfile();
+    for provider in &providers {
+        let locked_tool = if provider.tool == tool {
+            selected.clone()
+        } else {
+            let selection = match resolve_tool_selection(provider.tool, cwd, home) {
+                Ok(selection) => selection,
+                Err(
+                    Error::ToolSelectionNotFound { .. }
+                    | Error::ProjectToolSelectionRequired { .. },
+                ) => {
+                    return Err(Error::ProviderDependencyMissing {
+                        tool: tool.to_owned(),
+                        dependency: provider.tool.to_owned(),
+                    }
+                    .into());
+                }
+                Err(error) => return Err(error.into()),
+            };
+            let lock_path = match selection.source {
+                pinset_core::SelectionSource::Project => lockfile_path(&selection.config_path),
+                pinset_core::SelectionSource::Global => global_lockfile_path(home),
+                pinset_core::SelectionSource::System => unreachable!("declared selection"),
+            };
+            let dependency_lock = load_lockfile(&lock_path)?;
+            validate_lock_matches_tool(
+                &dependency_lock,
+                provider.tool,
+                &selection.requested,
+                &selection.config_path,
+            )?;
+            if selection.source == pinset_core::SelectionSource::Project {
+                let config = load_project_config(&selection.config_path)?;
+                validate_project_lock_policy(
+                    &config,
+                    &dependency_lock,
+                    std::time::SystemTime::now(),
+                )?;
+            }
+            dependency_lock
+                .tool(provider.tool)
+                .cloned()
+                .ok_or_else(|| Error::LockedToolMissing {
+                    tool: provider.tool.to_owned(),
+                })?
+        };
+        lockfile.upsert_tool(locked_tool)?;
+    }
+    for provider in providers {
+        install_tool_from_lock(home, &lockfile, provider.tool, false, catalog)?;
+    }
+    Ok(())
 }
 
 fn runtime_command_path(command_dir: &Path, command: &str) -> PathBuf {
@@ -5309,6 +5411,129 @@ fn activation_script(shell: ActivationShell, shim_directory: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn one_shot_install_reuses_verified_runtime_without_writing_selection_state() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        let target = current_target_for_tool("node");
+        let install_dir = home
+            .join("installs")
+            .join("node")
+            .join("24.0.0")
+            .join(&target);
+        let command = if cfg!(windows) {
+            install_dir.join("node.exe")
+        } else {
+            install_dir.join("bin").join("node")
+        };
+        fs::create_dir_all(command.parent().expect("command parent")).expect("install directory");
+        fs::write(&command, b"fixture").expect("runtime command");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = fs::metadata(&command)
+                .expect("command metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&command, permissions).expect("command permissions");
+        }
+        fs::write(
+            install_dir.join(".pinset-install.toml"),
+            format!(
+                "complete = true\ntool = \"node\"\nversion = \"24.0.0\"\ntarget = \"{target}\"\nselected_source = \"fixture\"\nartifact_sha256 = \"{}\"\n",
+                "ab".repeat(32)
+            ),
+        )
+        .expect("install receipt");
+        fs::create_dir_all(&project).expect("project directory");
+        let locked = LockedTool {
+            name: "node".to_owned(),
+            requested: "24".to_owned(),
+            version: "24.0.0".to_owned(),
+            provider: "nodejs".to_owned(),
+            released_at: None,
+            metadata: BTreeMap::new(),
+            artifacts: pinset_core::MVP_NODE_TARGETS
+                .into_iter()
+                .map(|target| {
+                    let plan = pinset_core::plan_node_artifact(
+                        &pinset_core::SourceConfig::default(),
+                        "24.0.0",
+                        target,
+                    )
+                    .expect("Node artifact plan");
+                    pinset_core::LockedArtifact {
+                        target: target.to_owned(),
+                        canonical_url: plan.canonical_url,
+                        artifact_path: plan.artifact_path,
+                        sha256: "ab".repeat(32),
+                        integrity: None,
+                        format: match plan.format {
+                            pinset_core::NodeArchiveFormat::Zip => {
+                                pinset_core::LockedArtifactFormat::Zip
+                            }
+                            pinset_core::NodeArchiveFormat::TarXz => {
+                                pinset_core::LockedArtifactFormat::TarXz
+                            }
+                        },
+                        archive_root: plan.archive_root,
+                        verification: "nodejs-openpgp-sha256".to_owned(),
+                        overlays: Vec::new(),
+                    }
+                })
+                .collect(),
+        };
+
+        install_ephemeral_selection(
+            &home,
+            &project,
+            "node",
+            locked,
+            Catalog::new(Language::English),
+        )
+        .expect("one-shot install");
+
+        assert!(!project.join("pinset.toml").exists());
+        assert!(!project.join("pinset.lock").exists());
+        assert!(!global_config_path(&home).exists());
+        assert!(!global_lockfile_path(&home).exists());
+        assert!(!home.join("shims").exists());
+    }
+
+    #[test]
+    fn one_shot_resolves_provider_dependencies_before_installing() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        fs::create_dir_all(&project).expect("project directory");
+        let selected = LockedTool {
+            name: "pnpm".to_owned(),
+            requested: "11".to_owned(),
+            version: "11.0.0".to_owned(),
+            provider: "pnpm-npm".to_owned(),
+            released_at: None,
+            metadata: BTreeMap::new(),
+            artifacts: Vec::new(),
+        };
+
+        let error = install_ephemeral_selection(
+            &home,
+            &project,
+            "pnpm",
+            selected,
+            Catalog::new(Language::English),
+        )
+        .expect_err("pnpm requires a selected Node.js runtime");
+
+        assert!(matches!(
+            error.downcast_ref::<Error>(),
+            Some(Error::ProviderDependencyMissing { tool, dependency })
+                if tool == "pnpm" && dependency == "node"
+        ));
+        assert!(!home.join("installs").exists());
+    }
 
     #[test]
     fn formats_download_sizes_for_progress_output() {

--- a/crates/pinset/tests/mvp_cli.rs
+++ b/crates/pinset/tests/mvp_cli.rs
@@ -650,6 +650,30 @@ fn exec_can_select_an_installed_exact_version_without_changing_project_state() {
 }
 
 #[test]
+fn one_shot_rejects_a_command_from_another_provider_without_writing_state() {
+    let root = tempdir().expect("temporary root");
+    let workspace = root.path().join("workspace");
+    let home = root.path().join("home");
+    fs::create_dir(&workspace).expect("workspace");
+
+    let output = pinset(
+        &workspace,
+        &home,
+        &["x", "node@24", "--", "python", "--version"],
+    );
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("python"),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!workspace.join("pinset.toml").exists());
+    assert!(!workspace.join("pinset.lock").exists());
+    assert!(!home.exists());
+}
+
+#[test]
 fn doctor_json_is_machine_readable_and_has_no_manager_migration_report() {
     let root = tempdir().expect("temporary root");
     let project = root.path().join("project");

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2,7 +2,7 @@
 
 [English](commands.md) | [简体中文](commands.zh-CN.md) · [README](../README.md)
 
-This document describes the Pinset v1.8 command-line contract. Run `pinset <command> --help` for the exact parser help shipped with your binary.
+This document describes the Pinset v1.9 command-line contract. Run `pinset <command> --help` for the exact parser help shipped with your binary.
 
 ## Conventions
 
@@ -41,7 +41,7 @@ Only commands marked **Yes** below accept `--json`. They write one JSON document
 - `0`: Pinset completed successfully.
 - `1`: `pinset lock audit` completed and found one or more errors or warnings that require action. Informational findings alone still return `0`.
 - `2`: Pinset usage, configuration, metadata, integrity, or installation failure.
-- `pinset exec`: returns the exact child-process exit code after a successful launch; Pinset failures before launch return `2`.
+- `pinset exec` and `pinset x`: return the exact child-process exit code after a successful launch; Pinset failures before launch return `2`.
 
 The tables below repeat exceptional behavior where it matters. Otherwise the command follows these exit codes.
 
@@ -263,6 +263,18 @@ Stable reason codes are grouped as follows:
 | JSON | No; child stdout/stderr remains unwrapped. |
 | Exit | Exact child exit code after launch; `2` if Pinset cannot resolve or launch it. |
 | Key errors | Missing command, unresolved runtime, exact override not installed, shim recursion protection, or process launch failure. |
+
+### `x`
+
+| Field | Description |
+| --- | --- |
+| Purpose | Resolve, verify, install, and run one Provider command without changing project/global selection state. |
+| Syntax and arguments | `pinset x <tool>@<selector> [--cwd <path>] -- <command> [args...]`. The command must belong to the selected Provider. |
+| Modifies state | Selection state: **No**. Verified downloads, cache entries, installation receipts, and installed runtimes under `PINSET_HOME` may be created. The launched program may modify its own files or external state. |
+| Example | `pinset x node@24 -- node ./scripts/build.js` |
+| JSON | No; child stdout/stderr remains unwrapped. |
+| Exit | Exact child exit code after launch; `2` if Pinset cannot resolve, verify, install, or launch it. |
+| Key errors | Invalid selector, command/Provider mismatch, failed metadata or artifact verification, missing declared Provider dependency, unsupported platform, or process launch failure. pnpm requires a valid project/global Node.js selection. |
 
 ### `doctor`
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](commands.md) | [简体中文](commands.zh-CN.md) · [README](../README.zh-CN.md)
 
-本文档描述 Pinset v1.8 命令行协议。可以运行 `pinset <command> --help` 查看当前二进制附带的精确参数帮助。
+本文档描述 Pinset v1.9 命令行协议。可以运行 `pinset <command> --help` 查看当前二进制附带的精确参数帮助。
 
 ## 通用约定
 
@@ -41,7 +41,7 @@
 - `0`：Pinset 成功完成。
 - `1`：`pinset lock audit` 已完成，但发现一个或多个需要处理的错误或警告。只有信息级发现时仍返回 `0`。
 - `2`：Pinset 使用、配置、元数据、完整性或安装失败。
-- `pinset exec`：成功启动子进程后，透传子进程的精确退出码；启动前的 Pinset 错误返回 `2`。
+- `pinset exec` 与 `pinset x`：成功启动子进程后，透传子进程的精确退出码；启动前的 Pinset 错误返回 `2`。
 
 下表会在必要位置重复特殊行为；其余命令均遵循这些退出码。
 
@@ -263,6 +263,18 @@
 | JSON | 不支持；子进程 stdout/stderr 不会被包装。 |
 | 退出码 | 启动后透传子进程精确退出码；Pinset 无法解析或启动时为 `2`。 |
 | 关键错误 | 缺少命令、运行时无法解析、精确覆盖版本未安装、shim 防递归保护或进程启动失败。 |
+
+### `x`
+
+| 字段 | 说明 |
+| --- | --- |
+| 用途 | 解析、验证、安装并运行一次 Provider 命令，同时不改变项目/全局选择状态。 |
+| 语法与参数 | `pinset x <tool>@<selector> [--cwd <path>] -- <command> [args...]`。命令必须属于所选择的 Provider。 |
+| 修改状态 | 选择状态：**否**。可能在 `PINSET_HOME` 下创建已验证下载、缓存项、安装收据与运行时；子进程可能修改自己的文件或外部状态。 |
+| 示例 | `pinset x node@24 -- node ./scripts/build.js` |
+| JSON | 不支持；子进程 stdout/stderr 不封装。 |
+| 退出码 | 成功启动后透传子进程精确退出码；Pinset 无法解析、验证、安装或启动时返回 `2`。 |
+| 关键错误 | 选择器无效、命令与 Provider 不匹配、元数据/制品验证失败、声明的 Provider 依赖缺失、平台不支持或进程启动失败。pnpm 需要有效的项目/全局 Node.js 选择。 |
 
 ### `doctor`
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,57 @@
+# Integrations and distribution
+
+Pinset integrations always select an exact Pinset release and verify the downloaded archive. They do not use an unverified `latest` redirect.
+
+## GitHub Actions
+
+The repository root contains a composite action for Linux x64/ARM64, Windows x64, and macOS ARM64. It verifies the release archive against `SHA256SUMS`, adds both Pinset binaries to `PATH`, and installs the project's locked runtimes by default.
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: Future-Element/pinset@v1.9.0
+    with:
+      version: 1.9.0
+      install: "true"
+  - run: pinset lock audit
+  - run: pinset exec -- node --version
+```
+
+Set `install: "false"` when the job only needs the Pinset CLI. `working-directory` selects the directory passed to `pinset install --locked`.
+
+## Renovate
+
+Merge [`integrations/renovate/pinset.json5`](../integrations/renovate/pinset.json5) into the repository's Renovate configuration, then annotate each managed selector immediately above its TOML key:
+
+```toml
+[tools]
+# renovate: datasource=node-version depName=node
+node = "24.0.0"
+# renovate: datasource=npm depName=pnpm
+pnpm = "11.0.0"
+```
+
+The explicit datasource is intentional: Pinset Providers consume different upstream version systems, so a single guessed datasource would produce incorrect updates. Renovate changes `pinset.toml`; run `pinset update` in the update workflow to refresh and verify `pinset.lock`.
+
+## VS Code schemas
+
+[`schemas/pinset.schema.json`](../schemas/pinset.schema.json) and [`schemas/pinset-lock.schema.json`](../schemas/pinset-lock.schema.json) describe schema 3 configuration and lockfiles. They are JSON Schema documents, while the files they describe use TOML syntax. VS Code's built-in JSON schema association applies only to JSON files, so install a TOML language extension that supports JSON Schema and associate:
+
+- `**/pinset.toml` with `https://raw.githubusercontent.com/Future-Element/pinset/v1.9.0/schemas/pinset.schema.json`
+- `**/pinset.lock` with `https://raw.githubusercontent.com/Future-Element/pinset/v1.9.0/schemas/pinset-lock.schema.json`
+
+Use the tag-pinned URLs for reproducible completion. `pinset.lock` is generated state and should still be updated through Pinset, not hand-edited.
+
+## Dev Containers
+
+Copy [`examples/devcontainer/.devcontainer`](../examples/devcontainer/.devcontainer) into a Pinset project. Its Dockerfile downloads an architecture-specific v1.9.0 archive, verifies `SHA256SUMS`, and installs `pinset` plus `pinset-shim`; `postCreateCommand` then runs `pinset install --locked` after the workspace is mounted.
+
+## Winget, Scoop, and Homebrew
+
+Each GitHub Release includes:
+
+- `pinset-winget.yaml`
+- `pinset-scoop.json`
+- `pinset.rb`
+
+The release workflow generates these files from the same archives it publishes, appends their hashes to `SHA256SUMS`, and creates GitHub artifact attestations. The manifests can be installed directly or used as the source for an upstream catalog submission. Publishing changes to community-owned package indexes is a separate maintainer action from producing the official Pinset manifests.

--- a/docs/integrations.zh-CN.md
+++ b/docs/integrations.zh-CN.md
@@ -1,0 +1,57 @@
+# 集成与分发
+
+Pinset 的集成始终选择精确 Pinset release 并验证下载归档，不使用未经验证的 `latest` 跳转。
+
+## GitHub Actions
+
+仓库根目录包含支持 Linux x64/ARM64、Windows x64 与 macOS ARM64 的 composite action。它会用 `SHA256SUMS` 验证 release 归档，把两个 Pinset 二进制加入 `PATH`，并默认安装项目锁定的运行时。
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: Future-Element/pinset@v1.9.0
+    with:
+      version: 1.9.0
+      install: "true"
+  - run: pinset lock audit
+  - run: pinset exec -- node --version
+```
+
+任务只需要 Pinset CLI 时设置 `install: "false"`；`working-directory` 用于指定执行 `pinset install --locked` 的目录。
+
+## Renovate
+
+把 [`integrations/renovate/pinset.json5`](../integrations/renovate/pinset.json5) 合并进仓库的 Renovate 配置，然后在每个需要管理的 TOML key 紧邻上一行添加注解：
+
+```toml
+[tools]
+# renovate: datasource=node-version depName=node
+node = "24.0.0"
+# renovate: datasource=npm depName=pnpm
+pnpm = "11.0.0"
+```
+
+显式 datasource 是必要边界：不同 Pinset Provider 消费不同上游版本系统，统一猜测 datasource 会产生错误更新。Renovate 修改 `pinset.toml` 后，应在更新工作流中运行 `pinset update` 来刷新并验证 `pinset.lock`。
+
+## VS Code Schema
+
+[`schemas/pinset.schema.json`](../schemas/pinset.schema.json) 与 [`schemas/pinset-lock.schema.json`](../schemas/pinset-lock.schema.json) 描述 schema 3 配置和锁文件。它们是 JSON Schema 文档，但被描述的文件使用 TOML 语法。VS Code 内置 JSON schema 关联只作用于 JSON 文件，因此需要安装支持 JSON Schema 的 TOML 语言扩展，并关联：
+
+- `**/pinset.toml` → `https://raw.githubusercontent.com/Future-Element/pinset/v1.9.0/schemas/pinset.schema.json`
+- `**/pinset.lock` → `https://raw.githubusercontent.com/Future-Element/pinset/v1.9.0/schemas/pinset-lock.schema.json`
+
+使用固定 tag 的 URL 可保证补全行为可复现。`pinset.lock` 仍是生成状态，应由 Pinset 更新而不是手工编辑。
+
+## Dev Container
+
+把 [`examples/devcontainer/.devcontainer`](../examples/devcontainer/.devcontainer) 复制到 Pinset 项目。Dockerfile 会下载适配架构的 v1.9.0 归档、验证 `SHA256SUMS` 并安装 `pinset` 与 `pinset-shim`；工作区挂载后，`postCreateCommand` 再执行 `pinset install --locked`。
+
+## Winget、Scoop 与 Homebrew
+
+每个 GitHub Release 都包含：
+
+- `pinset-winget.yaml`
+- `pinset-scoop.json`
+- `pinset.rb`
+
+release 工作流会根据同一批已发布归档生成它们，把 manifest 哈希追加进 `SHA256SUMS`，并创建 GitHub artifact attestation。它们可以直接使用，也可以作为向上游 catalog 提交的来源。把变更发布到社区所有的包索引，属于生成 Pinset 官方 manifest 之外的独立维护者操作。

--- a/examples/devcontainer/.devcontainer/Dockerfile
+++ b/examples/devcontainer/.devcontainer/Dockerfile
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+ARG PINSET_VERSION=1.9.0
+
+RUN set -eux; \
+    architecture="$(dpkg --print-architecture)"; \
+    case "${architecture}" in \
+      amd64) archive="pinset-linux-x86_64.tar.gz" ;; \
+      arm64) archive="pinset-linux-aarch64.tar.gz" ;; \
+      *) echo "Unsupported architecture: ${architecture}" >&2; exit 1 ;; \
+    esac; \
+    release="https://github.com/Future-Element/pinset/releases/download/v${PINSET_VERSION}"; \
+    curl --fail --location --silent --show-error "${release}/${archive}" --output "/tmp/${archive}"; \
+    curl --fail --location --silent --show-error "${release}/SHA256SUMS" --output /tmp/SHA256SUMS; \
+    expected="$(awk -v name="${archive}" '$2 == name { print $1 }' /tmp/SHA256SUMS)"; \
+    actual="$(sha256sum "/tmp/${archive}" | awk '{ print $1 }')"; \
+    test -n "${expected}"; \
+    test "${actual}" = "${expected}"; \
+    tar -xzf "/tmp/${archive}" -C /usr/local/bin pinset pinset-shim; \
+    rm -f "/tmp/${archive}" /tmp/SHA256SUMS

--- a/examples/devcontainer/.devcontainer/devcontainer.json
+++ b/examples/devcontainer/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "name": "Pinset",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "PINSET_VERSION": "1.9.0"
+    }
+  },
+  "postCreateCommand": "pinset install --locked",
+  "remoteUser": "vscode"
+}

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="1.8.0"
+DEFAULT_VERSION="1.9.0"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -18,7 +18,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 1.8.0.
+  --version VERSION       Install an exact release, for example 1.9.0.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.

--- a/integrations/renovate/pinset.json5
+++ b/integrations/renovate/pinset.json5
@@ -1,0 +1,11 @@
+{
+  customManagers: [
+    {
+      customType: "regex",
+      managerFilePatterns: ["/(^|/)pinset\\.toml$/"],
+      matchStrings: [
+        '#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?\\s*\\n\\s*[A-Za-z0-9_-]+\\s*=\\s*"(?<currentValue>[^"]+)"',
+      ],
+    },
+  ],
+}

--- a/schemas/pinset-lock.schema.json
+++ b/schemas/pinset-lock.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Future-Element/pinset/main/schemas/pinset-lock.schema.json",
+  "title": "Pinset lockfile",
+  "description": "Schema for generated pinset.lock files. Do not edit lockfiles manually.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "generated_by", "tool"],
+  "properties": {
+    "schema": { "const": 3 },
+    "generated_by": { "type": "string", "pattern": "^pinset " },
+    "tool": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/tool" }
+    }
+  },
+  "$defs": {
+    "tool": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "requested", "version", "provider", "artifact"],
+      "properties": {
+        "name": {
+          "enum": [
+            "node",
+            "pnpm",
+            "bun",
+            "go",
+            "flutter",
+            "python",
+            "java",
+            "rust",
+            "dotnet"
+          ]
+        },
+        "requested": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "provider": { "type": "string", "minLength": 1 },
+        "released-at": { "type": "string", "format": "date-time" },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "artifact": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/artifact" }
+        }
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target",
+        "canonical_url",
+        "artifact_path",
+        "format",
+        "archive_root",
+        "verification"
+      ],
+      "properties": {
+        "target": { "type": "string", "minLength": 1 },
+        "canonical_url": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https://"
+        },
+        "artifact_path": { "type": "string", "minLength": 1 },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "integrity": {
+          "type": "string",
+          "pattern": "^(sha256|sha512):[0-9a-f]+$"
+        },
+        "format": { "enum": ["zip", "tar.xz", "tar.gz"] },
+        "archive_root": { "type": "string" },
+        "verification": { "type": "string", "minLength": 1 },
+        "overlay": { "type": "array", "items": { "$ref": "#/$defs/overlay" } }
+      },
+      "anyOf": [{ "required": ["sha256"] }, { "required": ["integrity"] }]
+    },
+    "overlay": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "canonical_url",
+        "artifact_path",
+        "integrity",
+        "format",
+        "archive_root",
+        "verification"
+      ],
+      "properties": {
+        "canonical_url": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https://"
+        },
+        "artifact_path": { "type": "string", "minLength": 1 },
+        "integrity": {
+          "type": "string",
+          "pattern": "^(sha256|sha512):[0-9a-f]+$"
+        },
+        "format": { "enum": ["zip", "tar.xz", "tar.gz"] },
+        "archive_root": { "type": "string" },
+        "verification": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/schemas/pinset.schema.json
+++ b/schemas/pinset.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Future-Element/pinset/main/schemas/pinset.schema.json",
+  "title": "Pinset project configuration",
+  "description": "Schema for pinset.toml. Associate it with TOML files through a VS Code TOML extension.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "tools"],
+  "properties": {
+    "schema": { "const": 3 },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "inherit-global": { "type": "boolean", "default": false },
+        "system-fallback": { "type": "boolean", "default": false },
+        "boundary": { "enum": ["git", "filesystem"], "default": "git" },
+        "verification-strength": {
+          "enum": ["checksum", "signed-checksum", "provenance"]
+        },
+        "minimum-release-age": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]*[dhms]$"
+        }
+      }
+    },
+    "tools": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "node": { "$ref": "#/$defs/selector" },
+        "pnpm": { "$ref": "#/$defs/selector" },
+        "bun": { "$ref": "#/$defs/selector" },
+        "go": { "$ref": "#/$defs/selector" },
+        "flutter": { "$ref": "#/$defs/selector" },
+        "python": { "$ref": "#/$defs/selector" },
+        "java": { "$ref": "#/$defs/selector" },
+        "rust": { "$ref": "#/$defs/selector" },
+        "dotnet": { "$ref": "#/$defs/selector" }
+      }
+    }
+  },
+  "$defs": {
+    "selector": { "type": "string", "minLength": 1 }
+  }
+}

--- a/scripts/generate_package_manifests.py
+++ b/scripts/generate_package_manifests.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Generate package-manager manifests from verified Pinset release archive hashes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+
+
+REPOSITORY = "https://github.com/Future-Element/pinset"
+REQUIRED_ARCHIVES = (
+    "pinset-linux-x86_64.tar.gz",
+    "pinset-linux-aarch64.tar.gz",
+    "pinset-macos-aarch64.tar.gz",
+    "pinset-windows-x86_64.zip",
+)
+
+
+def read_checksums(path: pathlib.Path) -> dict[str, str]:
+    checksums: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = re.fullmatch(r"([0-9a-fA-F]{64})\s+\*?(.+)", line.strip())
+        if match:
+            checksums[match.group(2)] = match.group(1).lower()
+    missing = [archive for archive in REQUIRED_ARCHIVES if archive not in checksums]
+    if missing:
+        raise SystemExit(f"missing release checksums: {', '.join(missing)}")
+    return checksums
+
+
+def release_url(version: str, archive: str) -> str:
+    return f"{REPOSITORY}/releases/download/v{version}/{archive}"
+
+
+def winget(version: str, checksums: dict[str, str]) -> str:
+    archive = "pinset-windows-x86_64.zip"
+    return f"""# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.12.0.schema.json
+PackageIdentifier: FutureElement.Pinset
+PackageVersion: {version}
+PackageLocale: en-US
+Publisher: Future Element
+PackageName: Pinset
+License: MIT
+ShortDescription: Predictable runtime version management for multilingual projects
+PackageUrl: {REPOSITORY}
+InstallerType: zip
+NestedInstallerType: portable
+Installers:
+  - Architecture: x64
+    InstallerUrl: {release_url(version, archive)}
+    InstallerSha256: {checksums[archive].upper()}
+    NestedInstallerFiles:
+      - RelativeFilePath: pinset.exe
+        PortableCommandAlias: pinset
+      - RelativeFilePath: pinset-shim.exe
+        PortableCommandAlias: pinset-shim
+ManifestType: singleton
+ManifestVersion: 1.12.0
+"""
+
+
+def scoop(version: str, checksums: dict[str, str]) -> str:
+    archive = "pinset-windows-x86_64.zip"
+    manifest = {
+        "version": version,
+        "description": "Predictable runtime version management for multilingual projects",
+        "homepage": REPOSITORY,
+        "license": "MIT",
+        "architecture": {
+            "64bit": {
+                "url": release_url(version, archive),
+                "hash": checksums[archive],
+            }
+        },
+        "bin": ["pinset.exe", "pinset-shim.exe"],
+        "checkver": {"github": REPOSITORY},
+        "autoupdate": {
+            "architecture": {
+                "64bit": {
+                    "url": f"{REPOSITORY}/releases/download/v$version/{archive}"
+                }
+            }
+        },
+    }
+    return json.dumps(manifest, indent=2) + "\n"
+
+
+def homebrew(version: str, checksums: dict[str, str]) -> str:
+    linux_x64 = "pinset-linux-x86_64.tar.gz"
+    linux_arm64 = "pinset-linux-aarch64.tar.gz"
+    macos_arm64 = "pinset-macos-aarch64.tar.gz"
+    return f'''class Pinset < Formula
+  desc "Predictable runtime version management for multilingual projects"
+  homepage "{REPOSITORY}"
+  version "{version}"
+  license "MIT"
+
+  on_macos do
+    depends_on arch: :arm64
+    url "{release_url(version, macos_arm64)}"
+    sha256 "{checksums[macos_arm64]}"
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "{release_url(version, linux_arm64)}"
+      sha256 "{checksums[linux_arm64]}"
+    else
+      url "{release_url(version, linux_x64)}"
+      sha256 "{checksums[linux_x64]}"
+    end
+  end
+
+  def install
+    bin.install "pinset", "pinset-shim"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{{bin}}/pinset --version")
+  end
+end
+'''
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--checksums", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args()
+    if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:-rc\.[0-9]+)?", args.version):
+        raise SystemExit(f"invalid release version: {args.version}")
+    checksums = read_checksums(args.checksums)
+    args.output.mkdir(parents=True, exist_ok=True)
+    (args.output / "pinset-winget.yaml").write_text(
+        winget(args.version, checksums), encoding="utf-8", newline="\n"
+    )
+    (args.output / "pinset-scoop.json").write_text(
+        scoop(args.version, checksums), encoding="utf-8", newline="\n"
+    )
+    (args.output / "pinset.rb").write_text(
+        homebrew(args.version, checksums), encoding="utf-8", newline="\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/integrations_test.py
+++ b/scripts/tests/integrations_test.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Static contract checks for v1.9 editor, CI, container, and distribution assets."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+import tomllib
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKSPACE_VERSION = tomllib.loads((ROOT / "Cargo.toml").read_text(encoding="utf-8"))["workspace"][
+    "package"
+]["version"]
+ARCHIVES = (
+    "pinset-linux-x86_64.tar.gz",
+    "pinset-linux-aarch64.tar.gz",
+    "pinset-macos-aarch64.tar.gz",
+    "pinset-windows-x86_64.zip",
+)
+
+
+def require_text(path: pathlib.Path, values: tuple[str, ...]) -> None:
+    content = path.read_text(encoding="utf-8")
+    display = path.relative_to(ROOT) if path.is_relative_to(ROOT) else path
+    for value in values:
+        if value not in content:
+            raise AssertionError(f"{display} is missing {value!r}")
+
+
+for schema_name in ("pinset.schema.json", "pinset-lock.schema.json"):
+    schema = json.loads((ROOT / "schemas" / schema_name).read_text(encoding="utf-8"))
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["additionalProperties"] is False
+
+devcontainer = json.loads(
+    (ROOT / "examples/devcontainer/.devcontainer/devcontainer.json").read_text(encoding="utf-8")
+)
+assert devcontainer["build"]["args"]["PINSET_VERSION"] == WORKSPACE_VERSION
+
+require_text(
+    ROOT / "action.yml",
+    ("using: composite", "SHA256SUMS", "sha256sum", "Get-FileHash", "pinset install --locked"),
+)
+action = (ROOT / "action.yml").read_text(encoding="utf-8")
+action_version = re.search(r"(?ms)^  version:\s*$.*?^    default: ([^\s]+)$", action)
+assert action_version and action_version.group(1) == WORKSPACE_VERSION
+require_text(
+    ROOT / "integrations/renovate/pinset.json5",
+    ("customType: \"regex\"", "datasource", "depName", "currentValue"),
+)
+require_text(
+    ROOT / ".github/workflows/release.yml",
+    ("generate_package_manifests.py", "dist/pinset-winget.yaml", "dist/pinset-scoop.json", "dist/pinset.rb"),
+)
+require_text(
+    ROOT / "examples/devcontainer/.devcontainer/Dockerfile",
+    ("ARG PINSET_VERSION=1.9.0", "SHA256SUMS", "sha256sum"),
+)
+
+with tempfile.TemporaryDirectory() as temporary:
+    temporary_path = pathlib.Path(temporary)
+    checksums = temporary_path / "SHA256SUMS"
+    checksums.write_text(
+        "".join(f"{'ab' * 32}  {archive}\n" for archive in ARCHIVES), encoding="utf-8"
+    )
+    output = temporary_path / "manifests"
+    subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/generate_package_manifests.py"),
+            "--version",
+            WORKSPACE_VERSION,
+            "--checksums",
+            str(checksums),
+            "--output",
+            str(output),
+        ],
+        check=True,
+    )
+    scoop = json.loads((output / "pinset-scoop.json").read_text(encoding="utf-8"))
+    assert scoop["version"] == WORKSPACE_VERSION
+    assert scoop["architecture"]["64bit"]["hash"] == "ab" * 32
+    require_text(
+        output / "pinset-winget.yaml", (f"PackageVersion: {WORKSPACE_VERSION}", "AB" * 32)
+    )
+    require_text(
+        output / "pinset.rb",
+        (f'version "{WORKSPACE_VERSION}"', 'sha256 "' + "ab" * 32 + '"'),
+    )
+
+print("v1.9 integration contracts passed")


### PR DESCRIPTION
## Summary
- add verified one-shot execution with Provider dependency handling and zero selection-state writes
- add checksum-verified GitHub Action, Renovate preset, JSON Schemas, and Dev Container example
- generate checksummed and attested Winget, Scoop, and Homebrew release manifests
- bump the workspace and installer to 1.9.0 and document the release

## Verification
- cargo test --workspace --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings (CI-pinned Rust 1.88; local Rust 1.97 additionally needs the two pre-existing baseline lint allowances)
- python scripts/tests/integrations_test.py
- real isolated pinset x node@24.0.0 -- node --version download/install/run
- winget validate on a generated real-hash manifest

The pre-existing local deletion of docs/comparison.zh-CN.md is intentionally excluded.