### PR TITLE
Fix exact RC version identity in release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,8 @@ jobs:
   build:
     name: Build ${{ matrix.artifact }}
     needs: metadata
+    env:
+      PINSET_RELEASE_VERSION: ${{ github.ref_name }}
     strategy:
       fail-fast: false
       matrix:
@@ -180,6 +182,20 @@ jobs:
 
       - name: Build release binaries
         run: cargo build --release --locked -p pinset-cli -p pinset-shim
+
+      - name: Verify release version handshake
+        shell: bash
+        run: |
+          binary="target/release/pinset"
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            binary="${binary}.exe"
+          fi
+          expected="pinset ${GITHUB_REF_NAME#v}"
+          reported="$("${binary}" --version)"
+          if [[ "${reported}" != "${expected}" ]]; then
+            echo "release binary reported '${reported}', expected '${expected}'" >&2
+            exit 1
+          fi
 
       - name: Verify macOS release dependencies
         if: runner.os == 'macOS'

--- a/crates/pinset-core/src/installer.rs
+++ b/crates/pinset-core/src/installer.rs
@@ -1611,7 +1611,7 @@ fn write_receipt(
         install_root,
         file_count,
         total_size,
-        pinset_version: env!("CARGO_PKG_VERSION"),
+        pinset_version: crate::pinset_version(),
         critical_entries,
     };
     let serialized =

--- a/crates/pinset-core/src/lib.rs
+++ b/crates/pinset-core/src/lib.rs
@@ -279,3 +279,8 @@ pub use target::{current_target, current_target_for_tool};
 #[cfg(feature = "state-write")]
 pub use user_settings::save_user_settings;
 pub use user_settings::{UserSettings, load_user_settings, user_settings_path};
+
+pub fn pinset_version() -> &'static str {
+    let version = option_env!("PINSET_RELEASE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
+    version.strip_prefix('v').unwrap_or(version)
+}

--- a/crates/pinset-shim/src/main.rs
+++ b/crates/pinset-shim/src/main.rs
@@ -183,7 +183,7 @@ fn encrypted_environment(
         .arg("--cwd")
         .arg(cwd)
         .arg("--shim-version")
-        .arg(env!("CARGO_PKG_VERSION"))
+        .arg(pinset_core::pinset_version())
         .stdin(Stdio::inherit())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit());

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -61,7 +61,7 @@ use crate::i18n::{Catalog, Language};
 #[derive(Debug, Parser)]
 #[command(
     name = "pinset",
-    version,
+    version = pinset_core::pinset_version(),
     about = "Predictable runtime version management for multilingual projects"
 )]
 struct Cli {
@@ -1294,10 +1294,10 @@ fn run(cli: Cli, catalog: Catalog) -> Result<i32, Box<dyn std::error::Error>> {
             profile,
             shim_version,
         } => {
-            if shim_version != env!("CARGO_PKG_VERSION") {
+            if shim_version != pinset_core::pinset_version() {
                 return Err(format!(
                     "Pinset CLI/shim version mismatch: CLI={} shim={shim_version}",
-                    env!("CARGO_PKG_VERSION")
+                    pinset_core::pinset_version()
                 )
                 .into());
             }
@@ -2922,8 +2922,10 @@ fn resolve_locked_tool(
     let provider = runtime_provider(tool).expect("validated provider");
     let mut locked = match provider.capabilities.metadata {
         RuntimeMetadataKind::Node => {
-            let lockfile = node_metadata_client(&pinset_home()?)?
-                .resolve_lock(selector, &format!("pinset {}", env!("CARGO_PKG_VERSION")))?;
+            let lockfile = node_metadata_client(&pinset_home()?)?.resolve_lock(
+                selector,
+                &format!("pinset {}", pinset_core::pinset_version()),
+            )?;
             lockfile
                 .tool("node")
                 .expect("generated Node lock contains node")
@@ -2950,7 +2952,7 @@ fn resolve_locked_tool(
 fn new_lockfile() -> Lockfile {
     Lockfile {
         schema: pinset_core::LOCKFILE_SCHEMA,
-        generated_by: format!("pinset {}", env!("CARGO_PKG_VERSION")),
+        generated_by: format!("pinset {}", pinset_core::pinset_version()),
         tools: Vec::new(),
     }
 }
@@ -2975,7 +2977,7 @@ fn select_tool(
         let mut config = load_optional_global_config(&config_path)?.unwrap_or_default();
         let lock_path = global_lockfile_path(&home);
         let mut lockfile = load_optional_lockfile(&lock_path)?.unwrap_or_else(new_lockfile);
-        lockfile.generated_by = format!("pinset {}", env!("CARGO_PKG_VERSION"));
+        lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
         lockfile.upsert_tool(locked_tool.clone())?;
         config.set_tool(&tool, &selector);
         validate_lock_matches_tools(&lockfile, &config.tools, &config_path)?;
@@ -2990,7 +2992,7 @@ fn select_tool(
         let mut project = load_project_config(&config_path)?;
         let lock_path = lockfile_path(&config_path);
         let mut lockfile = load_optional_lockfile(&lock_path)?.unwrap_or_else(new_lockfile);
-        lockfile.generated_by = format!("pinset {}", env!("CARGO_PKG_VERSION"));
+        lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
         lockfile.upsert_tool(locked_tool.clone())?;
         project.set_tool(&tool, &selector);
         save_project_state(&config_path, &project, &lockfile)?;
@@ -3283,7 +3285,7 @@ fn run_project_import(
     }
 
     let mut lockfile = existing_lockfile.unwrap_or_else(new_lockfile);
-    lockfile.generated_by = format!("pinset {}", env!("CARGO_PKG_VERSION"));
+    lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
     for (tool, selector, locked_tool) in &resolved {
         if selector != &locked_tool.version {
             println!(
@@ -3419,7 +3421,7 @@ fn run_update(
     }
 
     if !dry_run {
-        lockfile.generated_by = format!("pinset {}", env!("CARGO_PKG_VERSION"));
+        lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
         if global {
             let config = load_global_config(&config_path)?;
             save_global_state(&home, &config, &lockfile)?;

--- a/crates/pinset/src/self_update.rs
+++ b/crates/pinset/src/self_update.rs
@@ -22,7 +22,7 @@ struct Release {
 
 pub(crate) fn outdated(prerelease: bool, json: bool) -> Result<(), Box<dyn std::error::Error>> {
     let latest = latest_release(prerelease)?;
-    let current = Version::parse(env!("CARGO_PKG_VERSION"))?;
+    let current = Version::parse(pinset_core::pinset_version())?;
     let available = parse_tag(&latest.tag_name)?;
     let is_outdated = available > current;
     if json {
@@ -42,7 +42,7 @@ pub(crate) fn outdated(prerelease: bool, json: bool) -> Result<(), Box<dyn std::
 }
 
 pub(crate) fn update(requested: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
-    let current = Version::parse(env!("CARGO_PKG_VERSION"))?;
+    let current = Version::parse(pinset_core::pinset_version())?;
     let version = match requested {
         Some(value) => Version::parse(value.trim_start_matches('v'))?,
         None => parse_tag(&latest_release(false)?.tag_name)?,
@@ -91,7 +91,7 @@ fn latest_release(prerelease: bool) -> Result<Release, Box<dyn std::error::Error
 
 fn client() -> Result<Client, reqwest::Error> {
     Client::builder()
-        .user_agent(format!("pinset/{}", env!("CARGO_PKG_VERSION")))
+        .user_agent(format!("pinset/{}", pinset_core::pinset_version()))
         .build()
 }
 

--- a/crates/pinset/tests/environment_cli.rs
+++ b/crates/pinset/tests/environment_cli.rs
@@ -97,7 +97,7 @@ fn broker(
     Command::new(env!("CARGO_BIN_EXE_pinset"))
         .args(["__env-resolve", "--cwd"])
         .arg(project)
-        .args(["--shim-version", env!("CARGO_PKG_VERSION")])
+        .args(["--shim-version", pinset_core::pinset_version()])
         .env("PINSET_HOME", home)
         .env("PINSET_IDENTITY", identity)
         .output()


### PR DESCRIPTION
## Summary

- compile release binaries with the exact tag version while keeping the workspace at `2.0.0`
- use the same effective version for CLI output, shim/CLI handshake, receipts, locks, and self-update
- fail every platform release build before packaging when `pinset --version` does not match the tag

## RC finding

The first `v2.0.0-rc.1` assets passed checksums and archive checks, but the installer correctly rejected a binary that reported `2.0.0` instead of `2.0.0-rc.1`.

## Validation

- RC override: `pinset 2.0.0-rc.1`
- stable fallback: `pinset 2.0.0`
- Clippy with warnings denied
- full workspace tests
- integration contracts and diff checks