### PR TITLE
feat: release Pinset v2.1.0 batch selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.1.0 - 2026-08-21
+
+- Allow `pinset global` and `pinset use` to accept a variable-length batch of selections across any supported, non-duplicate Provider set whose dependencies are satisfied.
+- Parse and resolve the complete batch before one configuration/lock update, preserving unmentioned selections and leaving state unchanged on pre-commit failure.
+- Run installation once after the batch state commit in deterministic Provider dependency order; installation failure preserves the complete lock and reports the appropriate locked-install retry command.
+- Keep no-argument `global`, single-selection compatibility, `--no-install`, completions, and English/Chinese help and command documentation aligned with the batch interface.
+
+No configuration or lock schema migration is required. Explicit `install <tool@exact-version>` remains single-selection; `install --locked` continues to install the complete project or global scope.
+
 ## 2.0.0 - 2026-08-21
 
 - Add schema 4 project identities and profile-scoped age X25519 encrypted environments with explicit recipients, recovery files, system credential-store identities, portable dotenv import/export, and collision-safe direct shim injection.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2734,7 +2734,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "clap",
  "flate2",
@@ -2760,7 +2760,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "atomic-write-file",
  "base64",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-env"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "age",
  "atomic-write-file",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.97"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Future Element"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ export PATH="$HOME/.local/bin:$PATH"
 Install an exact version or choose another directory:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.0.0
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.0
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -103,7 +103,7 @@ Remove-Item .\install.ps1
 Install an exact version:
 
 ```powershell
-.\install.ps1 -Version 2.0.0
+.\install.ps1 -Version 2.1.0
 ```
 
 Windows and WSL are separate environments and require separate installations. The installer registers Pinset and every built-in command route, but it does not pre-download language runtimes.
@@ -151,8 +151,7 @@ pinset completions powershell | Out-String | Invoke-Expression
 Global selections apply outside Pinset projects, or when a project explicitly inherits them:
 
 ```sh
-pinset global node@lts
-pinset global pnpm@latest
+pinset global node@lts pnpm@latest
 pinset current node
 ```
 
@@ -161,9 +160,7 @@ pinset current node
 ```sh
 mkdir example && cd example
 pinset init
-pinset use node@24
-pinset use pnpm@11
-pinset use python@3.14
+pinset use node@24 pnpm@11 python@3.14 --no-install
 pinset install --locked
 pinset lock audit
 ```
@@ -284,9 +281,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.0.0
+      - uses: Future-Element/pinset@v2.1.0
         with:
-          version: 2.0.0
+          version: 2.1.0
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js
@@ -366,9 +363,27 @@ pinset prune --dry-run
 
 To remove Pinset itself, delete the CLI, shim, and routes from the command directory, then remove the initialization line you added to the Shell profile. Delete `PINSET_HOME` only when you also intend to remove every managed runtime, cache entry, global selection, and local trust record. Project `pinset.toml`, `pinset.lock`, `pinset.env/*.age`, and `.venv` files are never removed automatically.
 
-## Roadmap
+## Current release and roadmap
 
-Future 2.x work may evaluate KMS/OIDC, broader platform artifacts, and stronger provenance while preserving Pinset's local-first, fail-closed boundary. The roadmap does not promise specific versions or dates.
+### v2.1: batch selection and installation
+
+Pinset 2.1 lets `global` and `use` accept a variable-length `SELECTION...` list. A batch may contain any non-duplicate set of Pinset's built-in Providers whose declared dependencies are present in the resulting scope: Node.js, pnpm, Bun, Go, Python, Java, Rust, .NET, and Flutter. Dart continues to come from the selected Flutter SDK. The examples below are illustrative, not a fixed tool set:
+
+```sh
+pinset global node@lts python@latest rust@stable
+pinset use java@lts dotnet@lts flutter@latest
+pinset use --global node@lts pnpm@latest bun@latest go@latest python@3.14
+```
+
+- Public syntax is `pinset global [SELECTION...] [--no-install]` and `pinset use <SELECTION...> [--no-install] [--global]`. `global` keeps its no-argument inspection mode; `use` requires at least one selection. There is no fixed batch size.
+- `--no-install` applies to the complete batch. Existing selections not named by the command remain unchanged.
+- Every argument is parsed, duplicate Providers are rejected, and every selector is resolved before Pinset writes state. A parse, metadata, policy, or resolution failure leaves configuration, lockfiles, and installations unchanged.
+- All resolved selections are committed to configuration and the lockfile in one atomic state update. Project policy is validated against the complete resulting lock before the write.
+- After the state commit, Pinset performs one locked installation pass in Provider dependency order. Downloads are not run concurrently in v2.1, so output, shared dependencies, cache ownership, and failure recovery stay deterministic.
+- If installation fails after the state commit, successfully installed runtimes remain valid and the complete requested state remains locked. The error directs the user to retry with `pinset install --locked` or `pinset install --global --locked`; Pinset does not pretend that already completed filesystem installations can be rolled back atomically.
+- Help, completions, English/Chinese command references, and tests cover single-selection compatibility and multi-selection behavior. `install <tool@exact-version>` remains a single explicit-selection command; lock-based `install --locked` installs the complete scope.
+
+Later 2.x work may evaluate KMS/OIDC, broader platform artifacts, and stronger provenance while preserving Pinset's local-first, fail-closed boundary. The roadmap does not promise specific versions or dates.
 
 ## Contributing and license
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -88,7 +88,7 @@ export PATH="$HOME/.local/bin:$PATH"
 安装指定版本或目录：
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.0.0
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.0
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -103,7 +103,7 @@ Remove-Item .\install.ps1
 指定版本：
 
 ```powershell
-.\install.ps1 -Version 2.0.0
+.\install.ps1 -Version 2.1.0
 ```
 
 Windows 与 WSL 是两个独立环境，需要分别安装。安装器只安装 Pinset 和所有内置命令路由，不会预先下载语言运行时。
@@ -151,8 +151,7 @@ pinset completions powershell | Out-String | Invoke-Expression
 全局选择只在 Pinset 项目之外生效，或由项目策略显式继承：
 
 ```sh
-pinset global node@lts
-pinset global pnpm@latest
+pinset global node@lts pnpm@latest
 pinset current node
 ```
 
@@ -161,9 +160,7 @@ pinset current node
 ```sh
 mkdir example && cd example
 pinset init
-pinset use node@24
-pinset use pnpm@11
-pinset use python@3.14
+pinset use node@24 pnpm@11 python@3.14 --no-install
 pinset install --locked
 pinset lock audit
 ```
@@ -284,9 +281,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.0.0
+      - uses: Future-Element/pinset@v2.1.0
         with:
-          version: 2.0.0
+          version: 2.1.0
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js
@@ -366,9 +363,27 @@ pinset prune --dry-run
 
 完整卸载 Pinset 时，删除安装目录中的 CLI、shim 和路由命令，再删除自己加入 Shell 配置的初始化行。只有确定不再需要任何受管运行时、缓存、全局选择和本机信任时，才删除 `PINSET_HOME`。项目中的 `pinset.toml`、`pinset.lock`、`pinset.env/*.age` 与 `.venv` 不会自动删除。
 
-## 未来规划
+## 当前版本与未来规划
 
-后续 2.x 会在保持失败关闭和本地优先边界的前提下评估 KMS/OIDC、更广的平台制品和更强的来源证明。路线图不承诺具体版本或发布日期。
+### v2.1：批量选择与安装
+
+Pinset 2.1 允许 `global` 和 `use` 接受可变长度的 `SELECTION...` 列表。一个批次可以包含 Pinset 任意不重复、且在最终作用域中满足声明依赖的内置 Provider 集合：Node.js、pnpm、Bun、Go、Python、Java、Rust、.NET 和 Flutter；Dart 仍由选中的 Flutter SDK 提供。下面只是示例，不是固定工具组合：
+
+```sh
+pinset global node@lts python@latest rust@stable
+pinset use java@lts dotnet@lts flutter@latest
+pinset use --global node@lts pnpm@latest bun@latest go@latest python@3.14
+```
+
+- 公开语法为 `pinset global [SELECTION...] [--no-install]` 和 `pinset use <SELECTION...> [--no-install] [--global]`。`global` 保留无参数查看模式；`use` 至少需要一个选择，批次数量不固定。
+- `--no-install` 对整个批次生效。命令未提及的现有选择保持不变。
+- Pinset 先解析所有参数、拒绝重复 Provider，并在写入状态前解析完所有 selector。任一参数、元数据、策略或版本解析失败时，配置、锁文件和安装状态都不变。
+- 所有解析结果通过一次原子状态更新写入配置和锁文件。写入前使用完整的结果锁验证项目策略。
+- 状态提交后，Pinset 按 Provider 依赖顺序只执行一轮锁定安装。v2.1 不并发下载，以保证输出、共享依赖、缓存所有权和失败恢复具有确定性。
+- 如果状态提交后安装失败，已成功安装的运行时保持有效，完整请求状态仍保留在锁文件中。错误会提示使用 `pinset install --locked` 或 `pinset install --global --locked` 重试；Pinset 不会假装已完成的文件系统安装可以原子回滚。
+- 帮助、命令补全、中英文命令文档和测试同时覆盖单选择兼容性与多选择行为。`install <tool@精确版本>` 仍是单个显式选择命令；基于锁的 `install --locked` 会安装完整作用域。
+
+更后续的 2.x 会在保持失败关闭和本地优先边界的前提下评估 KMS/OIDC、更广的平台制品和更强的来源证明。路线图不承诺具体版本或发布日期。
 
 ## 贡献与许可证
 

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   version:
     description: Exact Pinset release version without the leading v.
     required: false
-    default: 2.0.0
+    default: 2.1.0
   install:
     description: Run pinset install --locked after Pinset is available.
     required: false

--- a/crates/pinset/src/i18n.rs
+++ b/crates/pinset/src/i18n.rs
@@ -288,7 +288,7 @@ impl Catalog {
     pub fn top_level_help(self) -> &'static str {
         match self.language {
             Language::English => {
-                "Pinset manages predictable runtime versions.\n\nUsage: pinset [--lang <en|zh-CN>] <COMMAND>\n\nCommands:\n  init         Create project configuration\n  detect       Detect traditional version files\n  import       Import traditional version selections\n  global       Show or set the global default\n  use          Select and lock a project version\n  unset        Clear a project or global selection\n  install      Install or repair a runtime\n  paths        Explain Pinset and runtime paths\n  uninstall    Safely uninstall an exact version\n  prune        Remove unused managed versions\n  outdated     Check selected versions for updates\n  current      Show the effective selection\n  list         List installed or available versions\n  lock         Audit lock integrity and ownership\n  cache        Inspect, verify or clean the download cache\n  which        Show the resolved command path\n  exec         Run with the selected version\n  doctor       Diagnose configuration and PATH\n  venv         Manage the project Python environment\n  shim         Repair or migrate command shims\n  env          Manage encrypted project environments\n  trust        Manage local project trust\n  self         Check or update Pinset\n  activate     Enable provider command routing in a shell\n  completions  Generate shell completion\n  source       Manage download sources\n  provider     Inspect and verify Provider manifests\n\nRun `pinset <command> --help` for command details."
+                "Pinset manages predictable runtime versions.\n\nUsage: pinset [--lang <en|zh-CN>] <COMMAND>\n\nCommands:\n  init         Create project configuration\n  detect       Detect traditional version files\n  import       Import traditional version selections\n  global       Show or batch-set global defaults\n  use          Select and lock project runtimes\n  unset        Clear a project or global selection\n  install      Install or repair a runtime\n  paths        Explain Pinset and runtime paths\n  uninstall    Safely uninstall an exact version\n  prune        Remove unused managed versions\n  outdated     Check selected versions for updates\n  current      Show the effective selection\n  list         List installed or available versions\n  lock         Audit lock integrity and ownership\n  cache        Inspect, verify or clean the download cache\n  which        Show the resolved command path\n  exec         Run with the selected version\n  doctor       Diagnose configuration and PATH\n  venv         Manage the project Python environment\n  shim         Repair or migrate command shims\n  env          Manage encrypted project environments\n  trust        Manage local project trust\n  self         Check or update Pinset\n  activate     Enable provider command routing in a shell\n  completions  Generate shell completion\n  source       Manage download sources\n  provider     Inspect and verify Provider manifests\n\nRun `pinset <command> --help` for command details."
             }
             Language::SimplifiedChinese => {
                 "Pinset 用于统一管理可复现的运行时版本。\n\n用法：pinset [--lang <en|zh-CN>] <命令>\n\n执行 `pinset <命令> --help` 查看命令详情。"
@@ -309,10 +309,10 @@ impl Catalog {
                 "将可安全映射的传统运行时版本选择导入 Pinset 配置和锁文件。\n\n用法：pinset import [--cwd <目录>] [--force] [--no-install]"
             }
             Some("global") => {
-                "查看或设置项目之外使用的全局默认运行时。\n\n用法：pinset global [node@lts|pnpm@11|bun@1.3|go@1.25|python@3.14|flutter@3.47|java@lts|rust@stable|dotnet@lts] [--no-install]"
+                "查看或批量设置项目之外使用的全局默认运行时。\n\n用法：pinset global [<工具>@<选择器>...] [--no-install]"
             }
             Some("use") => {
-                "选择并锁定 Node.js、pnpm、Bun、Go、Python、Flutter、Java、Rust 或 .NET SDK 版本。\n\n用法：pinset use <node@24|pnpm@11|bun@1.3|go@1.25|python@3.14|flutter@3.47|java@21|rust@1.97|dotnet@10> [--global] [--no-install]"
+                "批量选择并锁定 Node.js、pnpm、Bun、Go、Python、Flutter、Java、Rust 或 .NET SDK 版本。\n\n用法：pinset use <工具>@<选择器> [<工具>@<选择器>...] [--global] [--no-install]"
             }
             Some("unset") => {
                 "清除项目或全局运行时选择，不卸载运行时。\n\n用法：pinset unset <node|pnpm|bun|go|python|flutter|java|rust|dotnet> [--global] [--cwd <目录>]"

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -97,19 +97,21 @@ enum Commands {
         #[arg(long)]
         no_install: bool,
     },
-    /// Show or set a default runtime version used outside projects.
+    /// Show or set default runtime versions used outside projects.
     Global {
-        /// Selection such as node@lts, pnpm@11, bun@1.3, go@1.25, python@3.14, java@21, rust@stable or dotnet@lts.
-        selection: Option<String>,
-        /// Update the global selection and lock without downloading the runtime.
-        #[arg(long, requires = "selection")]
+        /// Selections such as node@lts, python@3.14 and rust@stable.
+        #[arg(value_name = "SELECTION")]
+        selections: Vec<String>,
+        /// Update every global selection and the lock without downloading runtimes.
+        #[arg(long, requires = "selections")]
         no_install: bool,
     },
-    /// Select and lock a runtime version for the current project or globally.
+    /// Select and lock one or more runtime versions for the current project or globally.
     Use {
-        /// Selection such as node@24, pnpm@11, bun@1.3, go@1.25, python@3.14, java@lts, rust@1.97 or dotnet@10.
-        selection: String,
-        /// Update the selection and lock without downloading the runtime.
+        /// Selections such as node@24, python@3.14 and rust@1.97.
+        #[arg(value_name = "SELECTION", required = true, num_args = 1..)]
+        selections: Vec<String>,
+        /// Update every selection and the lock without downloading runtimes.
         #[arg(long)]
         no_install: bool,
         /// Save the selection under PINSET_HOME instead of pinset.toml.
@@ -1115,12 +1117,12 @@ fn run(cli: Cli, catalog: Catalog) -> Result<i32, Box<dyn std::error::Error>> {
             no_install,
         } => run_project_import(&effective_cwd(cwd)?, force, no_install, catalog)?,
         Commands::Global {
-            selection,
+            selections,
             no_install,
         } => {
-            if let Some(selection) = selection {
+            if !selections.is_empty() {
                 let cwd = env::current_dir()?;
-                select_tool(&selection, true, no_install, false, &cwd, catalog)?;
+                select_tools(&selections, true, no_install, &cwd, catalog)?;
                 print_project_override(&cwd, &pinset_home()?, catalog)?;
             } else {
                 print_global_current(catalog)?;
@@ -1128,12 +1130,12 @@ fn run(cli: Cli, catalog: Catalog) -> Result<i32, Box<dyn std::error::Error>> {
             }
         }
         Commands::Use {
-            selection,
+            selections,
             no_install,
             global,
         } => {
             let cwd = env::current_dir()?;
-            select_tool(&selection, global, no_install, false, &cwd, catalog)?
+            select_tools(&selections, global, no_install, &cwd, catalog)?
         }
         Commands::Unset { tool, global, cwd } => {
             require_provider(&tool)?;
@@ -2957,70 +2959,163 @@ fn new_lockfile() -> Lockfile {
     }
 }
 
-fn select_tool(
-    selection: &str,
+type ResolvedSelection = (String, String, LockedTool);
+
+fn select_tools(
+    selections: &[String],
     global: bool,
     no_install: bool,
-    initialize_project: bool,
     cwd: &Path,
     catalog: Catalog,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let (tool, selector) = parse_tool_selection(selection, catalog)?;
-    let locked_tool = resolve_locked_tool(&tool, &selector)?;
-    let version = locked_tool.version.clone();
-    if selector != version {
-        println!("{tool}@{selector} resolved to {tool}@{version}");
+    let resolved = resolve_tool_selection_batch(selections, catalog, resolve_locked_tool)?;
+    let home = pinset_home()?;
+    let (scope, lock_path) = save_resolved_selection_batch(&home, cwd, global, &resolved)?;
+
+    for (tool, selector, locked_tool) in &resolved {
+        if selector != &locked_tool.version {
+            println!(
+                "{tool}@{selector} resolved to {tool}@{}",
+                locked_tool.version
+            );
+        }
+        if tool == "node" {
+            println!(
+                "{}",
+                catalog.selected(
+                    scope,
+                    &locked_tool.version,
+                    locked_tool.artifacts.len(),
+                    &lock_path,
+                )
+            );
+        } else {
+            println!(
+                "selected {tool}@{} for {scope} ({} targets, lock {})",
+                locked_tool.version,
+                locked_tool.artifacts.len(),
+                lock_path.display()
+            );
+        }
     }
-    let (scope, lock_path) = if global {
-        let home = pinset_home()?;
-        let config_path = global_config_path(&home);
+
+    if !no_install {
+        let installation = if global {
+            install_global(&home, catalog)
+        } else {
+            install_project(cwd, catalog)
+        };
+        if let Err(error) = installation {
+            let localized = catalog.command_error(error.as_ref());
+            let detail = localized
+                .strip_prefix("error: ")
+                .or_else(|| localized.strip_prefix("错误："))
+                .unwrap_or(&localized);
+            let retry = if global {
+                "pinset install --global --locked"
+            } else {
+                "pinset install --locked"
+            };
+            return Err(match catalog.language() {
+                Language::English => format!(
+                    "{detail}; every requested selection and lock was saved successfully, retry with `{retry}`"
+                )
+                .into(),
+                Language::SimplifiedChinese => format!(
+                    "{detail}；所有请求的选择和锁已成功保存，请使用 `{retry}` 重试"
+                )
+                .into(),
+            });
+        }
+    } else {
+        for (tool, _, _) in &resolved {
+            if let Err(error) = register_provider_commands(&home, tool, catalog) {
+                eprintln!(
+                    "{}",
+                    catalog.shim_auto_registration_failed(&error.to_string())
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn save_resolved_selection_batch(
+    home: &Path,
+    cwd: &Path,
+    global: bool,
+    resolved: &[ResolvedSelection],
+) -> Result<(&'static str, PathBuf), Box<dyn std::error::Error>> {
+    if global {
+        let config_path = global_config_path(home);
         let mut config = load_optional_global_config(&config_path)?.unwrap_or_default();
-        let lock_path = global_lockfile_path(&home);
+        let lock_path = global_lockfile_path(home);
         let mut lockfile = load_optional_lockfile(&lock_path)?.unwrap_or_else(new_lockfile);
         lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
-        lockfile.upsert_tool(locked_tool.clone())?;
-        config.set_tool(&tool, &selector);
-        validate_lock_matches_tools(&lockfile, &config.tools, &config_path)?;
-        save_global_state(&home, &config, &lockfile)?;
-        ("global", lock_path)
+        apply_resolved_selections(&mut config.tools, &mut lockfile, resolved)?;
+        save_global_state(home, &config, &lockfile)?;
+        Ok(("global", lock_path))
     } else {
-        let config_path = match find_optional_project_config(cwd)? {
-            Some(path) => path,
-            None if initialize_project => create_project_config(cwd)?,
-            None => find_project_config(cwd)?,
-        };
+        let config_path = find_project_config(cwd)?;
         let mut project = load_project_config(&config_path)?;
         let lock_path = lockfile_path(&config_path);
         let mut lockfile = load_optional_lockfile(&lock_path)?.unwrap_or_else(new_lockfile);
         lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
-        lockfile.upsert_tool(locked_tool.clone())?;
-        project.set_tool(&tool, &selector);
+        apply_resolved_selections(&mut project.tools, &mut lockfile, resolved)?;
         save_project_state(&config_path, &project, &lockfile)?;
-        ("project", lock_path)
-    };
-    if tool == "node" {
-        println!(
-            "{}",
-            catalog.selected(scope, &version, locked_tool.artifacts.len(), &lock_path)
-        );
-    } else {
-        println!(
-            "selected {tool}@{version} for {scope} ({} targets, lock {})",
-            locked_tool.artifacts.len(),
-            lock_path.display()
-        );
+        Ok(("project", lock_path))
     }
-    if !no_install {
-        if global {
-            install_global(&pinset_home()?, catalog)?;
-        } else {
-            install_project(cwd, catalog)?;
+}
+
+fn parse_tool_selection_batch(
+    selections: &[String],
+    catalog: Catalog,
+) -> Result<Vec<(String, String)>, Box<dyn std::error::Error>> {
+    let mut parsed = Vec::with_capacity(selections.len());
+    let mut seen = BTreeSet::new();
+    for selection in selections {
+        let (tool, selector) = parse_tool_selection(selection, catalog)?;
+        if !seen.insert(tool.clone()) {
+            return Err(match catalog.language() {
+                Language::English => format!(
+                    "runtime provider {tool:?} appears more than once in the selection batch"
+                )
+                .into(),
+                Language::SimplifiedChinese => {
+                    format!("运行时 Provider {tool:?} 在批量选择中重复出现").into()
+                }
+            });
         }
-    } else if let Err(error) = register_provider_commands(&pinset_home()?, &tool, catalog) {
-        eprintln!(
-            "{}",
-            catalog.shim_auto_registration_failed(&error.to_string())
-        );
+        parsed.push((tool, selector));
+    }
+    Ok(parsed)
+}
+
+fn resolve_tool_selection_batch<F>(
+    selections: &[String],
+    catalog: Catalog,
+    mut resolver: F,
+) -> Result<Vec<ResolvedSelection>, Box<dyn std::error::Error>>
+where
+    F: FnMut(&str, &str) -> Result<LockedTool, Box<dyn std::error::Error>>,
+{
+    let parsed = parse_tool_selection_batch(selections, catalog)?;
+    let mut resolved = Vec::with_capacity(parsed.len());
+    for (tool, selector) in parsed {
+        let locked_tool = resolver(&tool, &selector)?;
+        resolved.push((tool, selector, locked_tool));
+    }
+    Ok(resolved)
+}
+
+fn apply_resolved_selections(
+    configured: &mut BTreeMap<String, String>,
+    lockfile: &mut Lockfile,
+    resolved: &[ResolvedSelection],
+) -> Result<(), Box<dyn std::error::Error>> {
+    for (tool, selector, locked_tool) in resolved {
+        lockfile.upsert_tool(locked_tool.clone())?;
+        configured.insert(tool.clone(), selector.clone());
     }
     Ok(())
 }
@@ -6443,6 +6538,332 @@ mod tests {
                 ..
             }) if selection == "node@24"
         ));
+    }
+
+    #[test]
+    fn parses_variable_length_global_and_project_selection_batches() {
+        let global = Cli::try_parse_from([
+            "pinset",
+            "global",
+            "node@lts",
+            "python@latest",
+            "rust@stable",
+            "--no-install",
+        ])
+        .expect("global batch");
+        assert!(matches!(
+            global.command,
+            Some(Commands::Global {
+                selections,
+                no_install: true,
+            }) if selections == ["node@lts", "python@latest", "rust@stable"]
+        ));
+
+        let project = Cli::try_parse_from([
+            "pinset",
+            "use",
+            "--global",
+            "java@lts",
+            "dotnet@lts",
+            "flutter@latest",
+        ])
+        .expect("project batch");
+        assert!(matches!(
+            project.command,
+            Some(Commands::Use {
+                selections,
+                global: true,
+                no_install: false,
+            }) if selections == ["java@lts", "dotnet@lts", "flutter@latest"]
+        ));
+
+        let inspection = Cli::try_parse_from(["pinset", "global"]).expect("global inspection");
+        assert!(matches!(
+            inspection.command,
+            Some(Commands::Global { selections, .. }) if selections.is_empty()
+        ));
+
+        let single = Cli::try_parse_from(["pinset", "use", "node@24", "--no-install"])
+            .expect("single-selection compatibility");
+        assert!(matches!(
+            single.command,
+            Some(Commands::Use {
+                selections,
+                no_install: true,
+                ..
+            }) if selections == ["node@24"]
+        ));
+
+        let missing = Cli::try_parse_from(["pinset", "use"]).expect_err("use requires a batch");
+        assert_eq!(missing.kind(), ErrorKind::MissingRequiredArgument);
+
+        let invalid_no_install = Cli::try_parse_from(["pinset", "global", "--no-install"])
+            .expect_err("global --no-install requires a selection");
+        assert_eq!(
+            invalid_no_install.kind(),
+            ErrorKind::MissingRequiredArgument
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_providers_before_resolving_any_batch_member() {
+        let selections = vec!["node@22".to_owned(), "node@24".to_owned()];
+        let mut calls = 0;
+        let error =
+            resolve_tool_selection_batch(&selections, Catalog::new(Language::English), |_, _| {
+                calls += 1;
+                unreachable!("duplicate validation must run before metadata resolution")
+            })
+            .expect_err("duplicate Node.js selection");
+
+        assert_eq!(calls, 0);
+        assert!(error.to_string().contains("appears more than once"));
+    }
+
+    #[test]
+    fn failed_batch_resolution_leaves_the_candidate_state_unchanged() {
+        let selections = vec![
+            "node@lts".to_owned(),
+            "python@latest".to_owned(),
+            "rust@stable".to_owned(),
+        ];
+        let mut configured = BTreeMap::from([("go".to_owned(), "1.25".to_owned())]);
+        let original = configured.clone();
+        let mut lockfile = new_lockfile();
+        let mut calls = 0;
+
+        let result = resolve_tool_selection_batch(
+            &selections,
+            Catalog::new(Language::English),
+            |tool, selector| {
+                calls += 1;
+                if tool == "python" {
+                    return Err("fixture metadata failure".into());
+                }
+                Ok(test_selection_lock(tool, selector, &format!("{calls}.0.0")))
+            },
+        );
+        if let Ok(resolved) = result {
+            apply_resolved_selections(&mut configured, &mut lockfile, &resolved)
+                .expect("apply resolved batch");
+        }
+
+        assert_eq!(calls, 2);
+        assert_eq!(configured, original);
+        assert!(lockfile.tools.is_empty());
+    }
+
+    #[test]
+    fn applies_a_complete_batch_once_and_preserves_unmentioned_selections() {
+        let mut configured = BTreeMap::from([("go".to_owned(), "1.25".to_owned())]);
+        let mut lockfile = new_lockfile();
+        let resolved = vec![
+            (
+                "node".to_owned(),
+                "lts".to_owned(),
+                test_selection_lock("node", "lts", "24.0.0"),
+            ),
+            (
+                "python".to_owned(),
+                "latest".to_owned(),
+                test_selection_lock("python", "latest", "3.14.0"),
+            ),
+            (
+                "rust".to_owned(),
+                "stable".to_owned(),
+                test_selection_lock("rust", "stable", "1.97.0"),
+            ),
+        ];
+
+        apply_resolved_selections(&mut configured, &mut lockfile, &resolved)
+            .expect("apply complete batch");
+
+        assert_eq!(configured["go"], "1.25");
+        assert_eq!(configured["node"], "lts");
+        assert_eq!(configured["python"], "latest");
+        assert_eq!(configured["rust"], "stable");
+        assert_eq!(lockfile.tool("node").unwrap().version, "24.0.0");
+        assert_eq!(lockfile.tool("python").unwrap().version, "3.14.0");
+        assert_eq!(lockfile.tool("rust").unwrap().version, "1.97.0");
+    }
+
+    #[test]
+    fn saves_complete_project_and_global_batches() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        fs::create_dir_all(&project).expect("project directory");
+        let project_path = project.join(pinset_core::PROJECT_CONFIG_FILENAME);
+        save_project_config(
+            &project_path,
+            &ProjectConfig {
+                schema: PROJECT_CONFIG_SCHEMA,
+                project_id: Some(uuid::Uuid::new_v4().to_string()),
+                policy: Default::default(),
+                tools: BTreeMap::new(),
+                environment: None,
+            },
+        )
+        .expect("empty project config");
+
+        let project_batch = vec![
+            (
+                "node".to_owned(),
+                "lts".to_owned(),
+                persistable_selection_lock("node", "lts", "24.0.0"),
+            ),
+            (
+                "go".to_owned(),
+                "latest".to_owned(),
+                persistable_selection_lock("go", "latest", "1.25.1"),
+            ),
+        ];
+        let (scope, saved_lock_path) =
+            save_resolved_selection_batch(&home, &project, false, &project_batch)
+                .expect("save project batch");
+        assert_eq!(scope, "project");
+        assert_eq!(saved_lock_path, project.join("pinset.lock"));
+        let saved_project = load_project_config(&project_path).expect("saved project config");
+        let saved_project_lock = load_lockfile(&saved_lock_path).expect("saved project lock");
+        assert_eq!(saved_project.tools["node"], "lts");
+        assert_eq!(saved_project.tools["go"], "latest");
+        assert_eq!(saved_project_lock.tool("node").unwrap().version, "24.0.0");
+        assert_eq!(saved_project_lock.tool("go").unwrap().version, "1.25.1");
+
+        let global_batch = vec![
+            (
+                "node".to_owned(),
+                "lts".to_owned(),
+                persistable_selection_lock("node", "lts", "24.0.0"),
+            ),
+            (
+                "go".to_owned(),
+                "latest".to_owned(),
+                persistable_selection_lock("go", "latest", "1.25.1"),
+            ),
+        ];
+        let (scope, saved_lock_path) =
+            save_resolved_selection_batch(&home, &project, true, &global_batch)
+                .expect("save global batch");
+        assert_eq!(scope, "global");
+        assert_eq!(saved_lock_path, global_lockfile_path(&home));
+        let saved_global = load_global_config(&global_config_path(&home)).expect("global config");
+        let saved_global_lock = load_lockfile(&saved_lock_path).expect("global lock");
+        assert_eq!(saved_global.tools.len(), 2);
+        assert_eq!(saved_global.tools["node"], "lts");
+        assert_eq!(saved_global.tools["go"], "latest");
+        assert_eq!(saved_global_lock.tools.len(), 2);
+    }
+
+    fn persistable_selection_lock(tool: &str, requested: &str, version: &str) -> LockedTool {
+        match tool {
+            "node" => {
+                let artifacts = pinset_core::MVP_NODE_TARGETS
+                    .into_iter()
+                    .map(|target| {
+                        let plan = pinset_core::plan_node_artifact(
+                            &pinset_core::SourceConfig::default(),
+                            version,
+                            target,
+                        )
+                        .expect("Node artifact plan");
+                        pinset_core::LockedArtifact {
+                            target: target.to_owned(),
+                            canonical_url: plan.canonical_url,
+                            artifact_path: plan.artifact_path,
+                            sha256: "ab".repeat(32),
+                            integrity: None,
+                            format: match plan.format {
+                                pinset_core::NodeArchiveFormat::Zip => {
+                                    pinset_core::LockedArtifactFormat::Zip
+                                }
+                                pinset_core::NodeArchiveFormat::TarXz => {
+                                    pinset_core::LockedArtifactFormat::TarXz
+                                }
+                            },
+                            archive_root: plan.archive_root,
+                            verification: "nodejs-openpgp-sha256".to_owned(),
+                            overlays: Vec::new(),
+                        }
+                    })
+                    .collect();
+                let mut lockfile = Lockfile::new_node(
+                    "pinset batch selection test".to_owned(),
+                    version.to_owned(),
+                    "5BE8A3F6C8A5C01D106C0AD820B1A390B168D356".to_owned(),
+                    "official".to_owned(),
+                    artifacts,
+                );
+                let mut locked = lockfile.tools.remove(0);
+                locked.requested = requested.to_owned();
+                locked
+            }
+            "go" => {
+                let artifacts = pinset_core::GO_TARGETS
+                    .into_iter()
+                    .map(|target| {
+                        let plan = pinset_core::plan_go_artifact(
+                            &pinset_core::SourceConfig::default(),
+                            version,
+                            target,
+                        )
+                        .expect("Go artifact plan");
+                        pinset_core::LockedArtifact {
+                            target: target.to_owned(),
+                            canonical_url: plan.canonical_url,
+                            artifact_path: plan.artifact_path,
+                            sha256: "cd".repeat(32),
+                            integrity: None,
+                            format: match plan.format {
+                                pinset_core::GoArchiveFormat::Zip => {
+                                    pinset_core::LockedArtifactFormat::Zip
+                                }
+                                pinset_core::GoArchiveFormat::TarGz => {
+                                    pinset_core::LockedArtifactFormat::TarGz
+                                }
+                            },
+                            archive_root: plan.archive_root,
+                            verification: "go-download-json-sha256".to_owned(),
+                            overlays: Vec::new(),
+                        }
+                    })
+                    .collect();
+                LockedTool {
+                    name: tool.to_owned(),
+                    requested: requested.to_owned(),
+                    version: version.to_owned(),
+                    provider: "go-official".to_owned(),
+                    released_at: None,
+                    metadata: BTreeMap::new(),
+                    artifacts,
+                }
+            }
+            other => panic!("unsupported persistable test tool {other}"),
+        }
+    }
+
+    fn test_selection_lock(tool: &str, requested: &str, version: &str) -> LockedTool {
+        let provider = match tool {
+            "node" => "nodejs-official",
+            "pnpm" => "pnpm-npm",
+            "bun" => "bun-npm",
+            "go" => "go-official",
+            "flutter" => "flutter-official",
+            "python" => "python-build-standalone",
+            "java" => "adoptium-temurin",
+            "rust" => "rust-official",
+            "dotnet" => "microsoft-dotnet-sdk",
+            other => panic!("unsupported test tool {other}"),
+        };
+        LockedTool {
+            name: tool.to_owned(),
+            requested: requested.to_owned(),
+            version: version.to_owned(),
+            provider: provider.to_owned(),
+            released_at: None,
+            metadata: BTreeMap::new(),
+            artifacts: Vec::new(),
+        }
     }
 
     #[test]

--- a/crates/pinset/tests/language_cli.rs
+++ b/crates/pinset/tests/language_cli.rs
@@ -51,12 +51,9 @@ fn saves_chinese_and_uses_it_for_following_commands() {
     let help = pinset(&first_project, &home, &["--lang", "zh-CN", "use", "--help"]);
     assert_success_contains(
         &help,
-        "选择并锁定 Node.js、pnpm、Bun、Go、Python、Flutter、Java、Rust 或 .NET SDK 版本",
+        "批量选择并锁定 Node.js、pnpm、Bun、Go、Python、Flutter、Java、Rust 或 .NET SDK 版本",
     );
-    assert_success_contains(
-        &help,
-        "node@24|pnpm@11|bun@1.3|go@1.25|python@3.14|flutter@3.47|java@21|rust@1.97|dotnet@10",
-    );
+    assert_success_contains(&help, "<工具>@<选择器> [<工具>@<选择器>...]");
     assert!(
         !String::from_utf8_lossy(&help.stdout).contains("Usage:"),
         "help should be localized: {}",
@@ -68,7 +65,7 @@ fn saves_chinese_and_uses_it_for_following_commands() {
         &home,
         &["--lang", "zh-CN", "global", "--help"],
     );
-    assert_success_contains(&global_help, "查看或设置项目之外使用的全局默认运行时");
+    assert_success_contains(&global_help, "查看或批量设置项目之外使用的全局默认运行时");
     assert_success_contains(&global_help, "pinset global");
 
     let activate_help = pinset(

--- a/crates/pinset/tests/mvp_cli.rs
+++ b/crates/pinset/tests/mvp_cli.rs
@@ -165,6 +165,46 @@ fn global_command_without_state_is_read_only_and_actionable() {
 }
 
 #[test]
+fn invalid_selection_batches_fail_before_creating_global_state() {
+    let root = tempdir().expect("temporary root");
+    let workspace = root.path().join("workspace");
+    let home = root.path().join("home");
+    fs::create_dir(&workspace).expect("workspace");
+
+    let duplicate = pinset(
+        &workspace,
+        &home,
+        &["global", "node@22", "node@24", "--no-install"],
+    );
+    assert!(!duplicate.status.success());
+    assert!(
+        String::from_utf8_lossy(&duplicate.stderr).contains("appears more than once"),
+        "stderr: {}",
+        String::from_utf8_lossy(&duplicate.stderr)
+    );
+    assert!(
+        !home.exists(),
+        "duplicate batch must not create global state"
+    );
+
+    let unsupported = pinset(
+        &workspace,
+        &home,
+        &["global", "node@24", "unknown@latest", "--no-install"],
+    );
+    assert!(!unsupported.status.success());
+    assert!(
+        String::from_utf8_lossy(&unsupported.stderr).contains("is not available"),
+        "stderr: {}",
+        String::from_utf8_lossy(&unsupported.stderr)
+    );
+    assert!(
+        !home.exists(),
+        "unsupported batch member must fail before metadata resolution or state writes"
+    );
+}
+
+#[test]
 fn shim_path_is_read_only_and_install_keeps_explicit_safe_overrides() {
     let root = tempdir().expect("temporary root");
     let workspace = root.path().join("workspace");

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2,7 +2,7 @@
 
 [English](commands.md) | [简体中文](commands.zh-CN.md) · [README](../README.md)
 
-This document describes the Pinset v2.0 command-line contract. Run `pinset <command> --help` for the exact parser help shipped with your binary.
+This document describes the Pinset v2.1 command-line contract. Run `pinset <command> --help` for the exact parser help shipped with your binary.
 
 ## Conventions
 
@@ -91,25 +91,25 @@ Import never reads installed state from another runtime manager, executes manage
 
 | Field | Description |
 | --- | --- |
-| Purpose | Show global selections or set one global default. |
-| Syntax and arguments | `pinset global [<tool>@<selector>] [--no-install]`. `--no-install` requires a selection. |
-| Modifies state | Without a selection: **No**. With a selection: **Yes**, writes global config and lock; installs unless `--no-install` is used. |
-| Example | `pinset global node@lts` |
+| Purpose | Show global selections or batch-set any combination of global runtime defaults. |
+| Syntax and arguments | `pinset global [<tool>@<selector>...] [--no-install]`. With no selections it remains read-only; `--no-install` requires at least one selection. A Provider may appear only once per batch. |
+| Modifies state | Without selections: **No**. With selections: **Yes.** Pinset resolves the complete batch before one config/lock update, preserves unmentioned selections, then performs one locked installation pass unless `--no-install` is used. |
+| Example | `pinset global node@lts python@latest rust@stable` |
 | JSON | No. |
 | Exit | `0` success; `2` on Pinset failure. |
-| Key errors | Unsupported Provider, invalid selector, unavailable metadata, untrusted manifest, download/integrity failure, or unsupported target. |
+| Key errors | Duplicate/unsupported Provider, invalid selector, unavailable metadata, untrusted manifest, dependency or policy failure, download/integrity failure, or unsupported target. A pre-commit failure changes no selection; an installation failure retains the complete new lock and reports the global locked-install retry command. |
 
 ### `use`
 
 | Field | Description |
 | --- | --- |
-| Purpose | Resolve and lock one runtime for the nearest project, or for global scope. |
-| Syntax and arguments | `pinset use <tool>@<selector> [--no-install] [--global]`. |
-| Modifies state | **Yes.** Writes the selected scope's config and lock; installs unless `--no-install` is used. |
-| Example | `pinset use pnpm@10` |
+| Purpose | Resolve and lock one or more runtimes for the nearest project, or for global scope. |
+| Syntax and arguments | `pinset use <tool>@<selector>... [--no-install] [--global]`. At least one selection is required and a Provider may appear only once. |
+| Modifies state | **Yes.** Resolves every selection before one scope config/lock update, preserves unmentioned selections, then performs one dependency-ordered locked installation pass unless `--no-install` is used. |
+| Example | `pinset use java@lts dotnet@lts flutter@latest` |
 | JSON | No. |
 | Exit | `0` success; `2` on Pinset failure. |
-| Key errors | Missing project config, invalid selector, metadata/signature failure, unsupported platform, or installation failure. |
+| Key errors | Missing project config, duplicate Provider, invalid selector, metadata/signature, dependency or project-policy failure, unsupported platform, or installation failure. A pre-commit failure changes no selection; an installation failure retains the complete new lock and reports the locked-install retry command. |
 
 ### `unset`
 
@@ -889,9 +889,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.0.0
+      - uses: Future-Element/pinset@v2.1.0
         with:
-          version: 2.0.0
+          version: 2.1.0
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](commands.md) | [简体中文](commands.zh-CN.md) · [README](../README.zh-CN.md)
 
-本文档描述 Pinset v2.0 命令行协议。可以运行 `pinset <command> --help` 查看当前二进制附带的精确参数帮助。
+本文档描述 Pinset v2.1 命令行协议。可以运行 `pinset <command> --help` 查看当前二进制附带的精确参数帮助。
 
 ## 通用约定
 
@@ -91,25 +91,25 @@
 
 | 字段 | 说明 |
 | --- | --- |
-| 用途 | 查看全局选择，或设置一个全局默认版本。 |
-| 语法与参数 | `pinset global [<tool>@<selector>] [--no-install]`。`--no-install` 必须与选择表达式一起使用。 |
-| 修改状态 | 不带选择表达式：**否**。带选择表达式：**是**，写入全局配置和锁；除非指定 `--no-install`，否则同时安装。 |
-| 示例 | `pinset global node@lts` |
+| 用途 | 查看全局选择，或批量设置任意组合的全局默认运行时。 |
+| 语法与参数 | `pinset global [<tool>@<selector>...] [--no-install]`。不带选择时仍是只读查看；`--no-install` 至少需要一个选择。每个 Provider 在同一批次只能出现一次。 |
+| 修改状态 | 不带选择：**否**。带选择：**是。** Pinset 先解析完整批次，再执行一次配置/锁更新，保留未提及的选择；除非使用 `--no-install`，之后只执行一轮锁定安装。 |
+| 示例 | `pinset global node@lts python@latest rust@stable` |
 | JSON | 不支持。 |
 | 退出码 | 成功为 `0`；Pinset 失败为 `2`。 |
-| 关键错误 | Provider 不支持、选择器无效、元数据不可用、清单不受信任、下载/完整性失败或目标平台不支持。 |
+| 关键错误 | Provider 重复/不支持、选择器无效、元数据不可用、清单不受信任、依赖/策略失败、下载/完整性失败或目标平台不支持。状态提交前失败不修改选择；安装失败保留完整新锁，并报告全局锁定安装重试命令。 |
 
 ### `use`
 
 | 字段 | 说明 |
 | --- | --- |
-| 用途 | 为最近项目解析并锁定一个运行时，或写入全局作用域。 |
-| 语法与参数 | `pinset use <tool>@<selector> [--no-install] [--global]`。 |
-| 修改状态 | **是。** 写入所选作用域的配置和锁；除非指定 `--no-install`，否则同时安装。 |
-| 示例 | `pinset use pnpm@10` |
+| 用途 | 为最近项目解析并锁定一个或多个运行时，或写入全局作用域。 |
+| 语法与参数 | `pinset use <tool>@<selector>... [--no-install] [--global]`。至少需要一个选择，每个 Provider 只能出现一次。 |
+| 修改状态 | **是。** 先解析所有选择，再执行一次作用域配置/锁更新，保留未提及的选择；除非使用 `--no-install`，之后只按依赖顺序执行一轮锁定安装。 |
+| 示例 | `pinset use java@lts dotnet@lts flutter@latest` |
 | JSON | 不支持。 |
 | 退出码 | 成功为 `0`；Pinset 失败为 `2`。 |
-| 关键错误 | 缺少项目配置、选择器无效、元数据/签名失败、平台不支持或安装失败。 |
+| 关键错误 | 缺少项目配置、Provider 重复、选择器无效、元数据/签名、依赖/项目策略失败、平台不支持或安装失败。状态提交前失败不修改选择；安装失败保留完整新锁，并报告锁定安装重试命令。 |
 
 ### `unset`
 
@@ -889,9 +889,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.0.0
+      - uses: Future-Element/pinset@v2.1.0
         with:
-          version: 2.0.0
+          version: 2.1.0
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/examples/devcontainer/.devcontainer/Dockerfile
+++ b/examples/devcontainer/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
-ARG PINSET_VERSION=2.0.0
+ARG PINSET_VERSION=2.1.0
 
 RUN set -eux; \
     architecture="$(dpkg --print-architecture)"; \

--- a/examples/devcontainer/.devcontainer/devcontainer.json
+++ b/examples/devcontainer/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-        "PINSET_VERSION": "2.0.0"
+        "PINSET_VERSION": "2.1.0"
     }
   },
   "postCreateCommand": "pinset install --locked",

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string] $Version = '2.0.0',
+    [string] $Version = '2.1.0',
     [string] $InstallDir = (Join-Path $env:LOCALAPPDATA 'Pinset\bin')
 )
 

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="2.0.0"
+DEFAULT_VERSION="2.1.0"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -22,7 +22,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 2.0.0.
+  --version VERSION       Install an exact release, for example 2.1.0.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.

--- a/scripts/tests/integrations_test.py
+++ b/scripts/tests/integrations_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Static contract checks for v2.0 editor, CI, container, and distribution assets."""
+"""Static contract checks for editor, CI, container, and distribution assets."""
 
 from __future__ import annotations
 
@@ -113,4 +113,4 @@ with tempfile.TemporaryDirectory() as temporary:
         (f'version "{WORKSPACE_VERSION}"', 'sha256 "' + "ab" * 32 + '"'),
     )
 
-print("v2.0 integration contracts passed")
+print(f"v{WORKSPACE_VERSION} integration contracts passed")


### PR DESCRIPTION
## Summary
- allow pinset global and pinset use to accept variable-length batches across any supported Provider set
- resolve the complete batch before one atomic state update, preserve unmentioned selections, and install once in dependency order
- add failure-safety, compatibility, help, documentation, and version 2.1.0 release metadata

## Verification
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo test --workspace --all-features --locked (304 tests)
- cargo check --workspace --all-features --locked
- integration contract tests
- Windows installer/uninstaller contract tests
- Unix uninstaller contract test
- shim dependency boundary check