### PR TITLE
fix: release Pinset v2.1.1 peer runtime routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.1.1 - 2026-08-26
+
+- Include every installed Provider selected by the active project configuration—or by global configuration when no project applies—in routed runtime `PATH`, so package-manager scripts can invoke locked peer runtimes such as `pnpm -> bun` without falling back to a Pinset shim.
+- Replace the blanket shim-depth guard with a bounded command-chain guard that permits legitimate cross-Provider calls while still rejecting real command cycles.
+
+No configuration or lock schema migration is required.
+
 ## 2.1.0 - 2026-08-21
 
 - Allow `pinset global` and `pinset use` to accept a variable-length batch of selections across any supported, non-duplicate Provider set whose dependencies are satisfied.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2734,7 +2734,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "clap",
  "flate2",
@@ -2760,7 +2760,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "atomic-write-file",
  "base64",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-env"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "age",
  "atomic-write-file",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.97"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Future Element"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ export PATH="$HOME/.local/bin:$PATH"
 Install an exact version or choose another directory:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.0
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.1
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -103,7 +103,7 @@ Remove-Item .\install.ps1
 Install an exact version:
 
 ```powershell
-.\install.ps1 -Version 2.1.0
+.\install.ps1 -Version 2.1.1
 ```
 
 Windows and WSL are separate environments and require separate installations. The installer registers Pinset and every built-in command route, but it does not pre-download language runtimes.
@@ -281,9 +281,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.0
+      - uses: Future-Element/pinset@v2.1.1
         with:
-          version: 2.1.0
+          version: 2.1.1
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -88,7 +88,7 @@ export PATH="$HOME/.local/bin:$PATH"
 安装指定版本或目录：
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.0
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.1
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -103,7 +103,7 @@ Remove-Item .\install.ps1
 指定版本：
 
 ```powershell
-.\install.ps1 -Version 2.1.0
+.\install.ps1 -Version 2.1.1
 ```
 
 Windows 与 WSL 是两个独立环境，需要分别安装。安装器只安装 Pinset 和所有内置命令路由，不会预先下载语言运行时。
@@ -281,9 +281,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.0
+      - uses: Future-Element/pinset@v2.1.1
         with:
-          version: 2.1.0
+          version: 2.1.1
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   version:
     description: Exact Pinset release version without the leading v.
     required: false
-    default: 2.1.0
+    default: 2.1.1
   install:
     description: Run pinset install --locked after Pinset is available.
     required: false

--- a/crates/pinset-core/src/resolver.rs
+++ b/crates/pinset-core/src/resolver.rs
@@ -5,6 +5,7 @@
 //! currently executing shim are excluded from system fallback to prevent recursive routing.
 
 use std::{
+    collections::BTreeMap,
     env,
     ffi::{OsStr, OsString},
     fs,
@@ -17,7 +18,7 @@ use crate::{
     Error, Result, RuntimeCommandLayout, RuntimeEnvironmentKind, current_target_for_tool,
     find_project_context, global_config_path, is_managed_command_shim, load_optional_global_config,
     load_project_config, load_project_python_environment, project_python_command_candidates,
-    provider_dependency_order, runtime_provider, runtime_provider_for_command,
+    provider_dependency_order, runtime_provider, runtime_provider_for_command, runtime_providers,
 };
 #[cfg(feature = "lockfile")]
 use crate::{
@@ -552,6 +553,39 @@ pub fn path_with_selected_tools(
             entries.push(command_dir);
         }
     }
+    let configured_tools = effective_configured_tools(cwd, pinset_home)?;
+    for provider in runtime_providers()
+        .iter()
+        .filter(|provider| configured_tools.contains_key(provider.tool))
+    {
+        if provider.tool == tool {
+            continue;
+        }
+        let Ok(selection) = resolve_tool_selection(provider.tool, cwd, pinset_home) else {
+            continue;
+        };
+        let install_dir = pinset_home
+            .join("installs")
+            .join(provider.tool)
+            .join(&selection.version)
+            .join(current_target_for_tool(provider.tool));
+        let command_dir =
+            if provider.tool == "python" && selection.source == SelectionSource::Project {
+                let Ok(environment) = load_project_python_environment(
+                    &selection.config_path,
+                    &selection.version,
+                    &current_target_for_tool("python"),
+                ) else {
+                    continue;
+                };
+                environment.command_directory
+            } else {
+                runtime_command_directory(provider.tool, &install_dir)
+            };
+        if command_dir.is_dir() && !entries.iter().any(|entry| paths_equal(entry, &command_dir)) {
+            entries.push(command_dir);
+        }
+    }
     if let Some(inherited) = env::var_os("PATH") {
         for entry in env::split_paths(&inherited) {
             if !paths_equal(&entry, &shim_dir)
@@ -562,6 +596,20 @@ pub fn path_with_selected_tools(
         }
     }
     env::join_paths(entries).map_err(|source| Error::RuntimePathJoin { source })
+}
+
+fn effective_configured_tools(cwd: &Path, pinset_home: &Path) -> Result<BTreeMap<String, String>> {
+    let context = find_project_context(cwd)?;
+    if let Some(config_path) = context.config_path {
+        let config = load_project_config(&config_path)?;
+        return Ok(config.tools);
+    }
+
+    Ok(
+        load_optional_global_config(&global_config_path(pinset_home))?
+            .map(|config| config.tools)
+            .unwrap_or_default(),
+    )
 }
 
 pub fn selected_runtime_environment(
@@ -818,6 +866,44 @@ mod tests {
         assert_eq!(resolution.source, SelectionSource::Project);
         assert_eq!(resolution.executable, executable);
         assert_eq!(resolution.selection_path, Some(project.join("pinset.toml")));
+    }
+
+    #[test]
+    fn selected_tool_path_includes_other_project_providers() {
+        let root = tempdir().expect("temp directory");
+        let project = root.path().join("project");
+        let home = root.path().join("home");
+        fs::create_dir_all(&project).expect("project");
+        fs::write(
+            project.join("pinset.toml"),
+            "schema = 1\n[tools]\nbun = \"1.3.14\"\nnode = \"24.0.0\"\npnpm = \"11.22.0\"\npython = \"3.13.0\"\n",
+        )
+        .expect("project config");
+
+        let pnpm_install_dir = home
+            .join("installs/pnpm/11.22.0")
+            .join(current_target_for_tool("pnpm"));
+        let node_install_dir = home
+            .join("installs/node/24.0.0")
+            .join(current_target_for_tool("node"));
+        let bun_install_dir = home
+            .join("installs/bun/1.3.14")
+            .join(current_target_for_tool("bun"));
+        let pnpm_dir = runtime_command_directory("pnpm", &pnpm_install_dir);
+        let node_dir = runtime_command_directory("node", &node_install_dir);
+        let bun_dir = runtime_command_directory("bun", &bun_install_dir);
+        for directory in [&pnpm_dir, &node_dir, &bun_dir] {
+            fs::create_dir_all(directory).expect("runtime command directory");
+        }
+        let pnpm = pnpm_dir.join(if cfg!(windows) { "pnpm.exe" } else { "pnpm" });
+        fs::write(&pnpm, b"fake pnpm").expect("pnpm executable");
+
+        let path = path_with_selected_tools("pnpm", &pnpm, &project, &home)
+            .expect("selected provider PATH");
+        let entries = env::split_paths(&path).collect::<Vec<_>>();
+        assert_eq!(entries[0], pnpm_dir);
+        assert_eq!(entries[1], node_dir);
+        assert_eq!(entries[2], bun_dir);
     }
 
     #[test]

--- a/crates/pinset-shim/src/main.rs
+++ b/crates/pinset-shim/src/main.rs
@@ -1,8 +1,8 @@
 //! Runtime-independent command router used by every Provider command.
 //!
-//! INVARIANT: resolution excludes this executable and the managed shim directory, while a depth
-//! marker protects the remaining process boundary. A routed runtime must never resolve back to a
-//! Pinset shim.
+//! INVARIANT: resolution excludes this executable and the managed shim directory, while an
+//! invocation chain rejects actual command cycles without blocking legitimate cross-Provider
+//! calls. A routed runtime must never resolve back to a Pinset shim.
 
 use std::{
     collections::BTreeSet,
@@ -27,7 +27,8 @@ use pinset_core::{
     resolve_command_with_path, selected_runtime_environment, validate_managed_runtime_invocation,
 };
 
-const SHIM_DEPTH_ENV: &str = "PINSET_SHIM_DEPTH";
+const SHIM_CHAIN_ENV: &str = "PINSET_SHIM_CHAIN";
+const MAX_SHIM_CHAIN_LENGTH: usize = 32;
 const SELECTED_TOOL_ENV: &str = "PINSET_SELECTED_TOOL";
 const SELECTED_VERSION_ENV: &str = "PINSET_SELECTED_VERSION";
 const SELECTION_SOURCE_ENV: &str = "PINSET_SELECTION_SOURCE";
@@ -48,9 +49,8 @@ fn main() {
 }
 
 fn run() -> Result<i32, Box<dyn std::error::Error>> {
-    ensure_not_recursive()?;
-
     let invocation = Invocation::parse()?;
+    let shim_chain = extend_shim_chain(&invocation.command)?;
     let home = pinset_home_from_env()?;
     let current_executable = env::current_exe()?;
     let path = env::var_os("PATH");
@@ -84,7 +84,7 @@ fn run() -> Result<i32, Box<dyn std::error::Error>> {
     let mut child = command_for_runtime(&resolution.executable, &runtime_arguments);
     child
         .env("PATH", runtime_path)
-        .env(SHIM_DEPTH_ENV, "1")
+        .env(SHIM_CHAIN_ENV, shim_chain)
         .env(SELECTED_TOOL_ENV, &resolution.tool)
         .env(SELECTED_VERSION_ENV, &resolution.version)
         .env(SELECTION_SOURCE_ENV, resolution.source.as_str());
@@ -279,13 +279,27 @@ fn command_name(path: &Path) -> Option<String> {
     Some(stem.to_ascii_lowercase())
 }
 
-fn ensure_not_recursive() -> Result<(), String> {
-    if env::var_os(SHIM_DEPTH_ENV).is_some() {
+fn extend_shim_chain(command: &str) -> Result<String, String> {
+    let inherited = env::var(SHIM_CHAIN_ENV).unwrap_or_default();
+    let mut chain = inherited
+        .split(',')
+        .filter(|entry| !entry.is_empty())
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    if chain.iter().any(|entry| entry == command) {
+        chain.push(command.to_owned());
         return Err(format!(
-            "recursive shim invocation detected via {SHIM_DEPTH_ENV}"
+            "recursive shim invocation detected: {}",
+            chain.join(" -> ")
         ));
     }
-    Ok(())
+    if chain.len() >= MAX_SHIM_CHAIN_LENGTH {
+        return Err(format!(
+            "shim invocation chain exceeds {MAX_SHIM_CHAIN_LENGTH} entries via {SHIM_CHAIN_ENV}"
+        ));
+    }
+    chain.push(command.to_owned());
+    Ok(chain.join(","))
 }
 
 fn reject_shim_directory_target(resolution: &CommandResolution, home: &Path) -> Result<(), String> {

--- a/crates/pinset-shim/tests/routing.rs
+++ b/crates/pinset-shim/tests/routing.rs
@@ -73,19 +73,53 @@ fn executes_fake_node_selected_by_global_config_without_a_project() {
 }
 
 #[test]
-fn rejects_recursive_shim_invocation() {
+fn rejects_a_command_already_present_in_the_shim_chain() {
     let output = Command::new(env!("CARGO_BIN_EXE_pinset-shim"))
         .args(["--as", "node"])
-        .env("PINSET_SHIM_DEPTH", "1")
+        .env("PINSET_SHIM_CHAIN", "pnpm,node")
         .output()
         .expect("run shim");
 
     assert!(!output.status.success());
     assert!(
-        String::from_utf8_lossy(&output.stderr).contains("recursive shim invocation"),
+        String::from_utf8_lossy(&output.stderr)
+            .contains("recursive shim invocation detected: pnpm -> node -> node"),
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+#[test]
+fn executes_another_selected_provider_from_a_managed_pnpm_process() {
+    let root = tempdir().expect("temp directory");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    fs::create_dir_all(&project).expect("project");
+    fs::write(
+        project.join("pinset.toml"),
+        "schema = 1\n[tools]\nbun = \"1.3.14\"\nnode = \"24.0.0\"\npnpm = \"11.22.0\"\n",
+    )
+    .expect("project config");
+    create_fake_node(&home, "24.0.0");
+    create_fake_pnpm(&home, "11.22.0");
+    create_fake_bun(&home, "1.3.14");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pinset-shim"))
+        .args(["--as", "pnpm", "--cwd"])
+        .arg(&project)
+        .args(["--", "dev"])
+        .env("PINSET_HOME", &home)
+        .output()
+        .expect("run pnpm shim");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("bun:dev"), "stdout: {stdout}");
+    assert!(stdout.contains("chain=pnpm"), "stdout: {stdout}");
 }
 
 #[test]
@@ -283,6 +317,51 @@ fn create_fake_node(home: &Path, version: &str) -> PathBuf {
         fs::set_permissions(&executable, permissions).expect("fake node permissions");
         executable
     }
+}
+
+fn create_fake_pnpm(home: &Path, version: &str) {
+    let directory = home
+        .join("installs/pnpm")
+        .join(version)
+        .join(pinset_core::current_target_for_tool("pnpm"));
+    fs::create_dir_all(&directory).expect("pnpm command directory");
+
+    #[cfg(windows)]
+    fs::write(directory.join("pnpm.cmd"), "@echo off\r\nbun %*\r\n").expect("fake pnpm");
+
+    #[cfg(not(windows))]
+    write_executable(&directory.join("pnpm"), "#!/bin/sh\nexec bun \"$@\"\n");
+}
+
+fn create_fake_bun(home: &Path, version: &str) {
+    let directory = home
+        .join("installs/bun")
+        .join(version)
+        .join(pinset_core::current_target_for_tool("bun"))
+        .join("bin");
+    fs::create_dir_all(&directory).expect("Bun command directory");
+
+    #[cfg(windows)]
+    fs::write(
+        directory.join("bun.cmd"),
+        "@echo off\r\necho bun:%*\r\necho chain=%PINSET_SHIM_CHAIN%\r\n",
+    )
+    .expect("fake Bun");
+
+    #[cfg(not(windows))]
+    write_executable(
+        &directory.join("bun"),
+        "#!/bin/sh\nprintf 'bun:%s\\nchain=%s\\n' \"$*\" \"$PINSET_SHIM_CHAIN\"\n",
+    );
+}
+
+#[cfg(not(windows))]
+fn write_executable(path: &Path, content: &str) {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::write(path, content).expect("fake executable");
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755))
+        .expect("fake executable permissions");
 }
 
 fn create_fake_flutter(home: &Path, version: &str) {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -889,9 +889,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.0
+      - uses: Future-Element/pinset@v2.1.1
         with:
-          version: 2.1.0
+          version: 2.1.1
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -889,9 +889,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.0
+      - uses: Future-Element/pinset@v2.1.1
         with:
-          version: 2.1.0
+          version: 2.1.1
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/examples/devcontainer/.devcontainer/Dockerfile
+++ b/examples/devcontainer/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
-ARG PINSET_VERSION=2.1.0
+ARG PINSET_VERSION=2.1.1
 
 RUN set -eux; \
     architecture="$(dpkg --print-architecture)"; \

--- a/examples/devcontainer/.devcontainer/devcontainer.json
+++ b/examples/devcontainer/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-        "PINSET_VERSION": "2.1.0"
+        "PINSET_VERSION": "2.1.1"
     }
   },
   "postCreateCommand": "pinset install --locked",

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string] $Version = '2.1.0',
+    [string] $Version = '2.1.1',
     [string] $InstallDir = (Join-Path $env:LOCALAPPDATA 'Pinset\bin')
 )
 

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="2.1.0"
+DEFAULT_VERSION="2.1.1"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -22,7 +22,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 2.1.0.
+  --version VERSION       Install an exact release, for example 2.1.1.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.


### PR DESCRIPTION
## Summary

- include installed peer Providers from the active Pinset scope in routed runtime PATH
- replace the blanket shim-depth guard with bounded command-chain cycle detection
- add pnpm-to-Bun regression coverage and bump release surfaces to 2.1.1

## Validation

- cargo test --workspace
- targeted pinset-core and pinset-shim Clippy (the pre-existing config.rs unnecessary-lazy-evaluations lint was allowed locally)
- Windows MuPros acceptance: apps/api pnpm dev reached Bun and started the API on port 1024

No configuration or lock schema migration is required.