### PR TITLE
Release Pinset 2.1.2 runtime routing hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       validation_required: ${{ steps.classify.outputs.validation_required }}
       code_changed: ${{ steps.classify.outputs.code_changed }}
       cargo_changed: ${{ steps.classify.outputs.cargo_changed }}
+      website_changed: ${{ steps.classify.outputs.website_changed }}
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -51,6 +52,7 @@ jobs:
           validation_required=true
           code_changed=true
           cargo_changed=true
+          website_changed=true
 
           if [[ "${EVENT_NAME}" == "pull_request" && "${IS_DRAFT}" == "true" ]]; then
             validation_required=false
@@ -75,6 +77,7 @@ jobs:
           if [[ "${EVENT_NAME}" == "schedule" ]]; then
             code_changed=false
             cargo_changed=true
+            website_changed=false
           elif [[ "${EVENT_NAME}" != "workflow_dispatch" ]]; then
             if [[ -n "${BASE_SHA}" && "${BASE_SHA}" != "0000000000000000000000000000000000000000" ]]; then
               changed_files="$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")"
@@ -84,11 +87,12 @@ jobs:
 
             code_changed=false
             cargo_changed=false
+            website_changed=false
             while IFS= read -r changed_file; do
               [[ -z "${changed_file}" ]] && continue
 
               case "${changed_file}" in
-                *.md|docs/*|.github/FUNDING.yml|.github/ISSUE_TEMPLATE/*)
+                *.md|docs/*|website/*|.github/FUNDING.yml|.github/ISSUE_TEMPLATE/*)
                   ;;
                 *)
                   code_changed=true
@@ -100,6 +104,12 @@ jobs:
                   cargo_changed=true
                   ;;
               esac
+
+              case "${changed_file}" in
+                website/*|docs/commands.md|docs/commands.zh-CN.md|.github/workflows/ci.yml|.github/workflows/release-preflight.yml|.github/workflows/release.yml)
+                  website_changed=true
+                  ;;
+              esac
             done <<< "${changed_files}"
           fi
 
@@ -107,11 +117,13 @@ jobs:
             echo "validation_required=${validation_required}"
             echo "code_changed=${code_changed}"
             echo "cargo_changed=${cargo_changed}"
+            echo "website_changed=${website_changed}"
           } >> "${GITHUB_OUTPUT}"
 
           echo "validation_required=${validation_required}"
           echo "code_changed=${code_changed}"
           echo "cargo_changed=${cargo_changed}"
+          echo "website_changed=${website_changed}"
 
   security:
     name: Audit Rust dependencies
@@ -296,6 +308,41 @@ jobs:
       - name: Link development binaries
         run: cargo build --locked -p pinset-cli -p pinset-shim
 
+  website:
+    name: Validate documentation website
+    needs: changes
+    if: >-
+      ${{
+        needs.changes.outputs.validation_required == 'true' &&
+        needs.changes.outputs.website_changed == 'true'
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: website
+    env:
+      NEXT_PUBLIC_SITE_URL: https://pinset.future-element.com
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install pinned pnpm
+        run: npm install --global pnpm@10.15.0
+
+      - name: Install locked website dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type-check website
+        run: pnpm typecheck
+
+      - name: Build production website
+        run: pnpm build
+
+      - name: Reject development origins in static output
+        shell: bash
+        run: if grep -R --exclude='404.html' --exclude='_not-found*' --exclude-dir='_not-found' "http://localhost:3000" out; then exit 1; fi
+
   gate:
     name: CI Gate
     needs:
@@ -303,6 +350,7 @@ jobs:
       - security
       - quality
       - build
+      - website
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -315,6 +363,8 @@ jobs:
           CODE_CHANGED: ${{ needs.changes.outputs.code_changed }}
           QUALITY_RESULT: ${{ needs.quality.result }}
           SECURITY_RESULT: ${{ needs.security.result }}
+          WEBSITE_CHANGED: ${{ needs.changes.outputs.website_changed }}
+          WEBSITE_RESULT: ${{ needs.website.result }}
           VALIDATION_REQUIRED: ${{ needs.changes.outputs.validation_required }}
         run: |
           if [[ "${CHANGES_RESULT}" != "success" ]]; then
@@ -327,6 +377,10 @@ jobs:
           fi
           if [[ "${SECURITY_RESULT}" != "success" && "${SECURITY_RESULT}" != "skipped" ]]; then
             echo "Dependency audit failed: ${SECURITY_RESULT}" >&2
+            exit 1
+          fi
+          if [[ "${WEBSITE_CHANGED}" == "true" && "${WEBSITE_RESULT}" != "success" ]]; then
+            echo "Documentation website validation failed: ${WEBSITE_RESULT}" >&2
             exit 1
           fi
           if [[ "${CODE_CHANGED}" != "true" ]]; then

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -41,6 +41,11 @@ jobs:
             echo "action.yml default ${action_version} does not match workspace version ${workspace_version}" >&2
             exit 1
           fi
+          website_version="$(python3 -c 'import json, pathlib; print(json.loads(pathlib.Path("website/package.json").read_text())["version"])')"
+          if [[ "${website_version}" != "${workspace_version}" ]]; then
+            echo "website/package.json version ${website_version} does not match workspace version ${workspace_version}" >&2
+            exit 1
+          fi
           if ! grep -F "## ${workspace_version} " CHANGELOG.md >/dev/null; then
             echo "CHANGELOG.md does not contain a ${workspace_version} release heading" >&2
             exit 1
@@ -164,6 +169,36 @@ jobs:
         shell: pwsh
         run: ./scripts/tests/install_ps1_test.ps1
 
+  website:
+    name: Validate release website
+    if: github.ref_name == 'main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: website
+    env:
+      NEXT_PUBLIC_SITE_URL: https://pinset.future-element.com
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install pinned pnpm
+        run: npm install --global pnpm@10.15.0
+
+      - name: Install locked website dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type-check website
+        run: pnpm typecheck
+
+      - name: Build production website
+        run: pnpm build
+
+      - name: Reject development origins in static output
+        shell: bash
+        run: if grep -R --exclude='404.html' --exclude='_not-found*' --exclude-dir='_not-found' "http://localhost:3000" out; then exit 1; fi
+
   build:
     name: Preflight ${{ matrix.artifact }}
     if: github.ref_name == 'main'
@@ -211,6 +246,7 @@ jobs:
       - validate
       - windows_scripts
       - build
+      - website
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -222,6 +258,7 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           VALIDATE_RESULT: ${{ needs.validate.result }}
           WINDOWS_RESULT: ${{ needs.windows_scripts.result }}
+          WEBSITE_RESULT: ${{ needs.website.result }}
         run: |
           if [[ "${REF_NAME}" != "main" ]]; then
             echo "Release preflight must be dispatched from main" >&2
@@ -237,6 +274,10 @@ jobs:
           fi
           if [[ "${BUILD_RESULT}" != "success" ]]; then
             echo "Release candidate builds failed: ${BUILD_RESULT}" >&2
+            exit 1
+          fi
+          if [[ "${WEBSITE_RESULT}" != "success" ]]; then
+            echo "Release website validation failed: ${WEBSITE_RESULT}" >&2
             exit 1
           fi
           echo "Release candidate is ready to tag"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,11 @@ jobs:
             echo "action.yml default ${action_version} does not match workspace version ${workspace_version}" >&2
             exit 1
           fi
+          website_version="$(python3 -c 'import json, pathlib; print(json.loads(pathlib.Path("website/package.json").read_text())["version"])')"
+          if [[ "${website_version}" != "${workspace_version}" ]]; then
+            echo "website/package.json version ${website_version} does not match workspace version ${workspace_version}" >&2
+            exit 1
+          fi
 
       - name: Require a recent successful release preflight
         shell: bash
@@ -389,8 +394,8 @@ jobs:
             dist/SHA256SUMS
           )
           if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
-            gh release upload "${GITHUB_REF_NAME}" "${assets[@]}" --clobber
-            exit 0
+            echo "Release ${GITHUB_REF_NAME} already exists; stable release assets are immutable and will not be replaced" >&2
+            exit 1
           fi
 
           release_flags=()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.1.2 - 2026-08-27
+
+- Make inherited global Providers and peer runtime environment roots available to managed child processes.
+- Preserve ordinary system-PATH passthrough for unselected Providers even when their managed Provider metadata declares dependencies.
+- Serialize project/global state mutations across processes, preserve concurrent batch updates, and register known projects for safer uninstall/prune reference checks.
+- Harden Windows batch argument forwarding and self-update locking, timeout, result reporting, and release-asset immutability.
+- Validate the documentation website and its release version in CI and release preflight.
+
 ## 2.1.1 - 2026-08-26
 
 - Include every installed Provider selected by the active project configuration—or by global configuration when no project applies—in routed runtime `PATH`, so package-manager scripts can invoke locked peer runtimes such as `pnpm -> bun` without falling back to a Pinset shim.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2734,7 +2734,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "clap",
  "flate2",
@@ -2760,7 +2760,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "atomic-write-file",
  "base64",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-env"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "age",
  "atomic-write-file",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.97"
-version = "2.1.1"
+version = "2.1.2"
 authors = ["Future Element"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ export PATH="$HOME/.local/bin:$PATH"
 Install an exact version or choose another directory:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.1
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.2
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -103,7 +103,7 @@ Remove-Item .\install.ps1
 Install an exact version:
 
 ```powershell
-.\install.ps1 -Version 2.1.1
+.\install.ps1 -Version 2.1.2
 ```
 
 Windows and WSL are separate environments and require separate installations. The installer registers Pinset and every built-in command route, but it does not pre-download language runtimes.
@@ -281,9 +281,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.1
+      - uses: Future-Element/pinset@v2.1.2
         with:
-          version: 2.1.1
+          version: 2.1.2
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js
@@ -378,7 +378,7 @@ pinset use --global node@lts pnpm@latest bun@latest go@latest python@3.14
 - Public syntax is `pinset global [SELECTION...] [--no-install]` and `pinset use <SELECTION...> [--no-install] [--global]`. `global` keeps its no-argument inspection mode; `use` requires at least one selection. There is no fixed batch size.
 - `--no-install` applies to the complete batch. Existing selections not named by the command remain unchanged.
 - Every argument is parsed, duplicate Providers are rejected, and every selector is resolved before Pinset writes state. A parse, metadata, policy, or resolution failure leaves configuration, lockfiles, and installations unchanged.
-- All resolved selections are committed to configuration and the lockfile in one atomic state update. Project policy is validated against the complete resulting lock before the write.
+- All resolved selections are committed under a cross-process state lock. Each file replacement is atomic, the complete resulting lock is validated before writing, and concurrent commands re-read state after acquiring the lock so unrelated selections are preserved. A process or machine failure between the two file replacements still fails closed and can be repaired by retrying the state command.
 - After the state commit, Pinset performs one locked installation pass in Provider dependency order. Downloads are not run concurrently in v2.1, so output, shared dependencies, cache ownership, and failure recovery stay deterministic.
 - If installation fails after the state commit, successfully installed runtimes remain valid and the complete requested state remains locked. The error directs the user to retry with `pinset install --locked` or `pinset install --global --locked`; Pinset does not pretend that already completed filesystem installations can be rolled back atomically.
 - Help, completions, English/Chinese command references, and tests cover single-selection compatibility and multi-selection behavior. `install <tool@exact-version>` remains a single explicit-selection command; lock-based `install --locked` installs the complete scope.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -88,7 +88,7 @@ export PATH="$HOME/.local/bin:$PATH"
 安装指定版本或目录：
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.1
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.2
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -103,7 +103,7 @@ Remove-Item .\install.ps1
 指定版本：
 
 ```powershell
-.\install.ps1 -Version 2.1.1
+.\install.ps1 -Version 2.1.2
 ```
 
 Windows 与 WSL 是两个独立环境，需要分别安装。安装器只安装 Pinset 和所有内置命令路由，不会预先下载语言运行时。
@@ -281,9 +281,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.1
+      - uses: Future-Element/pinset@v2.1.2
         with:
-          version: 2.1.1
+          version: 2.1.2
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js
@@ -378,7 +378,7 @@ pinset use --global node@lts pnpm@latest bun@latest go@latest python@3.14
 - 公开语法为 `pinset global [SELECTION...] [--no-install]` 和 `pinset use <SELECTION...> [--no-install] [--global]`。`global` 保留无参数查看模式；`use` 至少需要一个选择，批次数量不固定。
 - `--no-install` 对整个批次生效。命令未提及的现有选择保持不变。
 - Pinset 先解析所有参数、拒绝重复 Provider，并在写入状态前解析完所有 selector。任一参数、元数据、策略或版本解析失败时，配置、锁文件和安装状态都不变。
-- 所有解析结果通过一次原子状态更新写入配置和锁文件。写入前使用完整的结果锁验证项目策略。
+- 所有解析结果都在跨进程状态锁下提交。每个文件替换本身是原子的，写入前会验证完整的新锁，并发命令会在取得锁后重新读取状态，因此不会丢失无关选择。若进程或机器恰好在两个文件替换之间中断，Pinset 仍会失败关闭，可通过重试状态命令修复。
 - 状态提交后，Pinset 按 Provider 依赖顺序只执行一轮锁定安装。v2.1 不并发下载，以保证输出、共享依赖、缓存所有权和失败恢复具有确定性。
 - 如果状态提交后安装失败，已成功安装的运行时保持有效，完整请求状态仍保留在锁文件中。错误会提示使用 `pinset install --locked` 或 `pinset install --global --locked` 重试；Pinset 不会假装已完成的文件系统安装可以原子回滚。
 - 帮助、命令补全、中英文命令文档和测试同时覆盖单选择兼容性与多选择行为。`install <tool@精确版本>` 仍是单个显式选择命令；基于锁的 `install --locked` 会安装完整作用域。

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   version:
     description: Exact Pinset release version without the leading v.
     required: false
-    default: 2.1.1
+    default: 2.1.2
   install:
     description: Run pinset install --locked after Pinset is available.
     required: false

--- a/crates/pinset-core/Cargo.toml
+++ b/crates/pinset-core/Cargo.toml
@@ -43,10 +43,10 @@ npm-metadata = [
     "dep:semver",
     "dep:serde_json",
 ]
-project-write = ["dep:atomic-write-file", "dep:tempfile", "dep:uuid"]
+project-write = ["dep:atomic-write-file", "dep:fs4", "dep:sha2", "dep:tempfile", "dep:uuid"]
 project-discovery = ["dep:json5", "dep:serde_json", "dep:serde_yaml"]
 provider-registry = ["dep:hex", "dep:pgp", "dep:serde_json"]
-state-write = ["dep:atomic-write-file"]
+state-write = ["dep:atomic-write-file", "dep:fs4"]
 sources = [
     "dep:atomic-write-file",
     "dep:url",

--- a/crates/pinset-core/src/config.rs
+++ b/crates/pinset-core/src/config.rs
@@ -5,26 +5,23 @@ use std::{
 };
 
 #[cfg(feature = "project-write")]
-use std::io::Write;
-#[cfg(all(feature = "project-write", feature = "lockfile"))]
-use std::sync::Mutex;
-
-#[cfg(feature = "project-write")]
 use atomic_write_file::AtomicWriteFile;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "project-write")]
+use std::io::Write;
 
 use crate::{Error, MinimumReleaseAge, Result, VerificationStrength};
 
 #[cfg(feature = "lockfile")]
 use crate::Lockfile;
 #[cfg(all(feature = "project-write", feature = "lockfile"))]
-use crate::{lockfile_path, save_lockfile, validate_lock_matches_tools};
+use crate::{
+    acquire_project_state_write_lock, load_optional_lockfile, lockfile_path,
+    register_project_config, save_lockfile, validate_lock_matches_tools,
+};
 
 pub const PROJECT_CONFIG_FILENAME: &str = "pinset.toml";
 pub const PROJECT_CONFIG_SCHEMA: u32 = 4;
-#[cfg(all(feature = "project-write", feature = "lockfile"))]
-static PROJECT_STATE_WRITE_LOCK: Mutex<()> = Mutex::new(());
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectConfig {
@@ -385,18 +382,60 @@ fn valid_project_id(value: &str) -> bool {
 }
 
 #[cfg(all(feature = "project-write", feature = "lockfile"))]
-pub fn save_project_state(path: &Path, config: &ProjectConfig, lockfile: &Lockfile) -> Result<()> {
+pub fn save_project_state(
+    pinset_home: &Path,
+    path: &Path,
+    config: &ProjectConfig,
+    lockfile: &Lockfile,
+) -> Result<()> {
+    let _guard = acquire_project_state_write_lock(pinset_home, path)?;
+    save_project_state_locked(pinset_home, path, config, lockfile)
+}
+
+#[cfg(all(feature = "project-write", feature = "lockfile"))]
+pub fn save_project_state_locked(
+    pinset_home: &Path,
+    path: &Path,
+    config: &ProjectConfig,
+    lockfile: &Lockfile,
+) -> Result<()> {
     crate::validate_provider_selections(&config.tools)?;
     validate_lock_matches_tools(lockfile, &config.tools, path)?;
     validate_project_lock_policy(config, lockfile, std::time::SystemTime::now())?;
-    let _guard = PROJECT_STATE_WRITE_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    register_project_config(pinset_home, path)?;
 
     // Commit the lock first. If the second atomic write is interrupted, the previous
     // selection remains active and lock-dependent operations fail until this is retried.
-    save_lockfile(&lockfile_path(path), lockfile)?;
-    save_project_config(path, config)
+    let lock_path = lockfile_path(path);
+    let previous_lock = load_optional_lockfile(&lock_path)?;
+    save_lockfile(&lock_path, lockfile)?;
+    if let Err(commit_error) = save_project_config(path, config) {
+        if let Err(rollback_error) = restore_previous_lock(&lock_path, previous_lock.as_ref()) {
+            return Err(Error::StateCommitRollbackFailed {
+                scope: "project",
+                path: path.to_path_buf(),
+                commit_error: commit_error.to_string(),
+                rollback_error: rollback_error.to_string(),
+            });
+        }
+        return Err(commit_error);
+    }
+    Ok(())
+}
+
+#[cfg(all(feature = "project-write", feature = "lockfile"))]
+fn restore_previous_lock(path: &Path, previous: Option<&Lockfile>) -> Result<()> {
+    if let Some(previous) = previous {
+        return save_lockfile(path, previous);
+    }
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(Error::WriteLockfile {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
 }
 
 #[cfg(feature = "lockfile")]
@@ -653,7 +692,8 @@ mod tests {
             tools: Vec::new(),
         };
 
-        save_project_state(&config_path, &config, &lockfile).expect("save project state");
+        save_project_state(root.path(), &config_path, &config, &lockfile)
+            .expect("save project state");
 
         assert_eq!(load_project_config(&config_path).expect("config"), config);
         assert_eq!(

--- a/crates/pinset-core/src/error.rs
+++ b/crates/pinset-core/src/error.rs
@@ -108,6 +108,44 @@ pub enum Error {
         source: std::io::Error,
     },
 
+    #[cfg(any(feature = "project-write", feature = "state-write"))]
+    #[error("failed to create state write-lock directory {path}: {source}")]
+    CreateStateWriteLockDirectory {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[cfg(any(feature = "project-write", feature = "state-write"))]
+    #[error("failed to open state write lock {path}: {source}")]
+    OpenStateWriteLock {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[cfg(any(feature = "project-write", feature = "state-write"))]
+    #[error("failed to acquire state write lock {path}: {source}")]
+    AcquireStateWriteLock {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[cfg(all(
+        feature = "lockfile",
+        any(feature = "project-write", feature = "state-write")
+    ))]
+    #[error(
+        "failed to commit {scope} config/lock state at {path}: {commit_error}; lock rollback also failed: {rollback_error}"
+    )]
+    StateCommitRollbackFailed {
+        scope: &'static str,
+        path: PathBuf,
+        commit_error: String,
+        rollback_error: String,
+    },
+
     #[cfg(feature = "lockfile")]
     #[error("failed to read lockfile {path}: {source}")]
     ReadLockfile {
@@ -185,6 +223,32 @@ pub enum Error {
         source: std::io::Error,
     },
 
+    #[cfg(feature = "project-write")]
+    #[error("failed to create project registry directory {path}: {source}")]
+    CreateProjectRegistryDirectory {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[cfg(feature = "project-write")]
+    #[error("failed to write project registry record {path}: {source}")]
+    WriteProjectRegistry {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to read project registry {path}: {source}")]
+    ReadProjectRegistry {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("invalid project registry record {path}: {reason}")]
+    InvalidProjectRegistry { path: PathBuf, reason: String },
+
     #[error("command \"{command}\" is not handled by the Spike A shim")]
     UnsupportedCommand { command: String },
 
@@ -219,6 +283,11 @@ pub enum Error {
         command: String,
         searched: String,
     },
+
+    #[error(
+        "refusing to pass argument {index} to Windows batch runtime {path}: cmd.exe metacharacters cannot be forwarded safely"
+    )]
+    UnsafeWindowsBatchArgument { path: PathBuf, index: usize },
 
     #[error("runtime executable has no parent directory: {path}")]
     RuntimeCommandDirectoryMissing { path: PathBuf },

--- a/crates/pinset-core/src/global_state.rs
+++ b/crates/pinset-core/src/global_state.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 #[cfg(feature = "state-write")]
-use std::{io::Write, sync::Mutex};
+use std::io::Write;
 
 #[cfg(feature = "state-write")]
 use atomic_write_file::AtomicWriteFile;
@@ -14,14 +14,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Error, Result};
 #[cfg(all(feature = "state-write", feature = "lockfile"))]
-use crate::{Lockfile, save_lockfile, validate_lock_matches_tools};
+use crate::{
+    Lockfile, acquire_global_state_write_lock, load_optional_lockfile, save_lockfile,
+    validate_lock_matches_tools,
+};
 
 pub const GLOBAL_STATE_SCHEMA: u32 = 3;
 pub const GLOBAL_CONFIG_FILENAME: &str = "global.toml";
 pub const GLOBAL_LOCKFILE_FILENAME: &str = "global.lock";
-
-#[cfg(feature = "state-write")]
-static GLOBAL_STATE_WRITE_LOCK: Mutex<()> = Mutex::new(());
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -141,10 +141,20 @@ pub fn save_global_state(
     let config_path = global_config_path(pinset_home);
     crate::validate_provider_selections(&config.tools)?;
     validate_lock_matches_tools(lockfile, &config.tools, &config_path)?;
+    let _guard = acquire_global_state_write_lock(pinset_home)?;
+    save_global_state_locked(pinset_home, config, lockfile)
+}
 
-    let _guard = GLOBAL_STATE_WRITE_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+#[cfg(all(feature = "state-write", feature = "lockfile"))]
+pub fn save_global_state_locked(
+    pinset_home: &Path,
+    config: &GlobalConfig,
+    lockfile: &Lockfile,
+) -> Result<()> {
+    let config_path = global_config_path(pinset_home);
+    crate::validate_provider_selections(&config.tools)?;
+    validate_lock_matches_tools(lockfile, &config.tools, &config_path)?;
+
     let state_dir = global_state_dir(pinset_home);
     fs::create_dir_all(&state_dir).map_err(|source| Error::CreateGlobalStateDirectory {
         path: state_dir,
@@ -153,8 +163,36 @@ pub fn save_global_state(
 
     // Commit the lock first. If the second atomic write is interrupted, the previous
     // selection remains active and lock-dependent operations fail until this is retried.
-    save_lockfile(&global_lockfile_path(pinset_home), lockfile)?;
-    save_global_config(&config_path, config)
+    let lock_path = global_lockfile_path(pinset_home);
+    let previous_lock = load_optional_lockfile(&lock_path)?;
+    save_lockfile(&lock_path, lockfile)?;
+    if let Err(commit_error) = save_global_config(&config_path, config) {
+        if let Err(rollback_error) = restore_previous_lock(&lock_path, previous_lock.as_ref()) {
+            return Err(Error::StateCommitRollbackFailed {
+                scope: "global",
+                path: config_path,
+                commit_error: commit_error.to_string(),
+                rollback_error: rollback_error.to_string(),
+            });
+        }
+        return Err(commit_error);
+    }
+    Ok(())
+}
+
+#[cfg(all(feature = "state-write", feature = "lockfile"))]
+fn restore_previous_lock(path: &Path, previous: Option<&Lockfile>) -> Result<()> {
+    if let Some(previous) = previous {
+        return save_lockfile(path, previous);
+    }
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(source) if source.kind() == ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(Error::WriteLockfile {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
 }
 
 #[cfg(test)]

--- a/crates/pinset-core/src/lib.rs
+++ b/crates/pinset-core/src/lib.rs
@@ -60,6 +60,7 @@ mod npm_metadata;
 mod npm_runtime;
 #[cfg(feature = "project-discovery")]
 mod project_discovery;
+mod project_registry;
 mod provenance;
 #[cfg(feature = "provider-registry")]
 mod provider_registry;
@@ -86,11 +87,11 @@ mod rust_runtime;
 mod shim_install;
 #[cfg(feature = "sources")]
 mod source_config;
+#[cfg(any(feature = "project-write", feature = "state-write"))]
+mod state_write_lock;
 mod target;
 mod user_settings;
 
-#[cfg(all(feature = "project-write", feature = "lockfile"))]
-pub use config::save_project_state;
 #[cfg(feature = "lockfile")]
 pub use config::validate_project_lock_policy;
 pub use config::{
@@ -100,6 +101,8 @@ pub use config::{
 };
 #[cfg(feature = "project-write")]
 pub use config::{create_project_config, save_project_config};
+#[cfg(all(feature = "project-write", feature = "lockfile"))]
+pub use config::{save_project_state, save_project_state_locked};
 #[cfg(feature = "dotnet-metadata")]
 pub use dotnet_metadata::{DotnetMetadataClient, DotnetRelease};
 #[cfg(feature = "dotnet-provider")]
@@ -137,13 +140,13 @@ pub use flutter_provider::{
 pub use flutter_runtime::install_locked_flutter;
 #[cfg(feature = "state-write")]
 pub use global_state::save_global_config;
-#[cfg(all(feature = "state-write", feature = "lockfile"))]
-pub use global_state::save_global_state;
 pub use global_state::{
     GLOBAL_CONFIG_FILENAME, GLOBAL_LOCKFILE_FILENAME, GLOBAL_STATE_SCHEMA, GlobalConfig,
     global_config_path, global_lockfile_path, global_state_dir, load_global_config,
     load_optional_global_config,
 };
+#[cfg(all(feature = "state-write", feature = "lockfile"))]
+pub use global_state::{save_global_state, save_global_state_locked};
 #[cfg(feature = "go-metadata")]
 pub use go_metadata::{GoMetadataClient, GoRelease};
 #[cfg(feature = "go-provider")]
@@ -205,6 +208,9 @@ pub use npm_runtime::install_locked_npm_tool;
 pub use project_discovery::{
     DiscoveryFinding, DiscoveryKind, DiscoveryReport, DiscoveryStatus, scan_project_sources,
 };
+#[cfg(feature = "project-write")]
+pub use project_registry::register_project_config;
+pub use project_registry::registered_project_configs;
 pub use provenance::{
     MinimumReleaseAge, VerificationMethod, VerificationStrength, tool_verification_strength,
     valid_release_time, validate_tool_policy, validate_verification_transition,
@@ -241,7 +247,7 @@ pub use resolver::{
     resolve_command, resolve_command_with_path, resolve_from_env, resolve_project_python_command,
     resolve_tool_selection, runtime_command_candidates, runtime_command_directory,
     runtime_environment_for_install, selected_runtime_environment,
-    validate_managed_runtime_invocation,
+    validate_managed_runtime_invocation, validate_windows_batch_arguments,
 };
 pub use runtime_lifecycle::{
     InstalledToolVersion, ProtectedToolVersion, PruneToolCandidate, PruneToolPlan,
@@ -275,6 +281,10 @@ pub use source_config::{
     ResolvedArtifactSource, SUPPORTED_SOURCE_PROVIDERS, SourceConfig, SourceKind, SourceView,
     load_source_config, save_source_config, source_config_path,
 };
+#[cfg(feature = "project-write")]
+pub use state_write_lock::acquire_project_state_write_lock;
+#[cfg(feature = "state-write")]
+pub use state_write_lock::{acquire_global_state_write_lock, acquire_self_update_lock};
 pub use target::{current_target, current_target_for_tool};
 #[cfg(feature = "state-write")]
 pub use user_settings::save_user_settings;

--- a/crates/pinset-core/src/project_registry.rs
+++ b/crates/pinset-core/src/project_registry.rs
@@ -1,0 +1,186 @@
+use std::{
+    fs,
+    io::ErrorKind,
+    path::{Path, PathBuf},
+};
+
+#[cfg(feature = "project-write")]
+use std::io::Write;
+
+#[cfg(feature = "project-write")]
+use atomic_write_file::AtomicWriteFile;
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "project-write")]
+use sha2::{Digest, Sha256};
+
+use crate::{Error, Result, global_state_dir};
+
+const PROJECT_REGISTRY_SCHEMA: u32 = 1;
+const MAX_PROJECT_RECORD_BYTES: u64 = 64 * 1024;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProjectRecord {
+    schema: u32,
+    config: PathBuf,
+}
+
+#[cfg(feature = "project-write")]
+pub fn register_project_config(pinset_home: &Path, config_path: &Path) -> Result<()> {
+    let canonical = fs::canonicalize(config_path).unwrap_or_else(|_| config_path.to_path_buf());
+    let identity = if cfg!(windows) {
+        canonical.to_string_lossy().to_ascii_lowercase()
+    } else {
+        canonical.to_string_lossy().into_owned()
+    };
+    let digest = Sha256::digest(identity.as_bytes());
+    let filename = format!("{}.toml", hex_lower(&digest));
+    let directory = project_registry_dir(pinset_home);
+    fs::create_dir_all(&directory).map_err(|source| Error::CreateProjectRegistryDirectory {
+        path: directory.clone(),
+        source,
+    })?;
+    let path = directory.join(filename);
+    let serialized = toml::to_string_pretty(&ProjectRecord {
+        schema: PROJECT_REGISTRY_SCHEMA,
+        config: canonical,
+    })
+    .map_err(|source| Error::InvalidProjectRegistry {
+        path: path.clone(),
+        reason: source.to_string(),
+    })?;
+    let mut file =
+        AtomicWriteFile::options()
+            .open(&path)
+            .map_err(|source| Error::WriteProjectRegistry {
+                path: path.clone(),
+                source,
+            })?;
+    file.write_all(serialized.as_bytes())
+        .and_then(|()| file.commit())
+        .map_err(|source| Error::WriteProjectRegistry { path, source })
+}
+
+pub fn registered_project_configs(pinset_home: &Path) -> Result<Vec<PathBuf>> {
+    let directory = project_registry_dir(pinset_home);
+    match fs::symlink_metadata(&directory) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            return Err(Error::InvalidProjectRegistry {
+                path: directory,
+                reason: "registry path must be a regular directory".to_owned(),
+            });
+        }
+        Ok(_) => {}
+        Err(source) if source.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(source) => {
+            return Err(Error::ReadProjectRegistry {
+                path: directory,
+                source,
+            });
+        }
+    }
+    let entries = match fs::read_dir(&directory) {
+        Ok(entries) => entries,
+        Err(source) if source.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(source) => {
+            return Err(Error::ReadProjectRegistry {
+                path: directory,
+                source,
+            });
+        }
+    };
+    let mut configs = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|source| Error::ReadProjectRegistry {
+            path: directory.clone(),
+            source,
+        })?;
+        let path = entry.path();
+        let metadata =
+            fs::symlink_metadata(&path).map_err(|source| Error::ReadProjectRegistry {
+                path: path.clone(),
+                source,
+            })?;
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            return Err(Error::InvalidProjectRegistry {
+                path,
+                reason: "record must be a regular file".to_owned(),
+            });
+        }
+        if metadata.len() > MAX_PROJECT_RECORD_BYTES {
+            return Err(Error::InvalidProjectRegistry {
+                path,
+                reason: format!("record exceeds {MAX_PROJECT_RECORD_BYTES} bytes"),
+            });
+        }
+        let content = fs::read_to_string(&path).map_err(|source| Error::ReadProjectRegistry {
+            path: path.clone(),
+            source,
+        })?;
+        let record: ProjectRecord =
+            toml::from_str(&content).map_err(|source| Error::InvalidProjectRegistry {
+                path: path.clone(),
+                reason: source.to_string(),
+            })?;
+        if record.schema != PROJECT_REGISTRY_SCHEMA {
+            return Err(Error::InvalidProjectRegistry {
+                path,
+                reason: format!("unsupported schema {}", record.schema),
+            });
+        }
+        match fs::symlink_metadata(&record.config) {
+            Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+                return Err(Error::InvalidProjectRegistry {
+                    path,
+                    reason: format!(
+                        "registered config is not a regular file: {}",
+                        record.config.display()
+                    ),
+                });
+            }
+            Ok(_) => configs.push(record.config),
+            Err(source) if source.kind() == ErrorKind::NotFound => {}
+            Err(source) => {
+                return Err(Error::ReadProjectRegistry {
+                    path: record.config,
+                    source,
+                });
+            }
+        }
+    }
+    configs.sort();
+    configs.dedup();
+    Ok(configs)
+}
+
+fn project_registry_dir(pinset_home: &Path) -> PathBuf {
+    global_state_dir(pinset_home).join("projects")
+}
+
+#[cfg(feature = "project-write")]
+fn hex_lower(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "project-write")]
+    #[test]
+    fn registers_and_lists_existing_project_configs() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        fs::create_dir_all(&project).expect("project directory");
+        let config = project.join("pinset.toml");
+        fs::write(&config, "schema = 1\n[tools]\n").expect("project config");
+
+        register_project_config(&home, &config).expect("register project");
+
+        assert_eq!(
+            registered_project_configs(&home).expect("registered projects"),
+            vec![fs::canonicalize(config).expect("canonical config")]
+        );
+    }
+}

--- a/crates/pinset-core/src/resolver.rs
+++ b/crates/pinset-core/src/resolver.rs
@@ -375,7 +375,7 @@ fn selection_from_config(
             },
             source: std::io::Error::new(
                 std::io::ErrorKind::NotFound,
-                "schema 3 selections require a lockfile",
+                format!("schema {config_schema} selections require a lockfile"),
             ),
         });
     };
@@ -520,37 +520,43 @@ pub fn path_with_selected_tools(
         .to_path_buf();
     let shim_dir = pinset_home.join("shims");
     let mut entries = vec![selected_dir.clone()];
-    for provider in provider_dependency_order(tool)? {
-        if provider.tool == tool {
-            continue;
-        }
-        let selection = resolve_tool_selection(provider.tool, cwd, pinset_home).map_err(|_| {
-            Error::ProviderDependencyMissing {
-                tool: tool.to_owned(),
-                dependency: provider.tool.to_owned(),
+    // Provider dependencies are a managed-selection contract. A command resolved from the
+    // system PATH must retain ordinary system toolchain behavior instead of requiring Pinset
+    // selections for that Provider's declared dependencies.
+    if resolve_tool_selection(tool, cwd, pinset_home).is_ok() {
+        for provider in provider_dependency_order(tool)? {
+            if provider.tool == tool {
+                continue;
             }
-        })?;
-        let install_dir = pinset_home
-            .join("installs")
-            .join(provider.tool)
-            .join(&selection.version)
-            .join(current_target_for_tool(provider.tool));
-        let command_dir =
-            if provider.tool == "python" && selection.source == SelectionSource::Project {
-                load_project_python_environment(
-                    &selection.config_path,
-                    &selection.version,
-                    &current_target_for_tool("python"),
-                )?
-                .command_directory
-            } else {
-                runtime_command_directory(provider.tool, &install_dir)
-            };
-        if command_dir.is_dir()
-            && !paths_equal(&command_dir, &selected_dir)
-            && !entries.iter().any(|entry| paths_equal(entry, &command_dir))
-        {
-            entries.push(command_dir);
+            let selection =
+                resolve_tool_selection(provider.tool, cwd, pinset_home).map_err(|_| {
+                    Error::ProviderDependencyMissing {
+                        tool: tool.to_owned(),
+                        dependency: provider.tool.to_owned(),
+                    }
+                })?;
+            let install_dir = pinset_home
+                .join("installs")
+                .join(provider.tool)
+                .join(&selection.version)
+                .join(current_target_for_tool(provider.tool));
+            let command_dir =
+                if provider.tool == "python" && selection.source == SelectionSource::Project {
+                    load_project_python_environment(
+                        &selection.config_path,
+                        &selection.version,
+                        &current_target_for_tool("python"),
+                    )?
+                    .command_directory
+                } else {
+                    runtime_command_directory(provider.tool, &install_dir)
+                };
+            if command_dir.is_dir()
+                && !paths_equal(&command_dir, &selected_dir)
+                && !entries.iter().any(|entry| paths_equal(entry, &command_dir))
+            {
+                entries.push(command_dir);
+            }
         }
     }
     let configured_tools = effective_configured_tools(cwd, pinset_home)?;
@@ -602,7 +608,15 @@ fn effective_configured_tools(cwd: &Path, pinset_home: &Path) -> Result<BTreeMap
     let context = find_project_context(cwd)?;
     if let Some(config_path) = context.config_path {
         let config = load_project_config(&config_path)?;
-        return Ok(config.tools);
+        if !config.policy.inherit_global {
+            return Ok(config.tools);
+        }
+
+        let mut tools = load_optional_global_config(&global_config_path(pinset_home))?
+            .map(|config| config.tools)
+            .unwrap_or_default();
+        tools.extend(config.tools);
+        return Ok(tools);
     }
 
     Ok(
@@ -618,9 +632,22 @@ pub fn selected_runtime_environment(
     pinset_home: &Path,
 ) -> Vec<RuntimeEnvironmentVariable> {
     let mut variables = Vec::new();
-    let Ok(providers) = provider_dependency_order(tool) else {
+    let Ok(mut providers) = provider_dependency_order(tool) else {
         return variables;
     };
+    if let Ok(configured_tools) = effective_configured_tools(cwd, pinset_home) {
+        for provider in runtime_providers()
+            .iter()
+            .filter(|provider| configured_tools.contains_key(provider.tool))
+        {
+            if !providers
+                .iter()
+                .any(|existing| existing.tool == provider.tool)
+            {
+                providers.push(provider);
+            }
+        }
+    }
     for provider in providers {
         if provider.capabilities.environment == RuntimeEnvironmentKind::None {
             continue;
@@ -774,6 +801,35 @@ pub fn managed_runtime_arguments(
     resolved
 }
 
+pub fn validate_windows_batch_arguments(executable: &Path, arguments: &[OsString]) -> Result<()> {
+    if !cfg!(windows)
+        || !executable.extension().is_some_and(|extension| {
+            extension.eq_ignore_ascii_case("cmd") || extension.eq_ignore_ascii_case("bat")
+        })
+    {
+        return Ok(());
+    }
+
+    for (index, argument) in arguments.iter().enumerate() {
+        let Some(argument) = argument.to_str() else {
+            return Err(Error::UnsafeWindowsBatchArgument {
+                path: executable.to_path_buf(),
+                index: index + 1,
+            });
+        };
+        if argument
+            .chars()
+            .any(|character| "&|<>()@^%!\"\r\n".contains(character))
+        {
+            return Err(Error::UnsafeWindowsBatchArgument {
+                path: executable.to_path_buf(),
+                index: index + 1,
+            });
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 fn runtime_command_dir(install_dir: &Path) -> PathBuf {
     runtime_command_directory("node", install_dir)
@@ -904,6 +960,161 @@ mod tests {
         assert_eq!(entries[0], pnpm_dir);
         assert_eq!(entries[1], node_dir);
         assert_eq!(entries[2], bun_dir);
+    }
+
+    #[test]
+    fn selected_tool_path_includes_inherited_global_providers() {
+        let root = tempdir().expect("temp directory");
+        let project = root.path().join("project");
+        let home = root.path().join("home");
+        fs::create_dir_all(&project).expect("project");
+        fs::write(
+            project.join("pinset.toml"),
+            "schema = 1\n[policy]\ninherit-global = true\n[tools]\nnode = \"24.0.0\"\npnpm = \"11.22.0\"\n",
+        )
+        .expect("project config");
+        let global_path = global_config_path(&home);
+        fs::create_dir_all(global_path.parent().expect("global state directory"))
+            .expect("global state directory");
+        fs::write(&global_path, "schema = 1\n[tools]\nbun = \"1.3.14\"\n").expect("global config");
+
+        let pnpm_install_dir = home
+            .join("installs/pnpm/11.22.0")
+            .join(current_target_for_tool("pnpm"));
+        let node_install_dir = home
+            .join("installs/node/24.0.0")
+            .join(current_target_for_tool("node"));
+        let bun_install_dir = home
+            .join("installs/bun/1.3.14")
+            .join(current_target_for_tool("bun"));
+        let pnpm_dir = runtime_command_directory("pnpm", &pnpm_install_dir);
+        let node_dir = runtime_command_directory("node", &node_install_dir);
+        let bun_dir = runtime_command_directory("bun", &bun_install_dir);
+        for directory in [&pnpm_dir, &node_dir, &bun_dir] {
+            fs::create_dir_all(directory).expect("runtime command directory");
+        }
+        let pnpm = pnpm_dir.join(if cfg!(windows) { "pnpm.exe" } else { "pnpm" });
+        fs::write(&pnpm, b"fake pnpm").expect("pnpm executable");
+
+        let path = path_with_selected_tools("pnpm", &pnpm, &project, &home)
+            .expect("selected provider PATH");
+        let entries = env::split_paths(&path).collect::<Vec<_>>();
+        assert_eq!(entries[0], pnpm_dir);
+        assert_eq!(entries[1], node_dir);
+        assert_eq!(entries[2], bun_dir);
+    }
+
+    #[test]
+    fn selected_tool_path_and_environment_cover_every_configured_provider_capability() {
+        let root = tempdir().expect("temp directory");
+        let workspace = root.path().join("workspace");
+        let home = root.path().join("home");
+        fs::create_dir_all(&workspace).expect("workspace");
+        let global_path = global_config_path(&home);
+        fs::create_dir_all(global_path.parent().expect("global state directory"))
+            .expect("global state directory");
+        let mut config = String::from("schema = 1\n[tools]\n");
+        for provider in runtime_providers() {
+            config.push_str(&format!("{} = \"1.0.0\"\n", provider.tool));
+        }
+        fs::write(&global_path, config).expect("global config");
+
+        let mut provider_directories = Vec::new();
+        for provider in runtime_providers() {
+            let install_dir = home
+                .join("installs")
+                .join(provider.tool)
+                .join("1.0.0")
+                .join(current_target_for_tool(provider.tool));
+            let command_dir = runtime_command_directory(provider.tool, &install_dir);
+            fs::create_dir_all(&command_dir).expect("provider command directory");
+            provider_directories.push((provider.tool, install_dir, command_dir));
+        }
+        let node_dir = provider_directories
+            .iter()
+            .find(|(tool, _, _)| *tool == "node")
+            .map(|(_, _, directory)| directory.clone())
+            .expect("Node command directory");
+        let node = node_dir.join(if cfg!(windows) { "node.exe" } else { "node" });
+        fs::write(&node, b"fake node").expect("Node executable");
+
+        let path =
+            path_with_selected_tools("node", &node, &workspace, &home).expect("all-provider PATH");
+        let entries = env::split_paths(&path).collect::<Vec<_>>();
+        for (tool, _, expected) in &provider_directories {
+            let matches = entries
+                .iter()
+                .filter(|entry| paths_equal(entry, expected))
+                .count();
+            assert_eq!(
+                matches, 1,
+                "Provider {tool} command directory must appear exactly once in PATH: {entries:?}"
+            );
+        }
+        assert!(
+            entries
+                .iter()
+                .all(|entry| !paths_equal(entry, &home.join("shims"))),
+            "managed child PATH must not point back to Pinset shims"
+        );
+
+        let variables = selected_runtime_environment("node", &workspace, &home);
+        for (tool, install_dir, _) in &provider_directories {
+            let expected = match *tool {
+                "go" => Some(RuntimeEnvironmentVariable {
+                    name: "GOROOT",
+                    value: install_dir.as_os_str().to_owned(),
+                }),
+                "flutter" => Some(RuntimeEnvironmentVariable {
+                    name: "FLUTTER_ROOT",
+                    value: install_dir.as_os_str().to_owned(),
+                }),
+                "java" => Some(RuntimeEnvironmentVariable {
+                    name: "JAVA_HOME",
+                    value: java_home_for_install(install_dir).into_os_string(),
+                }),
+                "dotnet" => Some(RuntimeEnvironmentVariable {
+                    name: "DOTNET_ROOT",
+                    value: install_dir.as_os_str().to_owned(),
+                }),
+                _ => None,
+            };
+            if let Some(expected) = expected {
+                assert!(
+                    variables.contains(&expected),
+                    "Provider {tool} environment missing {expected:?}: {variables:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn selected_runtime_environment_includes_peer_provider_roots() {
+        let root = tempdir().expect("temp directory");
+        let project = root.path().join("project");
+        let home = root.path().join("home");
+        fs::create_dir_all(&project).expect("project");
+        fs::write(
+            project.join("pinset.toml"),
+            "schema = 1\n[tools]\njava = \"21.0.0\"\nnode = \"24.0.0\"\npnpm = \"11.22.0\"\n",
+        )
+        .expect("project config");
+        let java_install_dir = home
+            .join("installs")
+            .join("java")
+            .join("21.0.0")
+            .join(current_target_for_tool("java"));
+        fs::create_dir_all(&java_install_dir).expect("Java install directory");
+
+        let variables = selected_runtime_environment("pnpm", &project, &home);
+        let expected = RuntimeEnvironmentVariable {
+            name: "JAVA_HOME",
+            value: java_home_for_install(&java_install_dir).into_os_string(),
+        };
+        assert!(
+            variables.contains(&expected),
+            "expected {expected:?}; resolved environment variables: {variables:?}"
+        );
     }
 
     #[test]

--- a/crates/pinset-core/src/runtime_lifecycle.rs
+++ b/crates/pinset-core/src/runtime_lifecycle.rs
@@ -15,7 +15,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     Error, GlobalConfig, ProjectConfig, Result, find_optional_project_config, global_config_path,
-    load_optional_global_config, load_project_config, runtime_provider, runtime_providers,
+    load_optional_global_config, load_project_config, registered_project_configs, runtime_provider,
+    runtime_providers,
 };
 
 #[cfg(feature = "lockfile")]
@@ -213,27 +214,7 @@ pub fn find_tool_version_references(
     tool: &str,
     version: &str,
 ) -> Result<Vec<ToolVersionReference>> {
-    validate_tool_and_version(tool, version)?;
-    let mut references = Vec::new();
-    if let Some(path) = find_optional_project_config(cwd)? {
-        let config = load_project_config(&path)?;
-        if project_config_selects_version(&path, &config, tool, version)? {
-            references.push(ToolVersionReference {
-                scope: "project",
-                path,
-            });
-        }
-    }
-    let path = global_config_path(pinset_home);
-    if let Some(config) = load_optional_global_config(&path)?
-        && global_config_selects_version(pinset_home, &path, &config, tool, version)?
-    {
-        references.push(ToolVersionReference {
-            scope: "global",
-            path,
-        });
-    }
-    Ok(references)
+    find_tool_version_references_in_projects(pinset_home, &[cwd.to_path_buf()], tool, version)
 }
 
 pub fn find_tool_version_references_in_projects(
@@ -256,6 +237,18 @@ pub fn find_tool_version_references_in_projects(
         if project_config_selects_version(&path, &config, tool, version)? {
             references.push(ToolVersionReference {
                 scope: "project",
+                path,
+            });
+        }
+    }
+    for path in registered_project_configs(pinset_home)? {
+        if !seen_paths.insert(path.clone()) {
+            continue;
+        }
+        let config = load_project_config(&path)?;
+        if project_config_selects_version(&path, &config, tool, version)? {
+            references.push(ToolVersionReference {
+                scope: "registered-project",
                 path,
             });
         }
@@ -644,5 +637,35 @@ mod tests {
         assert_eq!(plan.candidates[0].version, "10.0.0");
         assert_eq!(plan.protected.len(), 2);
         assert!(plan.bytes > 0);
+    }
+
+    #[cfg(feature = "project-write")]
+    #[test]
+    fn prune_plan_protects_registered_projects_without_explicit_roots() {
+        let home = tempfile::tempdir().expect("home");
+        let current = tempfile::tempdir().expect("current project");
+        let registered = tempfile::tempdir().expect("registered project");
+        let config_path = registered.path().join("pinset.toml");
+        fs::write(&config_path, "schema = 2\n[tools]\nbun = \"1.3.14\"\n")
+            .expect("registered project config");
+        crate::register_project_config(home.path(), &config_path).expect("register project");
+        let directory = home.path().join("installs/bun/1.3.14/linux-x86_64");
+        fs::create_dir_all(&directory).expect("install directory");
+        fs::write(
+            directory.join(".pinset-install.toml"),
+            "schema = 2\ncomplete = true\ntool = \"bun\"\nversion = \"1.3.14\"\ntarget = \"linux-x86_64\"\n",
+        )
+        .expect("receipt");
+
+        let plan = plan_prune_tool_versions(home.path(), &[current.path().to_path_buf()])
+            .expect("prune plan");
+
+        assert!(plan.candidates.is_empty());
+        assert_eq!(plan.protected.len(), 1);
+        assert_eq!(plan.protected[0].references[0].scope, "registered-project");
+        assert_eq!(
+            plan.protected[0].references[0].path,
+            fs::canonicalize(config_path).unwrap()
+        );
     }
 }

--- a/crates/pinset-core/src/state_write_lock.rs
+++ b/crates/pinset-core/src/state_write_lock.rs
@@ -1,0 +1,93 @@
+use std::{
+    fs::{self, File},
+    path::{Path, PathBuf},
+};
+
+use fs4::FileExt;
+#[cfg(feature = "project-write")]
+use sha2::{Digest, Sha256};
+
+use crate::{Error, Result, global_state_dir};
+
+pub struct StateWriteLock {
+    file: File,
+}
+
+impl Drop for StateWriteLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+pub fn acquire_global_state_write_lock(pinset_home: &Path) -> Result<StateWriteLock> {
+    acquire(pinset_home, "global.lock")
+}
+
+pub fn acquire_self_update_lock(pinset_home: &Path) -> Result<StateWriteLock> {
+    acquire(pinset_home, "self-update.lock")
+}
+
+#[cfg(feature = "project-write")]
+pub fn acquire_project_state_write_lock(
+    pinset_home: &Path,
+    config_path: &Path,
+) -> Result<StateWriteLock> {
+    let canonical = fs::canonicalize(config_path).unwrap_or_else(|_| config_path.to_path_buf());
+    let identity = if cfg!(windows) {
+        canonical.to_string_lossy().to_ascii_lowercase()
+    } else {
+        canonical.to_string_lossy().into_owned()
+    };
+    let digest = Sha256::digest(identity.as_bytes());
+    let name = format!("project-{}.lock", hex_lower(&digest));
+    acquire(pinset_home, &name)
+}
+
+fn acquire(pinset_home: &Path, name: &str) -> Result<StateWriteLock> {
+    let directory = state_write_lock_dir(pinset_home);
+    fs::create_dir_all(&directory).map_err(|source| Error::CreateStateWriteLockDirectory {
+        path: directory.clone(),
+        source,
+    })?;
+    let directory_metadata =
+        fs::symlink_metadata(&directory).map_err(|source| Error::OpenStateWriteLock {
+            path: directory.clone(),
+            source,
+        })?;
+    if directory_metadata.file_type().is_symlink() || !directory_metadata.is_dir() {
+        return Err(Error::OpenStateWriteLock {
+            path: directory,
+            source: std::io::Error::other("state write-lock directory is not a regular directory"),
+        });
+    }
+    let path = directory.join(name);
+    if let Ok(metadata) = fs::symlink_metadata(&path)
+        && (metadata.file_type().is_symlink() || !metadata.is_file())
+    {
+        return Err(Error::OpenStateWriteLock {
+            path,
+            source: std::io::Error::other("state write lock is not a regular file"),
+        });
+    }
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&path)
+        .map_err(|source| Error::OpenStateWriteLock {
+            path: path.clone(),
+            source,
+        })?;
+    FileExt::lock(&file).map_err(|source| Error::AcquireStateWriteLock { path, source })?;
+    Ok(StateWriteLock { file })
+}
+
+fn state_write_lock_dir(pinset_home: &Path) -> PathBuf {
+    global_state_dir(pinset_home).join("write-locks")
+}
+
+#[cfg(feature = "project-write")]
+fn hex_lower(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}

--- a/crates/pinset-shim/src/main.rs
+++ b/crates/pinset-shim/src/main.rs
@@ -18,16 +18,15 @@ type EncryptedEnvironment = Option<(
     std::collections::BTreeMap<String, String>,
 )>;
 
-#[cfg(windows)]
-use std::ffi::OsStr;
-
 use pinset_core::{
     CommandResolution, EnvironmentCollision, decode_environment, find_optional_project_config,
     load_project_config, managed_runtime_arguments, path_with_selected_tools, pinset_home_from_env,
     resolve_command_with_path, selected_runtime_environment, validate_managed_runtime_invocation,
+    validate_windows_batch_arguments,
 };
 
 const SHIM_CHAIN_ENV: &str = "PINSET_SHIM_CHAIN";
+const SHIM_OWNER_ENV: &str = "PINSET_SHIM_OWNER";
 const MAX_SHIM_CHAIN_LENGTH: usize = 32;
 const SELECTED_TOOL_ENV: &str = "PINSET_SELECTED_TOOL";
 const SELECTED_VERSION_ENV: &str = "PINSET_SELECTED_VERSION";
@@ -50,9 +49,10 @@ fn main() {
 
 fn run() -> Result<i32, Box<dyn std::error::Error>> {
     let invocation = Invocation::parse()?;
-    let shim_chain = extend_shim_chain(&invocation.command)?;
     let home = pinset_home_from_env()?;
     let current_executable = env::current_exe()?;
+    let shim_owner = shim_owner(&current_executable);
+    let shim_chain = extend_shim_chain(&invocation.command, &shim_owner)?;
     let path = env::var_os("PATH");
     let resolution = resolve_command_with_path(
         &invocation.command,
@@ -74,6 +74,7 @@ fn run() -> Result<i32, Box<dyn std::error::Error>> {
     } else {
         managed_runtime_arguments(&resolution.tool, &invocation.command, &invocation.arguments)
     };
+    validate_windows_batch_arguments(&resolution.executable, &runtime_arguments)?;
 
     let runtime_path = path_with_selected_tools(
         &resolution.tool,
@@ -85,6 +86,7 @@ fn run() -> Result<i32, Box<dyn std::error::Error>> {
     child
         .env("PATH", runtime_path)
         .env(SHIM_CHAIN_ENV, shim_chain)
+        .env(SHIM_OWNER_ENV, shim_owner)
         .env(SELECTED_TOOL_ENV, &resolution.tool)
         .env(SELECTED_VERSION_ENV, &resolution.version)
         .env(SELECTION_SOURCE_ENV, resolution.source.as_str());
@@ -279,8 +281,12 @@ fn command_name(path: &Path) -> Option<String> {
     Some(stem.to_ascii_lowercase())
 }
 
-fn extend_shim_chain(command: &str) -> Result<String, String> {
-    let inherited = env::var(SHIM_CHAIN_ENV).unwrap_or_default();
+fn extend_shim_chain(command: &str, owner: &str) -> Result<String, String> {
+    let inherited = if env::var(SHIM_OWNER_ENV).is_ok_and(|value| value == owner) {
+        env::var(SHIM_CHAIN_ENV).unwrap_or_default()
+    } else {
+        String::new()
+    };
     let mut chain = inherited
         .split(',')
         .filter(|entry| !entry.is_empty())
@@ -302,6 +308,17 @@ fn extend_shim_chain(command: &str) -> Result<String, String> {
     Ok(chain.join(","))
 }
 
+fn shim_owner(executable: &Path) -> String {
+    let path = executable
+        .canonicalize()
+        .unwrap_or_else(|_| executable.to_path_buf());
+    if cfg!(windows) {
+        path.to_string_lossy().to_ascii_lowercase()
+    } else {
+        path.to_string_lossy().into_owned()
+    }
+}
+
 fn reject_shim_directory_target(resolution: &CommandResolution, home: &Path) -> Result<(), String> {
     let shims = home.join("shims");
     if resolution.executable.starts_with(&shims) {
@@ -314,19 +331,6 @@ fn reject_shim_directory_target(resolution: &CommandResolution, home: &Path) -> 
 }
 
 fn command_for_runtime(executable: &Path, arguments: &[OsString]) -> Command {
-    #[cfg(windows)]
-    {
-        let extension = executable
-            .extension()
-            .and_then(OsStr::to_str)
-            .unwrap_or_default();
-        if extension.eq_ignore_ascii_case("cmd") || extension.eq_ignore_ascii_case("bat") {
-            let mut command = Command::new("cmd.exe");
-            command.arg("/D").arg("/C").arg(executable).args(arguments);
-            return command;
-        }
-    }
-
     let mut command = Command::new(executable);
     command.args(arguments);
     command

--- a/crates/pinset-shim/tests/routing.rs
+++ b/crates/pinset-shim/tests/routing.rs
@@ -40,6 +40,36 @@ fn executes_fake_node_selected_by_nearest_project_config() {
     assert!(stdout.contains("source=project"), "stdout: {stdout}");
 }
 
+#[cfg(windows)]
+#[test]
+fn forwards_cmd_arguments_without_interpreting_shell_metacharacters() {
+    let root = tempdir().expect("temp directory");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    fs::create_dir_all(&project).expect("project directory");
+    fs::write(
+        project.join("pinset.toml"),
+        "schema = 1\n[tools]\nnode = \"20.0.0\"\n",
+    )
+    .expect("project config");
+    create_fake_node(&home, "20.0.0");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pinset-shim"))
+        .args(["--as", "node", "--cwd"])
+        .arg(&project)
+        .args(["--", "safe&echo PINSET_ARGUMENT_INJECTION"])
+        .env("PINSET_HOME", &home)
+        .output()
+        .expect("run shim");
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).is_empty());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("cmd.exe metacharacters cannot be forwarded safely")
+    );
+}
+
 #[test]
 fn executes_fake_node_selected_by_global_config_without_a_project() {
     let root = tempdir().expect("temp directory");
@@ -74,9 +104,21 @@ fn executes_fake_node_selected_by_global_config_without_a_project() {
 
 #[test]
 fn rejects_a_command_already_present_in_the_shim_chain() {
-    let output = Command::new(env!("CARGO_BIN_EXE_pinset-shim"))
+    let shim = PathBuf::from(env!("CARGO_BIN_EXE_pinset-shim"));
+    let owner = shim
+        .canonicalize()
+        .unwrap_or_else(|_| shim.clone())
+        .to_string_lossy()
+        .into_owned();
+    let owner = if cfg!(windows) {
+        owner.to_ascii_lowercase()
+    } else {
+        owner
+    };
+    let output = Command::new(&shim)
         .args(["--as", "node"])
         .env("PINSET_SHIM_CHAIN", "pnpm,node")
+        .env("PINSET_SHIM_OWNER", owner)
         .output()
         .expect("run shim");
 
@@ -86,6 +128,41 @@ fn rejects_a_command_already_present_in_the_shim_chain() {
             .contains("recursive shim invocation detected: pnpm -> node -> node"),
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn ignores_a_shim_chain_owned_by_another_router() {
+    let root = tempdir().expect("temp directory");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    fs::create_dir_all(&project).expect("project");
+    fs::write(
+        project.join("pinset.toml"),
+        "schema = 1\n[tools]\nnode = \"20.0.0\"\n",
+    )
+    .expect("project config");
+    create_fake_node(&home, "20.0.0");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pinset-shim"))
+        .args(["--as", "node", "--cwd"])
+        .arg(&project)
+        .args(["--", "foreign-chain"])
+        .env("PINSET_HOME", &home)
+        .env("PINSET_SHIM_CHAIN", "node")
+        .env("PINSET_SHIM_OWNER", "another-pinset-router")
+        .output()
+        .expect("run shim");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("20.0.0:foreign-chain"),
+        "stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
     );
 }
 
@@ -120,6 +197,155 @@ fn executes_another_selected_provider_from_a_managed_pnpm_process() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("bun:dev"), "stdout: {stdout}");
     assert!(stdout.contains("chain=pnpm"), "stdout: {stdout}");
+}
+
+#[test]
+fn executes_a_three_provider_chain_without_reentering_shims() {
+    let root = tempdir().expect("temp directory");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    fs::create_dir_all(&project).expect("project");
+    fs::write(
+        project.join("pinset.toml"),
+        "schema = 1\n[tools]\nbun = \"1.3.14\"\ngo = \"1.25.1\"\nnode = \"24.0.0\"\npnpm = \"11.22.0\"\n",
+    )
+    .expect("project config");
+    create_fake_node(&home, "24.0.0");
+    create_fake_pnpm(&home, "11.22.0");
+    create_fake_bun(&home, "1.3.14");
+    create_fake_go(&home, "1.25.1");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pinset-shim"))
+        .args(["--as", "pnpm", "--cwd"])
+        .arg(&project)
+        .args(["--", "chain3"])
+        .env("PINSET_HOME", &home)
+        .output()
+        .expect("run provider chain");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("go:final"), "stdout: {stdout}");
+    assert!(stdout.contains("chain=pnpm"), "stdout: {stdout}");
+}
+
+#[test]
+fn executes_the_same_managed_provider_in_a_child_process_without_reentering_the_shim() {
+    let root = tempdir().expect("temp directory");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    fs::create_dir_all(&project).expect("project");
+    fs::write(
+        project.join("pinset.toml"),
+        "schema = 1\n[tools]\nnode = \"20.0.0\"\n",
+    )
+    .expect("project config");
+    create_fake_node(&home, "20.0.0");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pinset-shim"))
+        .args(["--as", "node", "--cwd"])
+        .arg(&project)
+        .args(["--", "spawn-node"])
+        .env("PINSET_HOME", &home)
+        .output()
+        .expect("run same-provider child");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("node-child"), "stdout: {stdout}");
+    assert!(stdout.contains("chain=node"), "stdout: {stdout}");
+}
+
+#[test]
+fn executes_a_managed_system_managed_chain_with_the_effective_provider_path() {
+    let root = tempdir().expect("temp directory");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    let system_bin = root.path().join("system-bin");
+    fs::create_dir_all(&project).expect("project");
+    fs::write(
+        project.join("pinset.toml"),
+        "schema = 1\n[tools]\nbun = \"1.3.14\"\nnode = \"20.0.0\"\n",
+    )
+    .expect("project config");
+    create_fake_node(&home, "20.0.0");
+    create_fake_bun(&home, "1.3.14");
+    create_fake_system_bridge(&system_bin);
+    let inherited_path = env::var_os("PATH");
+    let path = std::iter::once(system_bin).chain(
+        inherited_path
+            .as_ref()
+            .into_iter()
+            .flat_map(|value| env::split_paths(value)),
+    );
+    let path = env::join_paths(path).expect("test PATH");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pinset-shim"))
+        .args(["--as", "node", "--cwd"])
+        .arg(&project)
+        .args(["--", "bridge"])
+        .env("PINSET_HOME", &home)
+        .env("PATH", path)
+        .output()
+        .expect("run mixed provider chain");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("bun:bridged"), "stdout: {stdout}");
+    assert!(stdout.contains("chain=node"), "stdout: {stdout}");
+}
+
+#[test]
+fn executes_an_inherited_global_provider_from_a_managed_pnpm_process() {
+    let root = tempdir().expect("temp directory");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    fs::create_dir_all(&project).expect("project");
+    fs::create_dir_all(home.join("state")).expect("global state");
+    fs::write(
+        project.join("pinset.toml"),
+        "schema = 1\n[policy]\ninherit-global = true\n[tools]\nnode = \"24.0.0\"\npnpm = \"11.22.0\"\n",
+    )
+    .expect("project config");
+    fs::write(
+        home.join("state/global.toml"),
+        "schema = 1\n[tools]\nbun = \"1.3.14\"\n",
+    )
+    .expect("global config");
+    create_fake_node(&home, "24.0.0");
+    create_fake_pnpm(&home, "11.22.0");
+    create_fake_bun(&home, "1.3.14");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pinset-shim"))
+        .args(["--as", "pnpm", "--cwd"])
+        .arg(&project)
+        .args(["--", "dev"])
+        .env("PINSET_HOME", &home)
+        .output()
+        .expect("run pnpm shim");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("bun:dev"),
+        "stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
 }
 
 #[test]
@@ -231,6 +457,53 @@ fn installed_shim_passes_through_to_system_path_without_recursing() {
 }
 
 #[test]
+fn installed_shim_passes_through_a_system_provider_with_declared_dependencies() {
+    let root = tempdir().expect("temp directory");
+    let workspace = root.path().join("workspace");
+    let home = root.path().join("home");
+    let shims = home.join("shims");
+    let system_bin = root.path().join("system-bin");
+    fs::create_dir_all(&workspace).expect("workspace");
+    create_fake_system_pnpm_and_node(&system_bin);
+    let installed = install_shims(
+        Path::new(env!("CARGO_BIN_EXE_pinset-shim")),
+        &shims,
+        &["pnpm".to_owned()],
+    )
+    .expect("install pnpm shim");
+    let inherited_path = env::var_os("PATH");
+    let path = std::iter::once(shims)
+        .chain(std::iter::once(system_bin))
+        .chain(
+            inherited_path
+                .as_ref()
+                .into_iter()
+                .flat_map(|value| env::split_paths(value)),
+        );
+    let path = env::join_paths(path).expect("test PATH");
+
+    let output = Command::new(&installed[0].destination)
+        .arg("system-chain")
+        .current_dir(&workspace)
+        .env("PINSET_HOME", &home)
+        .env("PATH", path)
+        .output()
+        .expect("run system pnpm shim");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("system-node:system-chain"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("source=system"), "stdout: {stdout}");
+}
+
+#[test]
 fn blocks_mutating_a_managed_flutter_sdk_before_invoking_it() {
     let root = tempdir().expect("temp directory");
     let project = root.path().join("project");
@@ -294,7 +567,7 @@ fn create_fake_node(home: &Path, version: &str) -> PathBuf {
         let executable = bin.join("node.cmd");
         fs::write(
             &executable,
-            "@echo off\r\nif \"%1\"==\"exit42\" exit /b 42\r\necho %PINSET_SELECTED_VERSION%:%*\r\necho source=%PINSET_SELECTION_SOURCE%\r\n",
+            "@echo off\r\nif \"%1\"==\"exit42\" exit /b 42\r\nif \"%1\"==\"spawn-node\" node child\r\nif \"%1\"==\"spawn-node\" exit /b %ERRORLEVEL%\r\nif \"%1\"==\"bridge\" pinset-test-bridge\r\nif \"%1\"==\"bridge\" exit /b %ERRORLEVEL%\r\nif \"%1\"==\"child\" echo node-child\r\nif \"%1\"==\"child\" echo chain=%PINSET_SHIM_CHAIN%\r\nif \"%1\"==\"child\" exit /b 0\r\necho %PINSET_SELECTED_VERSION%:%*\r\necho source=%PINSET_SELECTION_SOURCE%\r\n",
         )
         .expect("fake node");
         executable
@@ -307,7 +580,7 @@ fn create_fake_node(home: &Path, version: &str) -> PathBuf {
         let executable = bin.join("node");
         fs::write(
             &executable,
-            "#!/bin/sh\nif [ \"$1\" = \"exit42\" ]; then exit 42; fi\nprintf '%s:%s\\nsource=%s\\n' \"$PINSET_SELECTED_VERSION\" \"$*\" \"$PINSET_SELECTION_SOURCE\"\n",
+            "#!/bin/sh\nif [ \"$1\" = \"exit42\" ]; then exit 42; fi\nif [ \"$1\" = \"spawn-node\" ]; then exec node child; fi\nif [ \"$1\" = \"bridge\" ]; then exec pinset-test-bridge; fi\nif [ \"$1\" = \"child\" ]; then printf 'node-child\\nchain=%s\\n' \"$PINSET_SHIM_CHAIN\"; exit 0; fi\nprintf '%s:%s\\nsource=%s\\n' \"$PINSET_SELECTED_VERSION\" \"$*\" \"$PINSET_SELECTION_SOURCE\"\n",
         )
         .expect("fake node");
         let mut permissions = fs::metadata(&executable)
@@ -344,14 +617,36 @@ fn create_fake_bun(home: &Path, version: &str) {
     #[cfg(windows)]
     fs::write(
         directory.join("bun.cmd"),
-        "@echo off\r\necho bun:%*\r\necho chain=%PINSET_SHIM_CHAIN%\r\n",
+        "@echo off\r\nif \"%1\"==\"chain3\" go final\r\nif \"%1\"==\"chain3\" exit /b %ERRORLEVEL%\r\necho bun:%*\r\necho chain=%PINSET_SHIM_CHAIN%\r\n",
     )
     .expect("fake Bun");
 
     #[cfg(not(windows))]
     write_executable(
         &directory.join("bun"),
-        "#!/bin/sh\nprintf 'bun:%s\\nchain=%s\\n' \"$*\" \"$PINSET_SHIM_CHAIN\"\n",
+        "#!/bin/sh\nif [ \"$1\" = \"chain3\" ]; then exec go final; fi\nprintf 'bun:%s\\nchain=%s\\n' \"$*\" \"$PINSET_SHIM_CHAIN\"\n",
+    );
+}
+
+fn create_fake_go(home: &Path, version: &str) {
+    let directory = home
+        .join("installs/go")
+        .join(version)
+        .join(pinset_core::current_target_for_tool("go"))
+        .join("bin");
+    fs::create_dir_all(&directory).expect("Go command directory");
+
+    #[cfg(windows)]
+    fs::write(
+        directory.join("go.cmd"),
+        "@echo off\r\necho go:%*\r\necho chain=%PINSET_SHIM_CHAIN%\r\n",
+    )
+    .expect("fake Go");
+
+    #[cfg(not(windows))]
+    write_executable(
+        &directory.join("go"),
+        "#!/bin/sh\nprintf 'go:%s\\nchain=%s\\n' \"$*\" \"$PINSET_SHIM_CHAIN\"\n",
     );
 }
 
@@ -432,4 +727,45 @@ fn create_fake_system_node(directory: &Path) -> PathBuf {
         fs::set_permissions(&executable, permissions).expect("fake system node permissions");
         executable
     }
+}
+
+fn create_fake_system_pnpm_and_node(directory: &Path) {
+    fs::create_dir_all(directory).expect("system command directory");
+
+    #[cfg(windows)]
+    {
+        fs::write(directory.join("pnpm.cmd"), "@echo off\r\nnode %*\r\n")
+            .expect("fake system pnpm");
+        fs::write(
+            directory.join("node.cmd"),
+            "@echo off\r\necho system-node:%*\r\necho source=%PINSET_SELECTION_SOURCE%\r\n",
+        )
+        .expect("fake system node");
+    }
+
+    #[cfg(not(windows))]
+    {
+        write_executable(&directory.join("pnpm"), "#!/bin/sh\nexec node \"$@\"\n");
+        write_executable(
+            &directory.join("node"),
+            "#!/bin/sh\nprintf 'system-node:%s\\nsource=%s\\n' \"$*\" \"$PINSET_SELECTION_SOURCE\"\n",
+        );
+    }
+}
+
+fn create_fake_system_bridge(directory: &Path) {
+    fs::create_dir_all(directory).expect("system bridge directory");
+
+    #[cfg(windows)]
+    fs::write(
+        directory.join("pinset-test-bridge.cmd"),
+        "@echo off\r\nbun bridged\r\n",
+    )
+    .expect("fake system bridge");
+
+    #[cfg(not(windows))]
+    write_executable(
+        &directory.join("pinset-test-bridge"),
+        "#!/bin/sh\nexec bun bridged\n",
+    );
 }

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -14,9 +14,6 @@ mod environment;
 mod i18n;
 mod self_update;
 
-#[cfg(windows)]
-use std::ffi::OsStr;
-
 use clap::{Parser, Subcommand, ValueEnum, error::ErrorKind};
 use pinset_core::{
     ArtifactIntegrity, DiscoveryReport, DiscoveryStatus, DotnetMetadataClient,
@@ -25,7 +22,8 @@ use pinset_core::{
     LockAuditSeverity, LockedTool, Lockfile, NodeMetadataClient, NpmMetadataClient,
     PROJECT_CONFIG_SCHEMA, ProjectConfig, PythonMetadataClient, RuntimeInstallKind,
     RuntimeMetadataKind, RustMetadataClient, SUPPORTED_SOURCE_PROVIDERS, ShimInstallMethod,
-    SourceView, audit_global_lock, audit_project_lock, clean_download_cache, command_tool,
+    SourceView, acquire_global_state_write_lock, acquire_project_state_write_lock,
+    audit_global_lock, audit_project_lock, clean_download_cache, command_tool,
     create_project_config, create_project_python_environment, current_target_for_tool,
     download_cache_info, ensure_shims, find_optional_project_config, find_project_config,
     find_project_context, global_config_path, global_lockfile_path, import_download_cache,
@@ -37,18 +35,18 @@ use pinset_core::{
     load_optional_lockfile, load_project_config, load_project_python_environment,
     load_source_config, load_user_settings, lockfile_path, managed_runtime_arguments,
     path_with_selected_tools, pinset_home, plan_prune_tool_versions, plan_uninstall_tool_version,
-    project_python_environment_path, provider_dependency_order, repair_download_cache,
-    resolve_command, resolve_project_python_command, resolve_tool_selection,
+    project_python_environment_path, provider_dependency_order, register_project_config,
+    repair_download_cache, resolve_command, resolve_project_python_command, resolve_tool_selection,
     runtime_command_candidates, runtime_command_directory, runtime_environment_for_install,
-    runtime_provider, save_global_config, save_global_state, save_lockfile, save_project_config,
-    save_project_state, save_source_config, save_user_settings, scan_project_sources,
+    runtime_provider, save_global_config, save_global_state_locked, save_project_config,
+    save_project_state_locked, save_source_config, save_user_settings, scan_project_sources,
     selected_runtime_environment, source_config_path, uninstall_node_version,
     uninstall_tool_version, user_settings_path, validate_exact_dotnet_version,
     validate_exact_flutter_version, validate_exact_go_version, validate_exact_java_version,
     validate_exact_node_version, validate_exact_npm_tool_version, validate_exact_python_version,
     validate_exact_rust_version, validate_lock_matches_selection, validate_lock_matches_tool,
     validate_lock_matches_tools, validate_managed_runtime_invocation, validate_project_lock_policy,
-    verify_download_cache,
+    validate_windows_batch_arguments, verify_download_cache,
 };
 use serde::Serialize;
 use terminal_size::{Width, terminal_size_of};
@@ -3047,22 +3045,24 @@ fn save_resolved_selection_batch(
     resolved: &[ResolvedSelection],
 ) -> Result<(&'static str, PathBuf), Box<dyn std::error::Error>> {
     if global {
+        let _guard = acquire_global_state_write_lock(home)?;
         let config_path = global_config_path(home);
         let mut config = load_optional_global_config(&config_path)?.unwrap_or_default();
         let lock_path = global_lockfile_path(home);
         let mut lockfile = load_optional_lockfile(&lock_path)?.unwrap_or_else(new_lockfile);
         lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
         apply_resolved_selections(&mut config.tools, &mut lockfile, resolved)?;
-        save_global_state(home, &config, &lockfile)?;
+        save_global_state_locked(home, &config, &lockfile)?;
         Ok(("global", lock_path))
     } else {
         let config_path = find_project_config(cwd)?;
+        let _guard = acquire_project_state_write_lock(home, &config_path)?;
         let mut project = load_project_config(&config_path)?;
         let lock_path = lockfile_path(&config_path);
         let mut lockfile = load_optional_lockfile(&lock_path)?.unwrap_or_else(new_lockfile);
         lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
         apply_resolved_selections(&mut project.tools, &mut lockfile, resolved)?;
-        save_project_state(&config_path, &project, &lockfile)?;
+        save_project_state_locked(home, &config_path, &project, &lockfile)?;
         Ok(("project", lock_path))
     }
 }
@@ -3280,70 +3280,8 @@ fn run_project_import(
     }
 
     let config_path = report.target_config.clone();
-    let config_exists = match fs::symlink_metadata(&config_path) {
-        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
-            return Err(match catalog.language() {
-                Language::English => format!(
-                    "refusing to import into unsafe project configuration path {}",
-                    config_path.display()
-                )
-                .into(),
-                Language::SimplifiedChinese => {
-                    format!("拒绝导入到不安全的项目配置路径 {}", config_path.display()).into()
-                }
-            });
-        }
-        Ok(_) => true,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => false,
-        Err(error) => return Err(error.into()),
-    };
-    let mut project = if config_exists {
-        load_project_config(&config_path)?
-    } else {
-        ProjectConfig {
-            schema: PROJECT_CONFIG_SCHEMA,
-            project_id: Some(uuid::Uuid::new_v4().to_string()),
-            policy: Default::default(),
-            tools: BTreeMap::new(),
-            environment: None,
-        }
-    };
     let lock_path = lockfile_path(&config_path);
-    let existing_lockfile = match fs::symlink_metadata(&lock_path) {
-        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
-            return Err(match catalog.language() {
-                Language::English => format!(
-                    "refusing to import with unsafe lock path {}",
-                    lock_path.display()
-                )
-                .into(),
-                Language::SimplifiedChinese => {
-                    format!("拒绝使用不安全的锁文件路径 {} 导入", lock_path.display()).into()
-                }
-            });
-        }
-        Ok(_) => Some(load_lockfile(&lock_path)?),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => None,
-        Err(error) => return Err(error.into()),
-    };
-    match &existing_lockfile {
-        Some(lockfile) => validate_lock_matches_tools(lockfile, &project.tools, &config_path)?,
-        None if !project.tools.is_empty() => {
-            return Err(match catalog.language() {
-                Language::English => format!(
-                    "existing project configuration {} has selections but no pinset.lock",
-                    config_path.display()
-                )
-                .into(),
-                Language::SimplifiedChinese => format!(
-                    "现有项目配置 {} 包含版本选择，但缺少 pinset.lock",
-                    config_path.display()
-                )
-                .into(),
-            });
-        }
-        None => {}
-    }
+    let (project, _) = load_project_import_state(&config_path, catalog)?;
 
     let selections = report
         .findings
@@ -3362,22 +3300,12 @@ fn run_project_import(
         resolved.push((tool, selector, locked_tool));
     }
 
-    if !force
-        && let Some((tool, existing, imported)) = import_replacement_conflict(&project, &resolved)
-    {
-        return Err(match catalog.language() {
-            Language::English => format!(
-                "{} already selects {tool}@{existing}; importing {tool}@{imported} requires --force",
-                config_path.display(),
-            )
-            .into(),
-            Language::SimplifiedChinese => format!(
-                "{} 已选择 {tool}@{existing}；导入 {tool}@{imported} 需要 --force",
-                config_path.display(),
-            )
-            .into(),
-        });
-    }
+    reject_import_replacement_conflict(&config_path, &project, &resolved, force, catalog)?;
+
+    let home = pinset_home()?;
+    let _guard = acquire_project_state_write_lock(&home, &config_path)?;
+    let (mut project, existing_lockfile) = load_project_import_state(&config_path, catalog)?;
+    reject_import_replacement_conflict(&config_path, &project, &resolved, force, catalog)?;
 
     let mut lockfile = existing_lockfile.unwrap_or_else(new_lockfile);
     lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
@@ -3391,7 +3319,8 @@ fn run_project_import(
         project.set_tool(tool, selector);
         lockfile.upsert_tool(locked_tool.clone())?;
     }
-    save_project_state(&config_path, &project, &lockfile)?;
+    save_project_state_locked(&home, &config_path, &project, &lockfile)?;
+    drop(_guard);
 
     match catalog.language() {
         Language::English => println!(
@@ -3441,6 +3370,104 @@ fn run_project_import(
     Ok(())
 }
 
+fn load_project_import_state(
+    config_path: &Path,
+    catalog: Catalog,
+) -> Result<(ProjectConfig, Option<Lockfile>), Box<dyn std::error::Error>> {
+    let config_exists = match fs::symlink_metadata(config_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            return Err(match catalog.language() {
+                Language::English => format!(
+                    "refusing to import into unsafe project configuration path {}",
+                    config_path.display()
+                )
+                .into(),
+                Language::SimplifiedChinese => {
+                    format!("拒绝导入到不安全的项目配置路径 {}", config_path.display()).into()
+                }
+            });
+        }
+        Ok(_) => true,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => false,
+        Err(error) => return Err(error.into()),
+    };
+    let project = if config_exists {
+        load_project_config(config_path)?
+    } else {
+        ProjectConfig {
+            schema: PROJECT_CONFIG_SCHEMA,
+            project_id: Some(uuid::Uuid::new_v4().to_string()),
+            policy: Default::default(),
+            tools: BTreeMap::new(),
+            environment: None,
+        }
+    };
+    let lock_path = lockfile_path(config_path);
+    let lockfile = match fs::symlink_metadata(&lock_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            return Err(match catalog.language() {
+                Language::English => format!(
+                    "refusing to import with unsafe lock path {}",
+                    lock_path.display()
+                )
+                .into(),
+                Language::SimplifiedChinese => {
+                    format!("拒绝使用不安全的锁文件路径 {} 导入", lock_path.display()).into()
+                }
+            });
+        }
+        Ok(_) => Some(load_lockfile(&lock_path)?),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error.into()),
+    };
+    match &lockfile {
+        Some(lockfile) => validate_lock_matches_tools(lockfile, &project.tools, config_path)?,
+        None if !project.tools.is_empty() => {
+            return Err(match catalog.language() {
+                Language::English => format!(
+                    "existing project configuration {} has selections but no pinset.lock",
+                    config_path.display()
+                )
+                .into(),
+                Language::SimplifiedChinese => format!(
+                    "现有项目配置 {} 包含版本选择，但缺少 pinset.lock",
+                    config_path.display()
+                )
+                .into(),
+            });
+        }
+        None => {}
+    }
+    Ok((project, lockfile))
+}
+
+fn reject_import_replacement_conflict(
+    config_path: &Path,
+    project: &ProjectConfig,
+    resolved: &[ResolvedSelection],
+    force: bool,
+    catalog: Catalog,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if force {
+        return Ok(());
+    }
+    let Some((tool, existing, imported)) = import_replacement_conflict(project, resolved) else {
+        return Ok(());
+    };
+    Err(match catalog.language() {
+        Language::English => format!(
+            "{} already selects {tool}@{existing}; importing {tool}@{imported} requires --force",
+            config_path.display(),
+        )
+        .into(),
+        Language::SimplifiedChinese => format!(
+            "{} 已选择 {tool}@{existing}；导入 {tool}@{imported} 需要 --force",
+            config_path.display(),
+        )
+        .into(),
+    })
+}
+
 fn import_replacement_conflict(
     project: &ProjectConfig,
     resolved: &[(String, String, LockedTool)],
@@ -3464,14 +3491,29 @@ fn run_update(
     }
     let home = pinset_home()?;
     let cwd = effective_cwd(cwd)?;
+    let selected_config_path = if global {
+        global_config_path(&home)
+    } else {
+        find_project_config(&cwd)?
+    };
+    let _write_guard = if dry_run {
+        None
+    } else if global {
+        Some(acquire_global_state_write_lock(&home)?)
+    } else {
+        Some(acquire_project_state_write_lock(
+            &home,
+            &selected_config_path,
+        )?)
+    };
     let (scope, config_path, tools, mut lockfile) = if global {
-        let config_path = global_config_path(&home);
+        let config_path = selected_config_path;
         let config = load_global_config(&config_path)?;
         let lockfile = load_lockfile(&global_lockfile_path(&home))?;
         validate_lock_matches_tools(&lockfile, &config.tools, &config_path)?;
         ("global", config_path, config.tools, lockfile)
     } else {
-        let config_path = find_project_config(&cwd)?;
+        let config_path = selected_config_path;
         let config = load_project_config(&config_path)?;
         let lockfile = load_lockfile(&lockfile_path(&config_path))?;
         validate_lock_matches_tools(&lockfile, &config.tools, &config_path)?;
@@ -3519,10 +3561,10 @@ fn run_update(
         lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
         if global {
             let config = load_global_config(&config_path)?;
-            save_global_state(&home, &config, &lockfile)?;
+            save_global_state_locked(&home, &config, &lockfile)?;
         } else {
             let config = load_project_config(&config_path)?;
-            save_project_state(&config_path, &config, &lockfile)?;
+            save_project_state_locked(&home, &config_path, &config, &lockfile)?;
         }
     }
 
@@ -3556,9 +3598,14 @@ fn run_migrate(
     json: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let cwd = effective_cwd(cwd)?;
+    let home = pinset_home()?;
     let (scope, config_path, lock_path, config_schema, lock_schema) = if global {
-        let home = pinset_home()?;
         let config_path = global_config_path(&home);
+        let _guard = if dry_run {
+            None
+        } else {
+            Some(acquire_global_state_write_lock(&home)?)
+        };
         let lock_path = global_lockfile_path(&home);
         let config = load_global_config(&config_path)?;
         let lockfile = load_optional_lockfile(&lock_path)?;
@@ -3574,7 +3621,7 @@ fn run_migrate(
         );
         if !dry_run {
             if let Some(lockfile) = &lockfile {
-                save_global_state(&home, &config, lockfile)?;
+                save_global_state_locked(&home, &config, lockfile)?;
             } else {
                 save_global_config(&config_path, &config)?;
             }
@@ -3582,6 +3629,11 @@ fn run_migrate(
         report
     } else {
         let config_path = find_project_config(&cwd)?;
+        let _guard = if dry_run {
+            None
+        } else {
+            Some(acquire_project_state_write_lock(&home, &config_path)?)
+        };
         let lock_path = lockfile_path(&config_path);
         let config = load_project_config(&config_path)?;
         let lockfile = load_optional_lockfile(&lock_path)?;
@@ -3597,7 +3649,7 @@ fn run_migrate(
         );
         if !dry_run {
             if let Some(lockfile) = &lockfile {
-                save_project_state(&config_path, &config, lockfile)?;
+                save_project_state_locked(&home, &config_path, &config, lockfile)?;
             } else {
                 save_project_config(&config_path, &config)?;
             }
@@ -3609,7 +3661,7 @@ fn run_migrate(
     } else {
         PROJECT_CONFIG_SCHEMA
     };
-    let receipt_upgrade_needed = legacy_receipt_count(&pinset_home()?)?;
+    let receipt_upgrade_needed = legacy_receipt_count(&home)?;
     let report = MigrationReport {
         scope,
         config: config_path,
@@ -3685,6 +3737,7 @@ fn unset_tool(
     if global {
         let home = pinset_home()?;
         let config_path = global_config_path(&home);
+        let _guard = acquire_global_state_write_lock(&home)?;
         let Some(mut config) = load_optional_global_config(&config_path)? else {
             println!(
                 "{}",
@@ -3700,11 +3753,17 @@ fn unset_tool(
             return Ok(());
         }
         let lock_path = global_lockfile_path(&home);
-        if lock_path.is_file() {
-            load_lockfile(&lock_path)?;
+        if let Some(mut lockfile) = load_optional_lockfile(&lock_path)? {
+            lockfile.remove_tool(tool);
+            lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
+            let remove_empty_lock = lockfile.tools.is_empty();
+            save_global_state_locked(&home, &config, &lockfile)?;
+            if remove_empty_lock {
+                fs::remove_file(&lock_path)?;
+            }
+        } else {
+            save_global_config(&config_path, &config)?;
         }
-        save_global_config(&config_path, &config)?;
-        remove_tool_from_lock(&lock_path, tool)?;
         println!(
             "{}",
             catalog.selection_unset("global", tool, &config_path, true)
@@ -3713,6 +3772,8 @@ fn unset_tool(
     }
 
     let config_path = find_project_config(cwd)?;
+    let home = pinset_home()?;
+    let _guard = acquire_project_state_write_lock(&home, &config_path)?;
     let mut config = load_project_config(&config_path)?;
     if config.tools.remove(tool).is_none() {
         println!(
@@ -3722,29 +3783,21 @@ fn unset_tool(
         return Ok(());
     }
     let lock_path = lockfile_path(&config_path);
-    if lock_path.is_file() {
-        load_lockfile(&lock_path)?;
+    if let Some(mut lockfile) = load_optional_lockfile(&lock_path)? {
+        lockfile.remove_tool(tool);
+        lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
+        let remove_empty_lock = lockfile.tools.is_empty();
+        save_project_state_locked(&home, &config_path, &config, &lockfile)?;
+        if remove_empty_lock {
+            fs::remove_file(&lock_path)?;
+        }
+    } else {
+        save_project_config(&config_path, &config)?;
     }
-    save_project_config(&config_path, &config)?;
-    remove_tool_from_lock(&lock_path, tool)?;
     println!(
         "{}",
         catalog.selection_unset("project", tool, &config_path, true)
     );
-    Ok(())
-}
-
-fn remove_tool_from_lock(path: &Path, tool: &str) -> Result<(), Box<dyn std::error::Error>> {
-    if !path.is_file() {
-        return Ok(());
-    }
-    let mut lockfile = load_lockfile(path)?;
-    lockfile.remove_tool(tool);
-    if lockfile.tools.is_empty() {
-        fs::remove_file(path)?;
-    } else {
-        save_lockfile(path, &lockfile)?;
-    }
     Ok(())
 }
 
@@ -3863,7 +3916,9 @@ fn install_project_with_venv(
     let lock_path = lockfile_path(&config_path);
     let home = pinset_home()?;
     let policy_lock = load_lockfile(&lock_path)?;
+    validate_lock_matches_tools(&policy_lock, &project.tools, &config_path)?;
     validate_project_lock_policy(&project, &policy_lock, std::time::SystemTime::now())?;
+    register_project_config(&home, &config_path)?;
     install_locked_selection(&home, &project.tools, &config_path, &lock_path, catalog)?;
     if let Some(requested) = project.tools.get("python") {
         let distribution = selected_version_from_lock(
@@ -4578,6 +4633,7 @@ fn execute_selected(
     } else {
         managed_runtime_arguments(&tool, command_name, &command[1..])
     };
+    validate_windows_batch_arguments(&executable, &runtime_arguments)?;
     let mut child = command_for_runtime(&executable);
     child
         .args(runtime_arguments)
@@ -4724,18 +4780,6 @@ fn runtime_command_path(command_dir: &Path, command: &str) -> PathBuf {
 }
 
 fn command_for_runtime(executable: &Path) -> Command {
-    #[cfg(windows)]
-    {
-        let extension = executable
-            .extension()
-            .and_then(OsStr::to_str)
-            .unwrap_or_default();
-        if extension.eq_ignore_ascii_case("cmd") || extension.eq_ignore_ascii_case("bat") {
-            let mut command = Command::new("cmd.exe");
-            command.arg("/D").arg("/C").arg(executable);
-            return command;
-        }
-    }
     Command::new(executable)
 }
 
@@ -6753,6 +6797,60 @@ mod tests {
         assert_eq!(saved_global.tools["node"], "lts");
         assert_eq!(saved_global.tools["go"], "latest");
         assert_eq!(saved_global_lock.tools.len(), 2);
+    }
+
+    #[test]
+    fn concurrent_project_batches_preserve_both_updates() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let home = std::sync::Arc::new(root.path().join("home"));
+        let project = std::sync::Arc::new(root.path().join("project"));
+        fs::create_dir_all(project.as_ref()).expect("project directory");
+        let project_path = project.join(pinset_core::PROJECT_CONFIG_FILENAME);
+        save_project_config(
+            &project_path,
+            &ProjectConfig {
+                schema: PROJECT_CONFIG_SCHEMA,
+                project_id: Some(uuid::Uuid::new_v4().to_string()),
+                policy: Default::default(),
+                tools: BTreeMap::new(),
+                environment: None,
+            },
+        )
+        .expect("empty project config");
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+        let mut threads = Vec::new();
+        for batch in [
+            vec![(
+                "node".to_owned(),
+                "lts".to_owned(),
+                persistable_selection_lock("node", "lts", "24.0.0"),
+            )],
+            vec![(
+                "go".to_owned(),
+                "latest".to_owned(),
+                persistable_selection_lock("go", "latest", "1.25.1"),
+            )],
+        ] {
+            let home = std::sync::Arc::clone(&home);
+            let project = std::sync::Arc::clone(&project);
+            let barrier = std::sync::Arc::clone(&barrier);
+            threads.push(std::thread::spawn(move || {
+                barrier.wait();
+                save_resolved_selection_batch(&home, &project, false, &batch)
+                    .expect("save concurrent batch");
+            }));
+        }
+        barrier.wait();
+        for thread in threads {
+            thread.join().expect("batch thread");
+        }
+
+        let config = load_project_config(&project_path).expect("project config");
+        let lockfile = load_lockfile(&project.join("pinset.lock")).expect("project lock");
+        assert_eq!(config.tools["node"], "lts");
+        assert_eq!(config.tools["go"], "latest");
+        assert_eq!(lockfile.tool("node").unwrap().version, "24.0.0");
+        assert_eq!(lockfile.tool("go").unwrap().version, "1.25.1");
     }
 
     fn persistable_selection_lock(tool: &str, requested: &str, version: &str) -> LockedTool {

--- a/crates/pinset/src/self_update.rs
+++ b/crates/pinset/src/self_update.rs
@@ -1,8 +1,9 @@
 use std::{
     fs,
     io::{Cursor, Read, Write},
-    path::Path,
+    path::{Path, PathBuf},
     process::Command,
+    time::Duration,
 };
 
 use reqwest::blocking::Client;
@@ -20,7 +21,16 @@ struct Release {
     draft: bool,
 }
 
+#[derive(Debug, Deserialize)]
+struct SelfUpdateResult {
+    status: String,
+    version: String,
+    #[serde(default)]
+    message: String,
+}
+
 pub(crate) fn outdated(prerelease: bool, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    report_previous_result()?;
     let latest = latest_release(prerelease)?;
     let current = Version::parse(pinset_core::pinset_version())?;
     let available = parse_tag(&latest.tag_name)?;
@@ -42,6 +52,9 @@ pub(crate) fn outdated(prerelease: bool, json: bool) -> Result<(), Box<dyn std::
 }
 
 pub(crate) fn update(requested: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
+    let home = pinset_core::pinset_home()?;
+    let _update_lock = pinset_core::acquire_self_update_lock(&home)?;
+    report_previous_result_at(&self_update_result_path(&home))?;
     let current = Version::parse(pinset_core::pinset_version())?;
     let version = match requested {
         Some(value) => Version::parse(value.trim_start_matches('v'))?,
@@ -64,7 +77,12 @@ pub(crate) fn update(requested: Option<&str>) -> Result<(), Box<dyn std::error::
         return Err(format!("SHA-256 mismatch for {archive}").into());
     }
     let (cli_bytes, shim_bytes) = extract_pair(archive, &bytes)?;
-    publish(version, &cli_bytes, &shim_bytes)
+    publish(
+        version,
+        &cli_bytes,
+        &shim_bytes,
+        &self_update_result_path(&home),
+    )
 }
 
 fn latest_release(prerelease: bool) -> Result<Release, Box<dyn std::error::Error>> {
@@ -92,6 +110,7 @@ fn latest_release(prerelease: bool) -> Result<Release, Box<dyn std::error::Error
 fn client() -> Result<Client, reqwest::Error> {
     Client::builder()
         .user_agent(format!("pinset/{}", pinset_core::pinset_version()))
+        .timeout(Duration::from_secs(60))
         .build()
 }
 
@@ -218,7 +237,10 @@ fn publish(
     version: Version,
     cli_bytes: &[u8],
     shim_bytes: &[u8],
+    result_path: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(not(windows))]
+    let _ = result_path;
     let current = std::env::current_exe()?;
     let directory = current
         .parent()
@@ -240,8 +262,9 @@ fn publish(
             "self update requires pinset and pinset-shim in the same installation directory".into(),
         );
     }
-    let new_cli = directory.join(format!(".{cli_name}.{version}.new"));
-    let new_shim = directory.join(format!(".{shim_name}.{version}.new"));
+    let process_id = std::process::id();
+    let new_cli = directory.join(format!(".{cli_name}.{version}.{process_id}.new"));
+    let new_shim = directory.join(format!(".{shim_name}.{version}.{process_id}.new"));
     write_new(&new_cli, cli_bytes)?;
     write_new(&new_shim, shim_bytes)?;
     let output = Command::new(&new_cli).arg("--version").output()?;
@@ -254,7 +277,7 @@ fn publish(
         return Err("downloaded Pinset binary failed its version handshake".into());
     }
     #[cfg(windows)]
-    return publish_windows(&version, &cli, &shim, &new_cli, &new_shim);
+    return publish_windows(&version, &cli, &shim, &new_cli, &new_shim, result_path);
     #[cfg(not(windows))]
     publish_unix(&version, &cli, &shim, &new_cli, &new_shim)
 }
@@ -310,6 +333,8 @@ fn publish_unix(
         fs::rename(shim_backup, shim)?;
         return Err("updated Pinset failed validation and was rolled back".into());
     }
+    let _ = fs::remove_file(cli_backup);
+    let _ = fs::remove_file(shim_backup);
     println!("updated Pinset to {version}");
     Ok(())
 }
@@ -321,18 +346,21 @@ fn publish_windows(
     shim: &Path,
     new_cli: &Path,
     new_shim: &Path,
+    result_path: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use std::os::windows::process::CommandExt;
     let helper = cli
         .parent()
         .unwrap()
         .join(format!(".pinset-update-{}.ps1", std::process::id()));
-    let script = r#"param([int]$OldPid,[string]$Cli,[string]$Shim,[string]$NewCli,[string]$NewShim)
+    let script = r#"param([int]$OldPid,[string]$Cli,[string]$Shim,[string]$NewCli,[string]$NewShim,[string]$Result,[string]$Version)
 $ErrorActionPreference='Stop'; Wait-Process -Id $OldPid -ErrorAction SilentlyContinue
 $cliBak="$Cli.bak"; $shimBak="$Shim.bak"
-try { Move-Item -LiteralPath $Cli -Destination $cliBak -Force; Move-Item -LiteralPath $NewCli -Destination $Cli -Force; Move-Item -LiteralPath $Shim -Destination $shimBak -Force; Move-Item -LiteralPath $NewShim -Destination $Shim -Force; & $Cli --version; if ($LASTEXITCODE -ne 0) { throw 'version validation failed' } }
-catch { Remove-Item -LiteralPath $Cli,$Shim -Force -ErrorAction SilentlyContinue; Move-Item -LiteralPath $cliBak -Destination $Cli -Force -ErrorAction SilentlyContinue; Move-Item -LiteralPath $shimBak -Destination $Shim -Force -ErrorAction SilentlyContinue }
-finally { Remove-Item -LiteralPath $PSCommandPath -Force -ErrorAction SilentlyContinue }
+$record=@{status='failed';version=$Version;message='update helper did not complete'}
+Remove-Item -LiteralPath $cliBak,$shimBak -Force -ErrorAction SilentlyContinue
+try { Move-Item -LiteralPath $Cli -Destination $cliBak; Move-Item -LiteralPath $NewCli -Destination $Cli; Move-Item -LiteralPath $Shim -Destination $shimBak; Move-Item -LiteralPath $NewShim -Destination $Shim; & $Cli --version | Out-Null; if ($LASTEXITCODE -ne 0) { throw 'version validation failed' }; Remove-Item -LiteralPath $cliBak,$shimBak -Force -ErrorAction SilentlyContinue; $record=@{status='success';version=$Version;message=''} }
+catch { $record.message=$_.Exception.Message; try { if (Test-Path -LiteralPath $cliBak) { Remove-Item -LiteralPath $Cli -Force -ErrorAction SilentlyContinue; Move-Item -LiteralPath $cliBak -Destination $Cli -Force } } catch { $record.message += "; CLI rollback failed: $($_.Exception.Message)" }; try { if (Test-Path -LiteralPath $shimBak) { Remove-Item -LiteralPath $Shim -Force -ErrorAction SilentlyContinue; Move-Item -LiteralPath $shimBak -Destination $Shim -Force } } catch { $record.message += "; shim rollback failed: $($_.Exception.Message)" } }
+finally { $json=$record | ConvertTo-Json -Compress; [IO.File]::WriteAllText($Result,$json,(New-Object Text.UTF8Encoding($false))); Remove-Item -LiteralPath $PSCommandPath -Force -ErrorAction SilentlyContinue }
 "#;
     write_new(&helper, script.as_bytes())?;
     Command::new("powershell.exe")
@@ -354,10 +382,45 @@ finally { Remove-Item -LiteralPath $PSCommandPath -Force -ErrorAction SilentlyCo
         .arg(new_cli)
         .arg("-NewShim")
         .arg(new_shim)
+        .arg("-Result")
+        .arg(result_path)
+        .arg("-Version")
+        .arg(version.to_string())
         .creation_flags(0x08000000)
         .spawn()?;
     println!("Pinset {version} was verified; replacement will finish after this process exits");
     Ok(())
+}
+
+fn report_previous_result() -> Result<(), Box<dyn std::error::Error>> {
+    let home = pinset_core::pinset_home()?;
+    report_previous_result_at(&self_update_result_path(&home))
+}
+
+fn report_previous_result_at(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    let result: SelfUpdateResult = serde_json::from_str(content.trim_start_matches('\u{feff}'))?;
+    fs::remove_file(path)?;
+    if result.status == "success" {
+        eprintln!(
+            "previous Windows self update completed: Pinset {}",
+            result.version
+        );
+    } else {
+        eprintln!(
+            "warning: previous Windows self update to {} failed and was rolled back: {}",
+            result.version, result.message
+        );
+    }
+    Ok(())
+}
+
+fn self_update_result_path(pinset_home: &Path) -> PathBuf {
+    pinset_core::global_state_dir(pinset_home).join("self-update-result.json")
 }
 
 fn same_path(left: &Path, right: &Path) -> bool {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -18,6 +18,7 @@ The global `--lang <en|zh-CN>` option selects output language for one invocation
 
 - Project selection: `pinset.toml` and `pinset.lock`.
 - Global selection: `PINSET_HOME/state/global.toml` and `global.lock`.
+- Known-project protection records: `PINSET_HOME/state/projects`. Project `use`, `import`, and locked installation register the canonical config path so `uninstall` and `prune` can protect selections outside the current working tree.
 - Local machine settings, sources, download cache, installations, and receipts: under `PINSET_HOME`.
 - `--cwd <path>` starts project discovery at that path.
 - `--dry-run` reports a planned destructive operation without applying it.
@@ -238,19 +239,19 @@ Stable reason codes are grouped as follows:
 | Example | `pinset uninstall node@22.0.0 --dry-run --json` |
 | JSON | **Yes**; command name `uninstall`. |
 | Exit | `0` for a completed plan/removal; `2` when protection blocks it or validation fails. |
-| Key errors | Non-exact version, selected runtime still referenced, missing/invalid receipt, unsafe path, or non-owned installation. `--force` bypasses selection references, not ownership checks. |
+| Key errors | Non-exact version, selected runtime still referenced by the current, global, explicitly supplied, or locally registered project state, missing/invalid receipt, unsafe path, or non-owned installation. `--force` bypasses selection references, not ownership checks. Projects never used by this Pinset installation cannot be discovered automatically. |
 
 ### `prune`
 
 | Field | Description |
 | --- | --- |
-| Purpose | Remove installed versions not protected by global or supplied project selections. |
+| Purpose | Remove installed versions not protected by global, supplied, or locally registered project selections. |
 | Syntax and arguments | `pinset prune [--cwd <path>] [--project <path>]... [--dry-run] [--json]`. |
 | Modifies state | **Yes**, unless `--dry-run`. |
 | Example | `pinset prune --project ./app --project ../service --dry-run` |
 | JSON | **Yes**; command name `prune`. |
 | Exit | `0` for a completed plan/removal; `2` if references or ownership cannot be validated. |
-| Key errors | Invalid project lock, unsafe installation path, missing receipt, or filesystem failure. |
+| Key errors | Invalid project/registry state, unsafe installation path, missing receipt, or filesystem failure. Projects never used by this Pinset installation must still be supplied with `--project`. |
 
 ### `exec`
 
@@ -889,9 +890,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.1
+      - uses: Future-Element/pinset@v2.1.2
         with:
-          version: 2.1.1
+          version: 2.1.2
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js
@@ -904,6 +905,8 @@ The Action input is not a secret and does not persist the identity. Pinset remov
 `pinset paths [tool] [--json]` reports the CLI, adjacent shim, Pinset home, shim directory, installation root, and an optional tool's installed versions. `pinset list [tool] --long` adds receipt schema, installation root, file count, total size, critical entries, and integrity status. `pinset doctor --deep` rescans these statistics; it does not claim per-file cryptographic verification. `pinset install <tool@exact-version> --repair` repairs only an installation whose ownership receipt matches the requested tool, version, platform, and target directory. `pinset shim install --all` registers every built-in Provider command without downloading a runtime.
 
 `pinset self outdated [--channel stable|prerelease] [--json]` performs an explicit check against the fixed official repository. `pinset self update [--version <version>]` verifies platform, semantic version, archive structure, and `SHA256SUMS`, validates the new CLI, and replaces the CLI and shim as a pair with backup and rollback. Ordinary commands and `doctor` never check for updates in the background.
+
+Self updates use a cross-process lock and a 60-second HTTP timeout. Windows replacement remains asynchronous because a running executable cannot replace itself; the helper records success or rollback under `PINSET_HOME/state`, and the next `self outdated` or `self update` reports that result. Windows `.cmd`/`.bat` runtime fallbacks reject arguments containing `cmd.exe` metacharacters rather than risk shell reinterpretation; managed `.exe` runtimes are unaffected.
 
 ## Stable protocol boundary
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -18,6 +18,7 @@
 
 - 项目选择：`pinset.toml` 与 `pinset.lock`。
 - 全局选择：`PINSET_HOME/state/global.toml` 与 `global.lock`。
+- 已知项目保护记录：`PINSET_HOME/state/projects`。项目执行 `use`、`import` 或锁定安装时会登记规范化配置路径，使 `uninstall` 与 `prune` 能保护当前工作树之外的选择。
 - 本机设置、源、下载缓存、安装和收据：位于 `PINSET_HOME`。
 - `--cwd <path>` 从指定路径开始查找项目。
 - `--dry-run` 只报告计划中的破坏性操作，不执行修改。
@@ -238,19 +239,19 @@
 | 示例 | `pinset uninstall node@22.0.0 --dry-run --json` |
 | JSON | **支持**；命令名为 `uninstall`。 |
 | 退出码 | 完成计划/删除为 `0`；保护机制阻止或验证失败为 `2`。 |
-| 关键错误 | 版本不精确、运行时仍被选择引用、收据缺失/无效、路径不安全或安装不归 Pinset 所有。`--force` 只绕过选择引用，不绕过所有权检查。 |
+| 关键错误 | 当前项目、全局、显式提供或本机已登记项目仍引用该运行时，收据缺失/无效、路径不安全或安装不归 Pinset 所有。`--force` 只绕过选择引用，不绕过所有权检查。从未被本机 Pinset 使用过的项目无法自动发现。 |
 
 ### `prune`
 
 | 字段 | 说明 |
 | --- | --- |
-| 用途 | 删除未被全局或所提供项目选择保护的已安装版本。 |
+| 用途 | 删除未被全局、所提供项目或本机已登记项目选择保护的已安装版本。 |
 | 语法与参数 | `pinset prune [--cwd <path>] [--project <path>]... [--dry-run] [--json]`。 |
 | 修改状态 | **是**，但 `--dry-run` 时不修改。 |
 | 示例 | `pinset prune --project ./app --project ../service --dry-run` |
 | JSON | **支持**；命令名为 `prune`。 |
 | 退出码 | 完成计划/删除为 `0`；无法验证引用或所有权为 `2`。 |
-| 关键错误 | 项目锁无效、安装路径不安全、收据缺失或文件系统失败。 |
+| 关键错误 | 项目/登记状态无效、安装路径不安全、收据缺失或文件系统失败。从未被本机 Pinset 使用过的项目仍需通过 `--project` 提供。 |
 
 ### `exec`
 
@@ -889,9 +890,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.1
+      - uses: Future-Element/pinset@v2.1.2
         with:
-          version: 2.1.1
+          version: 2.1.2
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js
@@ -904,6 +905,8 @@ Action 输入不是秘密，也不保存 identity。Pinset 会在子进程启动
 `pinset paths [tool] [--json]` 会报告 CLI、相邻 shim、Pinset home、shim 目录、安装根，以及可选工具的已安装版本。`pinset list [tool] --long` 增加收据 schema、安装根、文件数量、总大小、关键入口与完整性状态。`pinset doctor --deep` 会重新扫描这些统计，但不宣称逐文件密码学验证。`pinset install <tool@精确版本> --repair` 只修复所有权收据与工具、版本、平台和目标目录全部匹配的安装。`pinset shim install --all` 注册所有内置 Provider 命令，但不下载运行时。
 
 `pinset self outdated [--channel stable|prerelease] [--json]` 只在用户明确执行时检查固定官方仓库。`pinset self update [--version <版本>]` 验证平台、语义版本、归档结构与 `SHA256SUMS`，校验新 CLI 后成对替换 CLI/shim，并支持备份与回滚。普通命令和 `doctor` 不会后台检查更新。
+
+自更新使用跨进程锁和 60 秒 HTTP 超时。Windows 中运行中的可执行文件不能替换自身，因此替换仍由异步辅助进程完成；辅助进程会把成功或回滚结果写入 `PINSET_HOME/state`，下一次执行 `self outdated` 或 `self update` 时会报告。Windows `.cmd`/`.bat` 运行时回退会拒绝包含 `cmd.exe` 元字符的参数，避免被 shell 二次解释；受管 `.exe` 运行时不受影响。
 
 ## 稳定协议边界
 

--- a/examples/devcontainer/.devcontainer/Dockerfile
+++ b/examples/devcontainer/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
-ARG PINSET_VERSION=2.1.1
+ARG PINSET_VERSION=2.1.2
 
 RUN set -eux; \
     architecture="$(dpkg --print-architecture)"; \

--- a/examples/devcontainer/.devcontainer/devcontainer.json
+++ b/examples/devcontainer/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-        "PINSET_VERSION": "2.1.1"
+        "PINSET_VERSION": "2.1.2"
     }
   },
   "postCreateCommand": "pinset install --locked",

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string] $Version = '2.1.1',
+    [string] $Version = '2.1.2',
     [string] $InstallDir = (Join-Path $env:LOCALAPPDATA 'Pinset\bin')
 )
 

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="2.1.1"
+DEFAULT_VERSION="2.1.2"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -22,7 +22,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 2.1.1.
+  --version VERSION       Install an exact release, for example 2.1.2.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.

--- a/scripts/tests/integrations_test.py
+++ b/scripts/tests/integrations_test.py
@@ -72,6 +72,22 @@ require_text(
         "dist/pinset-env.cdx.json",
     ),
 )
+release_workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+assert "--clobber" not in release_workflow
+assert "stable release assets are immutable" in release_workflow
+require_text(
+    ROOT / ".github/workflows/ci.yml",
+    (
+        "Validate documentation website",
+        "pnpm install --frozen-lockfile",
+        "pnpm typecheck",
+        "pnpm build",
+        "http://localhost:3000",
+    ),
+)
+website_package = json.loads((ROOT / "website/package.json").read_text(encoding="utf-8"))
+assert website_package["version"] == WORKSPACE_VERSION
+assert website_package["packageManager"] == "pnpm@10.15.0"
 require_text(
     ROOT / "examples/devcontainer/.devcontainer/Dockerfile",
     (f"ARG PINSET_VERSION={WORKSPACE_VERSION}", "SHA256SUMS", "sha256sum"),

--- a/website/.env.example
+++ b/website/.env.example
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_SITE_URL=https://docs.example.com
+NEXT_PUBLIC_SITE_URL=https://pinset.future-element.com

--- a/website/components/command-page.tsx
+++ b/website/components/command-page.tsx
@@ -20,7 +20,7 @@ export function CommandPage({ locale, groups, command }: { locale: Locale; group
     description: command.description,
     inLanguage: locale,
     isPartOf: { "@type": "WebSite", name: siteConfig.name },
-    about: { "@type": "SoftwareApplication", name: siteConfig.name, softwareVersion: "2.1.1" },
+    about: { "@type": "SoftwareApplication", name: siteConfig.name, softwareVersion: siteConfig.version },
   };
 
   return (

--- a/website/components/home-page.tsx
+++ b/website/components/home-page.tsx
@@ -40,7 +40,7 @@ export function HomePage({ locale, groups }: { locale: Locale; groups: CommandGr
     url: siteUrl,
     applicationCategory: "DeveloperApplication",
     operatingSystem: "Windows, Linux, macOS",
-    softwareVersion: "2.1.1",
+    softwareVersion: siteConfig.version,
     license: "https://opensource.org/license/mit",
     codeRepository: siteConfig.repository,
     description: zh ? siteConfig.descriptionZh : siteConfig.descriptionEn,

--- a/website/lib/site.ts
+++ b/website/lib/site.ts
@@ -1,8 +1,10 @@
-export const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000").replace(/\/$/, "");
+import packageJson from "../package.json";
+
+export const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || "https://pinset.future-element.com").replace(/\/$/, "");
 
 export const siteConfig = {
   name: "Pinset",
-  version: "2.1",
+  version: packageJson.version,
   repository: "https://github.com/Future-Element/pinset",
   organization: {
     name: "Future Element",

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,8 @@
 {
   "name": "pinset-website",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
+  "packageManager": "pnpm@10.15.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary
- make managed child-process routing provider-agnostic across selected, inherited-global, peer, and system-PATH providers
- prevent recursive shim re-entry and preserve Windows batch arguments safely across multi-provider chains
- serialize project/global state writes, register known projects, and protect referenced runtimes during uninstall and prune
- harden self-update locking, timeouts, result reporting, rollback, and stable release asset immutability
- publish the 2.1.2 metadata and validate the documentation website in CI and release preflight

## Local verification
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo test --workspace --all-features --locked
- cargo audit --deny warnings --ignore RUSTSEC-2023-0071
- integration contract tests
- Windows installer and uninstaller tests
- Unix uninstaller tests
- clean Windows release build and pinset 2.1.2 version handshake
- website frozen install, typecheck, production build, and origin gate