### PR TITLE
fix: release Pinset v2.1.3 site identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,9 @@ jobs:
       - name: Build production website
         run: pnpm build
 
+      - name: Validate site-name and canonical SEO signals
+        run: pnpm validate:seo
+
       - name: Reject development origins in static output
         shell: bash
         run: if grep -R --exclude='404.html' --exclude='_not-found*' --exclude-dir='_not-found' "http://localhost:3000" out; then exit 1; fi

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -195,6 +195,9 @@ jobs:
       - name: Build production website
         run: pnpm build
 
+      - name: Validate site-name and canonical SEO signals
+        run: pnpm validate:seo
+
       - name: Reject development origins in static output
         shell: bash
         run: if grep -R --exclude='404.html' --exclude='_not-found*' --exclude-dir='_not-found' "http://localhost:3000" out; then exit 1; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.3 - 2026-08-27
+
+- Strengthen the documentation site's Google site-name signals by keeping the Pinset brand identity and canonical subdomain consistent across exported pages.
+- Validate site-name, Open Graph, and canonical metadata during website CI and release preflight.
+
 ## 2.1.2 - 2026-08-27
 
 - Make inherited global Providers and peer runtime environment roots available to managed child processes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2734,7 +2734,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "clap",
  "flate2",
@@ -2760,7 +2760,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "atomic-write-file",
  "base64",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-env"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "age",
  "atomic-write-file",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.97"
-version = "2.1.2"
+version = "2.1.3"
 authors = ["Future Element"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ export PATH="$HOME/.local/bin:$PATH"
 Install an exact version or choose another directory:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.2
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.3
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -103,7 +103,7 @@ Remove-Item .\install.ps1
 Install an exact version:
 
 ```powershell
-.\install.ps1 -Version 2.1.2
+.\install.ps1 -Version 2.1.3
 ```
 
 Windows and WSL are separate environments and require separate installations. The installer registers Pinset and every built-in command route, but it does not pre-download language runtimes.
@@ -281,9 +281,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.2
+      - uses: Future-Element/pinset@v2.1.3
         with:
-          version: 2.1.2
+          version: 2.1.3
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -88,7 +88,7 @@ export PATH="$HOME/.local/bin:$PATH"
 安装指定版本或目录：
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.2
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.3
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -103,7 +103,7 @@ Remove-Item .\install.ps1
 指定版本：
 
 ```powershell
-.\install.ps1 -Version 2.1.2
+.\install.ps1 -Version 2.1.3
 ```
 
 Windows 与 WSL 是两个独立环境，需要分别安装。安装器只安装 Pinset 和所有内置命令路由，不会预先下载语言运行时。
@@ -281,9 +281,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.2
+      - uses: Future-Element/pinset@v2.1.3
         with:
-          version: 2.1.2
+          version: 2.1.3
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   version:
     description: Exact Pinset release version without the leading v.
     required: false
-    default: 2.1.2
+    default: 2.1.3
   install:
     description: Run pinset install --locked after Pinset is available.
     required: false

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -890,9 +890,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.2
+      - uses: Future-Element/pinset@v2.1.3
         with:
-          version: 2.1.2
+          version: 2.1.3
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -890,9 +890,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.2
+      - uses: Future-Element/pinset@v2.1.3
         with:
-          version: 2.1.2
+          version: 2.1.3
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/examples/devcontainer/.devcontainer/Dockerfile
+++ b/examples/devcontainer/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
-ARG PINSET_VERSION=2.1.2
+ARG PINSET_VERSION=2.1.3
 
 RUN set -eux; \
     architecture="$(dpkg --print-architecture)"; \

--- a/examples/devcontainer/.devcontainer/devcontainer.json
+++ b/examples/devcontainer/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-        "PINSET_VERSION": "2.1.2"
+        "PINSET_VERSION": "2.1.3"
     }
   },
   "postCreateCommand": "pinset install --locked",

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string] $Version = '2.1.2',
+    [string] $Version = '2.1.3',
     [string] $InstallDir = (Join-Path $env:LOCALAPPDATA 'Pinset\bin')
 )
 

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="2.1.2"
+DEFAULT_VERSION="2.1.3"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -22,7 +22,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 2.1.2.
+  --version VERSION       Install an exact release, for example 2.1.3.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.

--- a/website/app/(en)/en/docs/commands/[slug]/page.tsx
+++ b/website/app/(en)/en/docs/commands/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import { CommandPage } from "@/components/command-page";
 import { getCommand, getCommandDocs, getCommandGroups } from "@/lib/commands";
 import { openGraphImage, twitterImage } from "@/lib/metadata";
-import { languageAlternates } from "@/lib/site";
+import { languageAlternates, siteConfig } from "@/lib/site";
 
 export function generateStaticParams() {
   return getCommandDocs("en").map(({ slug }) => ({ slug }));
@@ -22,6 +22,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     },
     openGraph: {
       type: "article",
+      siteName: siteConfig.name,
       locale: "en_US",
       title: `pinset ${command.title}`,
       description: command.description,

--- a/website/app/(en)/en/docs/commands/page.tsx
+++ b/website/app/(en)/en/docs/commands/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { CommandIndexPage } from "@/components/command-index-page";
 import { getCommandGroups } from "@/lib/commands";
 import { openGraphImage, twitterImage } from "@/lib/metadata";
-import { languageAlternates } from "@/lib/site";
+import { languageAlternates, siteConfig } from "@/lib/site";
 
 export const metadata: Metadata = {
   title: "Command reference",
@@ -13,6 +13,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     type: "website",
+    siteName: siteConfig.name,
     locale: "en_US",
     url: "/en/docs/commands",
     title: "Pinset 2.1 command reference",

--- a/website/app/(en)/en/page.tsx
+++ b/website/app/(en)/en/page.tsx
@@ -9,6 +9,8 @@ export const metadata: Metadata = {
   alternates: { canonical: "/en", languages: languageAlternates("/", "/en") },
   openGraph: {
     locale: "en_US",
+    siteName: siteConfig.name,
+    type: "website",
     url: "/en",
     title: siteConfig.titleEn,
     description: siteConfig.descriptionEn,

--- a/website/app/(zh)/docs/commands/[slug]/page.tsx
+++ b/website/app/(zh)/docs/commands/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import { CommandPage } from "@/components/command-page";
 import { getCommand, getCommandDocs, getCommandGroups } from "@/lib/commands";
 import { openGraphImage, twitterImage } from "@/lib/metadata";
-import { languageAlternates } from "@/lib/site";
+import { languageAlternates, siteConfig } from "@/lib/site";
 
 export function generateStaticParams() {
   return getCommandDocs("zh-CN").map(({ slug }) => ({ slug }));
@@ -22,6 +22,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     },
     openGraph: {
       type: "article",
+      siteName: siteConfig.name,
       title: `pinset ${command.title}`,
       description: command.description,
       url: `/docs/commands/${slug}`,

--- a/website/app/(zh)/docs/commands/page.tsx
+++ b/website/app/(zh)/docs/commands/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { CommandIndexPage } from "@/components/command-index-page";
 import { getCommandGroups } from "@/lib/commands";
 import { openGraphImage, twitterImage } from "@/lib/metadata";
-import { languageAlternates } from "@/lib/site";
+import { languageAlternates, siteConfig } from "@/lib/site";
 
 export const metadata: Metadata = {
   title: "命令参考",
@@ -13,6 +13,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     type: "website",
+    siteName: siteConfig.name,
     url: "/docs/commands",
     title: "Pinset 2.1 命令参考",
     description: "Pinset 2.1 完整 CLI 命令参考：语法、参数、状态修改、JSON、退出码与错误。",

--- a/website/components/home-page.tsx
+++ b/website/components/home-page.tsx
@@ -36,7 +36,7 @@ export function HomePage({ locale, groups }: { locale: Locale; groups: CommandGr
     "@type": "SoftwareApplication",
     "@id": softwareId,
     name: siteConfig.name,
-    alternateName: "Pinset Runtime Manager",
+    alternateName: siteConfig.alternateName,
     url: siteUrl,
     applicationCategory: "DeveloperApplication",
     operatingSystem: "Windows, Linux, macOS",
@@ -47,20 +47,21 @@ export function HomePage({ locale, groups }: { locale: Locale; groups: CommandGr
     author: { "@id": organizationId },
     publisher: { "@id": organizationId },
   };
+  const website = {
+    "@type": "WebSite",
+    "@id": websiteId,
+    name: siteConfig.name,
+    alternateName: siteConfig.alternateName,
+    url: `${siteUrl}/`,
+    inLanguage: ["zh-CN", "en"],
+    publisher: { "@id": organizationId },
+  };
   const jsonLd = {
     "@context": "https://schema.org",
     "@graph": zh
       ? [
+          website,
           organization,
-          {
-            "@type": "WebSite",
-            "@id": websiteId,
-            name: siteConfig.name,
-            alternateName: ["Pinset Runtime Manager", "pinset.future-element.com"],
-            url: siteUrl,
-            inLanguage: ["zh-CN", "en"],
-            publisher: { "@id": organizationId },
-          },
           software,
         ]
       : [

--- a/website/lib/site.ts
+++ b/website/lib/site.ts
@@ -4,6 +4,7 @@ export const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || "https://pinset.futu
 
 export const siteConfig = {
   name: "Pinset",
+  alternateName: "Pinset Runtime Manager",
   version: packageJson.version,
   repository: "https://github.com/Future-Element/pinset",
   organization: {
@@ -15,7 +16,7 @@ export const siteConfig = {
   titleEn: "Pinset — Polyglot Runtime Version Manager",
   descriptionZh: "Pinset 是面向多语言项目的运行时版本管理器，用一份配置与锁文件管理 Node.js、Python、Rust、Go、Java、.NET、Flutter 等工具链。",
   descriptionEn: "Pinset is a runtime version manager for polyglot projects, using one configuration and lockfile for Node.js, Python, Rust, Go, Java, .NET, Flutter, and more.",
-  contentUpdatedAt: "2026-08-25T00:00:00.000Z",
+  contentUpdatedAt: "2026-08-27T00:00:00.000Z",
 };
 
 export type Locale = "zh-CN" | "en";

--- a/website/package.json
+++ b/website/package.json
@@ -1,11 +1,12 @@
 {
   "name": "pinset-website",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "private": true,
   "packageManager": "pnpm@10.15.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "validate:seo": "node scripts/validate-seo.mjs",
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "deploy:cloudflare": "next build && wrangler pages deploy out --project-name pinset"

--- a/website/scripts/validate-seo.mjs
+++ b/website/scripts/validate-seo.mjs
@@ -1,0 +1,51 @@
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+
+const origin = "https://pinset.future-element.com";
+const root = await readFile(path.join("out", "index.html"), "utf8");
+const english = await readFile(path.join("out", "en.html"), "utf8");
+
+function jsonLdNodes(html) {
+  return [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+    .flatMap((match) => {
+      const value = JSON.parse(match[1]);
+      return Array.isArray(value["@graph"]) ? value["@graph"] : [value];
+    });
+}
+
+function requireText(html, value, label) {
+  if (!html.includes(value)) {
+    throw new Error(`${label} is missing ${value}`);
+  }
+}
+
+const websites = jsonLdNodes(root).filter((node) => node["@type"] === "WebSite");
+if (websites.length !== 1) {
+  throw new Error(`root page must contain exactly one WebSite node; found ${websites.length}`);
+}
+const website = websites[0];
+if (website.name !== "Pinset" || website.alternateName !== "Pinset Runtime Manager") {
+  throw new Error("WebSite names do not match the Pinset brand identity");
+}
+if (website.url !== `${origin}/`) {
+  throw new Error(`WebSite URL must be the canonical subdomain root; received ${website.url}`);
+}
+if (JSON.stringify(website.alternateName).includes("future-element.com")) {
+  throw new Error("a hostname must not be used as a brand alternateName");
+}
+if (jsonLdNodes(english).some((node) => node["@type"] === "WebSite")) {
+  throw new Error("the language subpage must reference, not redefine, the root WebSite identity");
+}
+
+const htmlFiles = (await readdir("out", { recursive: true }))
+  .filter((entry) => entry.endsWith(".html"))
+  .filter((entry) => !entry.includes("404") && !entry.includes("_not-found"));
+for (const entry of htmlFiles) {
+  const html = await readFile(path.join("out", entry), "utf8");
+  const label = entry.replaceAll("\\", "/");
+  requireText(html, '<meta name="application-name" content="Pinset"', label);
+  requireText(html, '<meta property="og:site_name" content="Pinset"', label);
+  requireText(html, `<link rel="canonical" href="${origin}`, label);
+}
+
+console.log(`website site-name and canonical SEO signals are consistent across ${htmlFiles.length} pages`);


### PR DESCRIPTION
## Summary
- release Pinset 2.1.3 across the workspace, installers, Action, examples, docs, and website
- keep the canonical WebSite identity as Pinset on the documentation subdomain and preserve og:site_name on every exported route
- validate site-name, Open Graph, and canonical metadata in CI and release preflight

## Verification
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features
- scripts/tests/integrations_test.py
- pnpm typecheck
- pnpm build
- pnpm validate:seo