### PR TITLE
fix: release Pinset v2.1.4 lock compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.1.4 - 2026-08-31
+
+- Repair pre-1.0 pnpm and Bun locks that predate Linux ARM64 target coverage when a project or global selection is next changed.
+- Preserve existing selectors and exact resolved versions while rebuilding only the missing npm Provider target records from verified official metadata.
+- Keep ordinary lock reads strict, reject corrupted existing artifacts during repair, and preserve the previous lock bytes exactly if a paired configuration write must roll back.
+
+No configuration or lock schema migration is required. The compatibility repair is limited to the historical missing `linux-aarch64` pnpm/Bun artifact and runs only during an explicit `pinset use` or `pinset global` state change.
+
 ## 2.1.3 - 2026-08-27
 
 - Strengthen the documentation site's Google site-name signals by keeping the Pinset brand identity and canonical subdomain consistent across exported pages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Repair pre-1.0 pnpm and Bun locks that predate Linux ARM64 target coverage when a project or global selection is next changed.
 - Preserve existing selectors and exact resolved versions while rebuilding only the missing npm Provider target records from verified official metadata.
 - Keep ordinary lock reads strict, reject corrupted existing artifacts during repair, and preserve the previous lock bytes exactly if a paired configuration write must roll back.
+- Refresh the yanked `chacha20` transitive dependency to its maintained compatible release.
 
 No configuration or lock schema migration is required. The compatibility repair is limited to the historical missing `linux-aarch64` pnpm/Bun artifact and runs only during an explicit `pinset use` or `pinset global` state change.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2734,7 +2734,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "clap",
  "flate2",
@@ -2760,7 +2760,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "atomic-write-file",
  "base64",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-env"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "age",
  "atomic-write-file",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -3067,7 +3067,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.97"
-version = "2.1.3"
+version = "2.1.4"
 authors = ["Future Element"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ export PATH="$HOME/.local/bin:$PATH"
 Install an exact version or choose another directory:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.3
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.4
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -103,7 +103,7 @@ Remove-Item .\install.ps1
 Install an exact version:
 
 ```powershell
-.\install.ps1 -Version 2.1.3
+.\install.ps1 -Version 2.1.4
 ```
 
 Windows and WSL are separate environments and require separate installations. The installer registers Pinset and every built-in command route, but it does not pre-download language runtimes.
@@ -281,9 +281,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.3
+      - uses: Future-Element/pinset@v2.1.4
         with:
-          version: 2.1.3
+          version: 2.1.4
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -88,7 +88,7 @@ export PATH="$HOME/.local/bin:$PATH"
 安装指定版本或目录：
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.3
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.4
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -103,7 +103,7 @@ Remove-Item .\install.ps1
 指定版本：
 
 ```powershell
-.\install.ps1 -Version 2.1.3
+.\install.ps1 -Version 2.1.4
 ```
 
 Windows 与 WSL 是两个独立环境，需要分别安装。安装器只安装 Pinset 和所有内置命令路由，不会预先下载语言运行时。
@@ -281,9 +281,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.3
+      - uses: Future-Element/pinset@v2.1.4
         with:
-          version: 2.1.3
+          version: 2.1.4
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   version:
     description: Exact Pinset release version without the leading v.
     required: false
-    default: 2.1.3
+    default: 2.1.4
   install:
     description: Run pinset install --locked after Pinset is available.
     required: false

--- a/crates/pinset-core/src/config.rs
+++ b/crates/pinset-core/src/config.rs
@@ -16,8 +16,8 @@ use crate::{Error, MinimumReleaseAge, Result, VerificationStrength};
 use crate::Lockfile;
 #[cfg(all(feature = "project-write", feature = "lockfile"))]
 use crate::{
-    acquire_project_state_write_lock, load_optional_lockfile, lockfile_path,
-    register_project_config, save_lockfile, validate_lock_matches_tools,
+    acquire_project_state_write_lock, lockfile_path, register_project_config, save_lockfile,
+    validate_lock_matches_tools,
 };
 
 pub const PROJECT_CONFIG_FILENAME: &str = "pinset.toml";
@@ -407,10 +407,19 @@ pub fn save_project_state_locked(
     // Commit the lock first. If the second atomic write is interrupted, the previous
     // selection remains active and lock-dependent operations fail until this is retried.
     let lock_path = lockfile_path(path);
-    let previous_lock = load_optional_lockfile(&lock_path)?;
+    let previous_lock = match fs::read(&lock_path) {
+        Ok(content) => Some(content),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => None,
+        Err(source) => {
+            return Err(Error::ReadLockfile {
+                path: lock_path,
+                source,
+            });
+        }
+    };
     save_lockfile(&lock_path, lockfile)?;
     if let Err(commit_error) = save_project_config(path, config) {
-        if let Err(rollback_error) = restore_previous_lock(&lock_path, previous_lock.as_ref()) {
+        if let Err(rollback_error) = restore_previous_lock(&lock_path, previous_lock.as_deref()) {
             return Err(Error::StateCommitRollbackFailed {
                 scope: "project",
                 path: path.to_path_buf(),
@@ -424,9 +433,22 @@ pub fn save_project_state_locked(
 }
 
 #[cfg(all(feature = "project-write", feature = "lockfile"))]
-fn restore_previous_lock(path: &Path, previous: Option<&Lockfile>) -> Result<()> {
+fn restore_previous_lock(path: &Path, previous: Option<&[u8]>) -> Result<()> {
     if let Some(previous) = previous {
-        return save_lockfile(path, previous);
+        let mut file =
+            AtomicWriteFile::options()
+                .open(path)
+                .map_err(|source| Error::WriteLockfile {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+        return file
+            .write_all(previous)
+            .and_then(|()| file.commit())
+            .map_err(|source| Error::WriteLockfile {
+                path: path.to_path_buf(),
+                source,
+            });
     }
     match fs::remove_file(path) {
         Ok(()) => Ok(()),

--- a/crates/pinset-core/src/global_state.rs
+++ b/crates/pinset-core/src/global_state.rs
@@ -15,8 +15,7 @@ use serde::{Deserialize, Serialize};
 use crate::{Error, Result};
 #[cfg(all(feature = "state-write", feature = "lockfile"))]
 use crate::{
-    Lockfile, acquire_global_state_write_lock, load_optional_lockfile, save_lockfile,
-    validate_lock_matches_tools,
+    Lockfile, acquire_global_state_write_lock, save_lockfile, validate_lock_matches_tools,
 };
 
 pub const GLOBAL_STATE_SCHEMA: u32 = 3;
@@ -164,10 +163,19 @@ pub fn save_global_state_locked(
     // Commit the lock first. If the second atomic write is interrupted, the previous
     // selection remains active and lock-dependent operations fail until this is retried.
     let lock_path = global_lockfile_path(pinset_home);
-    let previous_lock = load_optional_lockfile(&lock_path)?;
+    let previous_lock = match fs::read(&lock_path) {
+        Ok(content) => Some(content),
+        Err(source) if source.kind() == ErrorKind::NotFound => None,
+        Err(source) => {
+            return Err(Error::ReadLockfile {
+                path: lock_path,
+                source,
+            });
+        }
+    };
     save_lockfile(&lock_path, lockfile)?;
     if let Err(commit_error) = save_global_config(&config_path, config) {
-        if let Err(rollback_error) = restore_previous_lock(&lock_path, previous_lock.as_ref()) {
+        if let Err(rollback_error) = restore_previous_lock(&lock_path, previous_lock.as_deref()) {
             return Err(Error::StateCommitRollbackFailed {
                 scope: "global",
                 path: config_path,
@@ -181,9 +189,22 @@ pub fn save_global_state_locked(
 }
 
 #[cfg(all(feature = "state-write", feature = "lockfile"))]
-fn restore_previous_lock(path: &Path, previous: Option<&Lockfile>) -> Result<()> {
+fn restore_previous_lock(path: &Path, previous: Option<&[u8]>) -> Result<()> {
     if let Some(previous) = previous {
-        return save_lockfile(path, previous);
+        let mut file =
+            AtomicWriteFile::options()
+                .open(path)
+                .map_err(|source| Error::WriteLockfile {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+        return file
+            .write_all(previous)
+            .and_then(|()| file.commit())
+            .map_err(|source| Error::WriteLockfile {
+                path: path.to_path_buf(),
+                source,
+            });
     }
     match fs::remove_file(path) {
         Ok(()) => Ok(()),

--- a/crates/pinset-core/src/lib.rs
+++ b/crates/pinset-core/src/lib.rs
@@ -181,8 +181,9 @@ pub use lock_audit::{
 pub use lockfile::{
     LOCKFILE_FILENAME, LOCKFILE_SCHEMA, LockedArtifact, LockedArtifactFormat,
     LockedArtifactOverlay, LockedTool, Lockfile, MVP_NODE_TARGETS, load_lockfile,
-    load_optional_lockfile, lockfile_path, save_lockfile, validate_lock_matches_project,
-    validate_lock_matches_selection, validate_lock_matches_tool, validate_lock_matches_tools,
+    load_lockfile_for_target_refresh, load_optional_lockfile, lockfile_path, save_lockfile,
+    validate_lock_matches_project, validate_lock_matches_selection, validate_lock_matches_tool,
+    validate_lock_matches_tools,
 };
 #[cfg(feature = "node-provider")]
 pub use node_lifecycle::{

--- a/crates/pinset-core/src/lockfile.rs
+++ b/crates/pinset-core/src/lockfile.rs
@@ -190,6 +190,35 @@ pub fn lockfile_path(project_config_path: &Path) -> PathBuf {
 }
 
 pub fn load_lockfile(path: &Path) -> Result<Lockfile> {
+    let lockfile = parse_lockfile(path)?;
+    validate_lockfile(&lockfile)?;
+    Ok(lockfile)
+}
+
+/// Loads a lockfile for a state-changing command that can refresh the historical
+/// pnpm/Bun target matrix before saving it again.
+///
+/// The relaxed result must never be used for installation or command resolution.
+/// Every artifact that is present is still validated strictly; the only tolerated
+/// gap is the Linux ARM64 artifact added to the pnpm/Bun matrix in Pinset 1.0.
+pub fn load_lockfile_for_target_refresh(path: &Path) -> Result<(Lockfile, bool)> {
+    let lockfile = parse_lockfile(path)?;
+    match validate_lockfile(&lockfile) {
+        Ok(()) => Ok((lockfile, false)),
+        Err(strict_error) => {
+            validate_lockfile_with_npm_target_policy(
+                &lockfile,
+                NpmTargetPolicy::AllowLegacyLinuxArm64Gap,
+            )?;
+            if !lockfile.tools.iter().any(has_legacy_npm_target_gap) {
+                return Err(strict_error);
+            }
+            Ok((lockfile, true))
+        }
+    }
+}
+
+fn parse_lockfile(path: &Path) -> Result<Lockfile> {
     let content = fs::read_to_string(path).map_err(|source| Error::ReadLockfile {
         path: path.to_path_buf(),
         source,
@@ -198,7 +227,6 @@ pub fn load_lockfile(path: &Path) -> Result<Lockfile> {
         path: path.to_path_buf(),
         source,
     })?;
-    validate_lockfile(&lockfile)?;
     Ok(lockfile)
 }
 
@@ -297,7 +325,20 @@ pub fn validate_lock_matches_tools(
     Ok(())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NpmTargetPolicy {
+    Current,
+    AllowLegacyLinuxArm64Gap,
+}
+
 fn validate_lockfile(lockfile: &Lockfile) -> Result<()> {
+    validate_lockfile_with_npm_target_policy(lockfile, NpmTargetPolicy::Current)
+}
+
+fn validate_lockfile_with_npm_target_policy(
+    lockfile: &Lockfile,
+    npm_target_policy: NpmTargetPolicy,
+) -> Result<()> {
     if !matches!(lockfile.schema, 1 | 2 | LOCKFILE_SCHEMA) {
         return Err(Error::UnsupportedLockfileSchema {
             actual: lockfile.schema,
@@ -315,7 +356,7 @@ fn validate_lockfile(lockfile: &Lockfile) -> Result<()> {
                 reason: format!("duplicate tool {}", tool.name),
             });
         }
-        validate_locked_tool(tool)?;
+        validate_locked_tool_with_npm_target_policy(tool, npm_target_policy)?;
         if lockfile.schema < LOCKFILE_SCHEMA && tool.requested != tool.version {
             return Err(Error::InvalidLockfile {
                 reason: format!(
@@ -333,7 +374,15 @@ fn validate_lockfile(lockfile: &Lockfile) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
 fn validate_locked_tool(tool: &LockedTool) -> Result<()> {
+    validate_locked_tool_with_npm_target_policy(tool, NpmTargetPolicy::Current)
+}
+
+fn validate_locked_tool_with_npm_target_policy(
+    tool: &LockedTool,
+    npm_target_policy: NpmTargetPolicy,
+) -> Result<()> {
     if tool
         .released_at
         .as_deref()
@@ -493,13 +542,21 @@ fn validate_locked_tool(tool: &LockedTool) -> Result<()> {
         }
     } else {
         for (target, _) in npm_tool_targets(&tool.name) {
+            if npm_target_policy == NpmTargetPolicy::AllowLegacyLinuxArm64Gap
+                && *target == "linux-aarch64"
+            {
+                continue;
+            }
             if !targets.contains(target) {
                 return Err(Error::InvalidLockfile {
                     reason: format!("missing {} artifact for {target}", tool.name),
                 });
             }
         }
-        if targets.len() != npm_tool_targets(&tool.name).len() {
+        if targets.len() != npm_tool_targets(&tool.name).len()
+            && !(npm_target_policy == NpmTargetPolicy::AllowLegacyLinuxArm64Gap
+                && has_legacy_npm_target_gap(tool))
+        {
             return Err(Error::InvalidLockfile {
                 reason: format!("{} lock contains an unsupported artifact target", tool.name),
             });
@@ -511,6 +568,12 @@ fn validate_locked_tool(tool: &LockedTool) -> Result<()> {
         });
     }
     Ok(())
+}
+
+fn has_legacy_npm_target_gap(tool: &LockedTool) -> bool {
+    matches!(tool.name.as_str(), "pnpm" | "bun")
+        && tool.artifact("linux-aarch64").is_none()
+        && tool.artifacts.len() + 1 == npm_tool_targets(&tool.name).len()
 }
 
 fn validate_node_metadata(tool: &LockedTool) -> Result<()> {
@@ -1203,6 +1266,41 @@ mod tests {
     }
 
     #[test]
+    fn target_refresh_loader_only_accepts_the_historical_npm_linux_arm64_gap() {
+        let root = tempdir().expect("temp directory");
+        let path = root.path().join(LOCKFILE_FILENAME);
+        let legacy = Lockfile {
+            schema: 2,
+            generated_by: "pinset 0.9.0".to_owned(),
+            tools: vec![
+                locked_npm_tool("bun", "1.3.14", false),
+                locked_npm_tool("pnpm", "11.21.0", false),
+            ],
+        };
+        fs::write(&path, toml::to_string_pretty(&legacy).expect("legacy TOML"))
+            .expect("legacy lockfile");
+
+        let strict = load_lockfile(&path).expect_err("strict loader rejects the old matrix");
+        assert!(strict.to_string().contains("linux-aarch64"));
+        let (loaded, requires_refresh) =
+            load_lockfile_for_target_refresh(&path).expect("refresh loader accepts old matrix");
+        assert!(requires_refresh);
+        assert_eq!(loaded.tools, legacy.tools);
+
+        let mut corrupted = legacy;
+        corrupted.tools[0].artifacts[0].canonical_url =
+            "https://example.invalid/bun.tgz".to_owned();
+        fs::write(
+            &path,
+            toml::to_string_pretty(&corrupted).expect("corrupt TOML"),
+        )
+        .expect("corrupt lockfile");
+        let error = load_lockfile_for_target_refresh(&path)
+            .expect_err("refresh loader still validates every present artifact");
+        assert!(error.to_string().contains("invalid npm artifact identity"));
+    }
+
+    #[test]
     fn schema_three_separates_requested_selector_from_resolved_version() {
         let artifacts = MVP_NODE_TARGETS
             .into_iter()
@@ -1746,9 +1844,39 @@ mod tests {
     }
 
     fn locked_pnpm_artifact(version: &str, with_overlay: bool) -> LockedArtifact {
-        let artifact_path = format!("@pnpm/linux-x64/-/linux-x64-{version}.tgz");
+        locked_npm_artifact("pnpm", version, "linux-x86_64", with_overlay)
+    }
+
+    fn locked_npm_tool(tool: &str, version: &str, include_linux_arm64: bool) -> LockedTool {
+        LockedTool {
+            name: tool.to_owned(),
+            requested: version.to_owned(),
+            version: version.to_owned(),
+            provider: format!("{tool}-npm"),
+            released_at: None,
+            metadata: BTreeMap::new(),
+            artifacts: npm_tool_targets(tool)
+                .iter()
+                .filter(|(target, _)| include_linux_arm64 || *target != "linux-aarch64")
+                .map(|(target, _)| locked_npm_artifact(tool, version, target, tool == "pnpm"))
+                .collect(),
+        }
+    }
+
+    fn locked_npm_artifact(
+        tool: &str,
+        version: &str,
+        target: &str,
+        with_overlay: bool,
+    ) -> LockedArtifact {
+        let package = npm_tool_targets(tool)
+            .iter()
+            .find_map(|(candidate, package)| (*candidate == target).then_some(*package))
+            .expect("known npm target");
+        let package_base = package.rsplit('/').next().expect("npm package");
+        let artifact_path = format!("{package}/-/{package_base}-{version}.tgz");
         LockedArtifact {
-            target: "linux-x86_64".to_owned(),
+            target: target.to_owned(),
             canonical_url: format!("https://registry.npmjs.org/{artifact_path}"),
             artifact_path,
             sha256: String::new(),
@@ -1756,7 +1884,7 @@ mod tests {
             format: LockedArtifactFormat::TarGz,
             archive_root: "package".to_owned(),
             verification: "npm-registry-signature-sha512".to_owned(),
-            overlays: with_overlay
+            overlays: (tool == "pnpm" && with_overlay)
                 .then(|| {
                     let artifact_path = format!("@pnpm/exe/-/exe-{version}.tgz");
                     LockedArtifactOverlay {

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -31,22 +31,22 @@ use pinset_core::{
     install_locked_go, install_locked_java, install_locked_node, install_locked_npm_tool,
     install_locked_python, install_locked_rust, install_payload_statistics,
     is_managed_command_shim, list_all_installed_tool_versions, list_download_cache,
-    list_installed_tool_versions, load_global_config, load_lockfile, load_optional_global_config,
-    load_optional_lockfile, load_project_config, load_project_python_environment,
-    load_source_config, load_user_settings, lockfile_path, managed_runtime_arguments,
-    path_with_selected_tools, pinset_home, plan_prune_tool_versions, plan_uninstall_tool_version,
-    project_python_environment_path, provider_dependency_order, register_project_config,
-    repair_download_cache, resolve_command, resolve_project_python_command, resolve_tool_selection,
-    runtime_command_candidates, runtime_command_directory, runtime_environment_for_install,
-    runtime_provider, save_global_config, save_global_state_locked, save_project_config,
-    save_project_state_locked, save_source_config, save_user_settings, scan_project_sources,
-    selected_runtime_environment, source_config_path, uninstall_node_version,
-    uninstall_tool_version, user_settings_path, validate_exact_dotnet_version,
-    validate_exact_flutter_version, validate_exact_go_version, validate_exact_java_version,
-    validate_exact_node_version, validate_exact_npm_tool_version, validate_exact_python_version,
-    validate_exact_rust_version, validate_lock_matches_selection, validate_lock_matches_tool,
-    validate_lock_matches_tools, validate_managed_runtime_invocation, validate_project_lock_policy,
-    validate_windows_batch_arguments, verify_download_cache,
+    list_installed_tool_versions, load_global_config, load_lockfile,
+    load_lockfile_for_target_refresh, load_optional_global_config, load_optional_lockfile,
+    load_project_config, load_project_python_environment, load_source_config, load_user_settings,
+    lockfile_path, managed_runtime_arguments, path_with_selected_tools, pinset_home,
+    plan_prune_tool_versions, plan_uninstall_tool_version, project_python_environment_path,
+    provider_dependency_order, register_project_config, repair_download_cache, resolve_command,
+    resolve_project_python_command, resolve_tool_selection, runtime_command_candidates,
+    runtime_command_directory, runtime_environment_for_install, runtime_provider,
+    save_global_config, save_global_state_locked, save_project_config, save_project_state_locked,
+    save_source_config, save_user_settings, scan_project_sources, selected_runtime_environment,
+    source_config_path, uninstall_node_version, uninstall_tool_version, user_settings_path,
+    validate_exact_dotnet_version, validate_exact_flutter_version, validate_exact_go_version,
+    validate_exact_java_version, validate_exact_node_version, validate_exact_npm_tool_version,
+    validate_exact_python_version, validate_exact_rust_version, validate_lock_matches_selection,
+    validate_lock_matches_tool, validate_lock_matches_tools, validate_managed_runtime_invocation,
+    validate_project_lock_policy, validate_windows_batch_arguments, verify_download_cache,
 };
 use serde::Serialize;
 use terminal_size::{Width, terminal_size_of};
@@ -3044,12 +3044,31 @@ fn save_resolved_selection_batch(
     global: bool,
     resolved: &[ResolvedSelection],
 ) -> Result<(&'static str, PathBuf), Box<dyn std::error::Error>> {
+    save_resolved_selection_batch_with(home, cwd, global, resolved, resolve_locked_tool)
+}
+
+fn save_resolved_selection_batch_with<F>(
+    home: &Path,
+    cwd: &Path,
+    global: bool,
+    resolved: &[ResolvedSelection],
+    mut resolver: F,
+) -> Result<(&'static str, PathBuf), Box<dyn std::error::Error>>
+where
+    F: FnMut(&str, &str) -> Result<LockedTool, Box<dyn std::error::Error>>,
+{
     if global {
         let _guard = acquire_global_state_write_lock(home)?;
         let config_path = global_config_path(home);
         let mut config = load_optional_global_config(&config_path)?.unwrap_or_default();
         let lock_path = global_lockfile_path(home);
-        let mut lockfile = load_optional_lockfile(&lock_path)?.unwrap_or_else(new_lockfile);
+        let (mut lockfile, requires_target_refresh) =
+            load_optional_lockfile_for_target_refresh(&lock_path)?
+                .unwrap_or_else(|| (new_lockfile(), false));
+        if requires_target_refresh {
+            validate_lock_matches_tools(&lockfile, &config.tools, &config_path)?;
+            refresh_legacy_npm_target_records(&mut lockfile, resolved, &mut resolver)?;
+        }
         lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
         apply_resolved_selections(&mut config.tools, &mut lockfile, resolved)?;
         save_global_state_locked(home, &config, &lockfile)?;
@@ -3059,12 +3078,61 @@ fn save_resolved_selection_batch(
         let _guard = acquire_project_state_write_lock(home, &config_path)?;
         let mut project = load_project_config(&config_path)?;
         let lock_path = lockfile_path(&config_path);
-        let mut lockfile = load_optional_lockfile(&lock_path)?.unwrap_or_else(new_lockfile);
+        let (mut lockfile, requires_target_refresh) =
+            load_optional_lockfile_for_target_refresh(&lock_path)?
+                .unwrap_or_else(|| (new_lockfile(), false));
+        if requires_target_refresh {
+            validate_lock_matches_tools(&lockfile, &project.tools, &config_path)?;
+            refresh_legacy_npm_target_records(&mut lockfile, resolved, &mut resolver)?;
+        }
         lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
         apply_resolved_selections(&mut project.tools, &mut lockfile, resolved)?;
         save_project_state_locked(home, &config_path, &project, &lockfile)?;
         Ok(("project", lock_path))
     }
+}
+
+fn load_optional_lockfile_for_target_refresh(
+    path: &Path,
+) -> Result<Option<(Lockfile, bool)>, Box<dyn std::error::Error>> {
+    match load_lockfile_for_target_refresh(path) {
+        Ok(lockfile) => Ok(Some(lockfile)),
+        Err(Error::ReadLockfile { source, .. }) if source.kind() == io::ErrorKind::NotFound => {
+            Ok(None)
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn refresh_legacy_npm_target_records<F>(
+    lockfile: &mut Lockfile,
+    resolved: &[ResolvedSelection],
+    resolver: &mut F,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    F: FnMut(&str, &str) -> Result<LockedTool, Box<dyn std::error::Error>>,
+{
+    let explicitly_resolved = resolved
+        .iter()
+        .map(|(tool, _, _)| tool.as_str())
+        .collect::<BTreeSet<_>>();
+    for tool in ["pnpm", "bun"] {
+        if explicitly_resolved.contains(tool) {
+            continue;
+        }
+        let Some((requested, version)) = lockfile.tool(tool).and_then(|locked| {
+            locked
+                .artifact("linux-aarch64")
+                .is_none()
+                .then(|| (locked.requested.clone(), locked.version.clone()))
+        }) else {
+            continue;
+        };
+        let mut refreshed = resolver(tool, &version)?;
+        refreshed.requested = requested;
+        lockfile.upsert_tool(refreshed)?;
+    }
+    Ok(())
 }
 
 fn parse_tool_selection_batch(
@@ -6800,6 +6868,82 @@ mod tests {
     }
 
     #[test]
+    fn repairs_pre_v1_npm_target_matrix_before_adding_a_global_selection() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        fs::create_dir_all(&project).expect("project directory");
+
+        let mut config = GlobalConfig::default();
+        config.set_tool("bun", "1.3.14");
+        config.set_tool("node", "24.0.0");
+        config.set_tool("pnpm", "11.21.0");
+        save_global_config(&global_config_path(&home), &config).expect("legacy global config");
+
+        let mut bun = persistable_selection_lock("bun", "1.3.14", "1.3.14");
+        bun.artifacts
+            .retain(|artifact| artifact.target != "linux-aarch64");
+        let mut pnpm = persistable_selection_lock("pnpm", "11.21.0", "11.21.0");
+        pnpm.artifacts
+            .retain(|artifact| artifact.target != "linux-aarch64");
+        let legacy_lock = Lockfile {
+            schema: 2,
+            generated_by: "pinset 0.9.0".to_owned(),
+            tools: vec![
+                bun,
+                persistable_selection_lock("node", "24.0.0", "24.0.0"),
+                pnpm,
+            ],
+        };
+        fs::write(
+            global_lockfile_path(&home),
+            toml::to_string_pretty(&legacy_lock).expect("legacy lock TOML"),
+        )
+        .expect("legacy global lock");
+
+        let resolved = vec![(
+            "go".to_owned(),
+            "latest".to_owned(),
+            persistable_selection_lock("go", "latest", "1.25.1"),
+        )];
+        let mut refreshed = Vec::new();
+        save_resolved_selection_batch_with(&home, &project, true, &resolved, |tool, version| {
+            refreshed.push((tool.to_owned(), version.to_owned()));
+            Ok(persistable_selection_lock(tool, version, version))
+        })
+        .expect("repair legacy npm targets and save Go selection");
+
+        assert_eq!(
+            refreshed,
+            [
+                ("pnpm".to_owned(), "11.21.0".to_owned()),
+                ("bun".to_owned(), "1.3.14".to_owned()),
+            ]
+        );
+        let saved_config =
+            load_global_config(&global_config_path(&home)).expect("saved global config");
+        assert_eq!(saved_config.tools["bun"], "1.3.14");
+        assert_eq!(saved_config.tools["node"], "24.0.0");
+        assert_eq!(saved_config.tools["pnpm"], "11.21.0");
+        assert_eq!(saved_config.tools["go"], "latest");
+        let saved_lock =
+            load_lockfile(&global_lockfile_path(&home)).expect("strictly valid refreshed lock");
+        assert!(
+            saved_lock
+                .tool("bun")
+                .and_then(|tool| tool.artifact("linux-aarch64"))
+                .is_some()
+        );
+        assert!(
+            saved_lock
+                .tool("pnpm")
+                .and_then(|tool| tool.artifact("linux-aarch64"))
+                .is_some()
+        );
+        assert_eq!(saved_lock.tool("go").unwrap().requested, "latest");
+    }
+
+    #[test]
     fn concurrent_project_batches_preserve_both_updates() {
         let root = tempfile::tempdir().expect("temporary root");
         let home = std::sync::Arc::new(root.path().join("home"));
@@ -6895,6 +7039,58 @@ mod tests {
                 let mut locked = lockfile.tools.remove(0);
                 locked.requested = requested.to_owned();
                 locked
+            }
+            "pnpm" | "bun" => {
+                let targets = if tool == "pnpm" {
+                    pinset_core::PNPM_TARGETS
+                } else {
+                    pinset_core::BUN_TARGETS
+                };
+                let artifacts = targets
+                    .iter()
+                    .map(|target| {
+                        let package_base =
+                            target.package.rsplit('/').next().expect("npm package name");
+                        let artifact_path =
+                            format!("{}/-/{package_base}-{version}.tgz", target.package);
+                        let overlays = (tool == "pnpm")
+                            .then(|| {
+                                let artifact_path = format!("@pnpm/exe/-/exe-{version}.tgz");
+                                pinset_core::LockedArtifactOverlay {
+                                    canonical_url: format!(
+                                        "https://registry.npmjs.org/{artifact_path}"
+                                    ),
+                                    artifact_path,
+                                    integrity: format!("sha512:{}", "ef".repeat(64)),
+                                    format: pinset_core::LockedArtifactFormat::TarGz,
+                                    archive_root: "package".to_owned(),
+                                    verification: "npm-registry-signature-sha512".to_owned(),
+                                }
+                            })
+                            .into_iter()
+                            .collect();
+                        pinset_core::LockedArtifact {
+                            target: target.target.to_owned(),
+                            canonical_url: format!("https://registry.npmjs.org/{artifact_path}"),
+                            artifact_path,
+                            sha256: String::new(),
+                            integrity: Some(format!("sha512:{}", "ab".repeat(64))),
+                            format: pinset_core::LockedArtifactFormat::TarGz,
+                            archive_root: "package".to_owned(),
+                            verification: "npm-registry-signature-sha512".to_owned(),
+                            overlays,
+                        }
+                    })
+                    .collect();
+                LockedTool {
+                    name: tool.to_owned(),
+                    requested: requested.to_owned(),
+                    version: version.to_owned(),
+                    provider: format!("{tool}-npm"),
+                    released_at: None,
+                    metadata: BTreeMap::new(),
+                    artifacts,
+                }
             }
             "go" => {
                 let artifacts = pinset_core::GO_TARGETS

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -890,9 +890,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.3
+      - uses: Future-Element/pinset@v2.1.4
         with:
-          version: 2.1.3
+          version: 2.1.4
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -890,9 +890,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.3
+      - uses: Future-Element/pinset@v2.1.4
         with:
-          version: 2.1.3
+          version: 2.1.4
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/examples/devcontainer/.devcontainer/Dockerfile
+++ b/examples/devcontainer/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
-ARG PINSET_VERSION=2.1.3
+ARG PINSET_VERSION=2.1.4
 
 RUN set -eux; \
     architecture="$(dpkg --print-architecture)"; \

--- a/examples/devcontainer/.devcontainer/devcontainer.json
+++ b/examples/devcontainer/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-        "PINSET_VERSION": "2.1.3"
+        "PINSET_VERSION": "2.1.4"
     }
   },
   "postCreateCommand": "pinset install --locked",

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string] $Version = '2.1.3',
+    [string] $Version = '2.1.4',
     [string] $InstallDir = (Join-Path $env:LOCALAPPDATA 'Pinset\bin')
 )
 

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="2.1.3"
+DEFAULT_VERSION="2.1.4"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -22,7 +22,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 2.1.3.
+  --version VERSION       Install an exact release, for example 2.1.4.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.

--- a/website/lib/site.ts
+++ b/website/lib/site.ts
@@ -16,7 +16,7 @@ export const siteConfig = {
   titleEn: "Pinset — Polyglot Runtime Version Manager",
   descriptionZh: "Pinset 是面向多语言项目的运行时版本管理器，用一份配置与锁文件管理 Node.js、Python、Rust、Go、Java、.NET、Flutter 等工具链。",
   descriptionEn: "Pinset is a runtime version manager for polyglot projects, using one configuration and lockfile for Node.js, Python, Rust, Go, Java, .NET, Flutter, and more.",
-  contentUpdatedAt: "2026-08-27T00:00:00.000Z",
+  contentUpdatedAt: "2026-08-31T00:00:00.000Z",
 };
 
 export type Locale = "zh-CN" | "en";

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pinset-website",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "private": true,
   "packageManager": "pnpm@10.15.0",
   "scripts": {


### PR DESCRIPTION
## Summary
- release Pinset 2.1.4 with compatibility repair for pre-1.0 pnpm and Bun locks that lack the Linux ARM64 artifact
- preserve configured selectors and exact resolved versions while re-resolving only missing npm Provider target records from verified official metadata
- keep ordinary lock reads fail-closed, reject corrupt existing artifacts during repair, and restore prior lock bytes exactly on state-pair rollback

## Local verification
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- focused legacy npm target refresh and global Go selection regressions
- git diff --check

## Validation boundary
- no real Provider downloads or macOS device execution were performed locally
- PR CI and main-branch Release preflight remain the authoritative all-feature, security, script, website, and cross-platform release gates