### PR TITLE
fix: release Pinset v2.1.5 lock migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.1.5 - 2026-08-31
+
+- Repair every exact pre-1.0 Provider target matrix expanded for Linux ARM64: Node.js, pnpm, Bun, Go, Python, Java, Rust, and .NET SDK.
+- Re-resolve each affected Provider at its existing exact version, preserve its requested selector, and upgrade legacy Node.js locks to the current OpenPGP-authenticated metadata contract.
+- Apply the shared compatibility migration to project/global selection, update, migrate, unset, and project-import state changes while keeping install, execution, and other ordinary lock reads strict.
+- Reject unknown or corrupted target gaps, validate all existing artifacts before migration, and leave configuration and lock bytes unchanged when any Provider refresh fails.
+
+No configuration or lock schema migration is required. Flutter is unchanged because its supported target matrix did not add Linux ARM64. Existing unselected installations and their receipts are preserved; only selected lock records are rebuilt during an explicit state-changing command or `pinset migrate`.
+
 ## 2.1.4 - 2026-08-31
 
 - Repair pre-1.0 pnpm and Bun locks that predate Linux ARM64 target coverage when a project or global selection is next changed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2734,7 +2734,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "clap",
  "flate2",
@@ -2760,7 +2760,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "atomic-write-file",
  "base64",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-env"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "age",
  "atomic-write-file",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.97"
-version = "2.1.4"
+version = "2.1.5"
 authors = ["Future Element"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ export PATH="$HOME/.local/bin:$PATH"
 Install an exact version or choose another directory:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.4
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.5
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -103,7 +103,7 @@ Remove-Item .\install.ps1
 Install an exact version:
 
 ```powershell
-.\install.ps1 -Version 2.1.4
+.\install.ps1 -Version 2.1.5
 ```
 
 Windows and WSL are separate environments and require separate installations. The installer registers Pinset and every built-in command route, but it does not pre-download language runtimes.
@@ -281,9 +281,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.4
+      - uses: Future-Element/pinset@v2.1.5
         with:
-          version: 2.1.4
+          version: 2.1.5
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -88,7 +88,7 @@ export PATH="$HOME/.local/bin:$PATH"
 安装指定版本或目录：
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.4
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.1.5
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -103,7 +103,7 @@ Remove-Item .\install.ps1
 指定版本：
 
 ```powershell
-.\install.ps1 -Version 2.1.4
+.\install.ps1 -Version 2.1.5
 ```
 
 Windows 与 WSL 是两个独立环境，需要分别安装。安装器只安装 Pinset 和所有内置命令路由，不会预先下载语言运行时。
@@ -281,9 +281,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.4
+      - uses: Future-Element/pinset@v2.1.5
         with:
-          version: 2.1.4
+          version: 2.1.5
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   version:
     description: Exact Pinset release version without the leading v.
     required: false
-    default: 2.1.4
+    default: 2.1.5
   install:
     description: Run pinset install --locked after Pinset is available.
     required: false

--- a/crates/pinset-core/src/lib.rs
+++ b/crates/pinset-core/src/lib.rs
@@ -181,9 +181,9 @@ pub use lock_audit::{
 pub use lockfile::{
     LOCKFILE_FILENAME, LOCKFILE_SCHEMA, LockedArtifact, LockedArtifactFormat,
     LockedArtifactOverlay, LockedTool, Lockfile, MVP_NODE_TARGETS, load_lockfile,
-    load_lockfile_for_target_refresh, load_optional_lockfile, lockfile_path, save_lockfile,
-    validate_lock_matches_project, validate_lock_matches_selection, validate_lock_matches_tool,
-    validate_lock_matches_tools,
+    load_lockfile_for_provider_refresh, load_lockfile_for_target_refresh, load_optional_lockfile,
+    lockfile_path, save_lockfile, validate_lock_matches_project, validate_lock_matches_selection,
+    validate_lock_matches_tool, validate_lock_matches_tools,
 };
 #[cfg(feature = "node-provider")]
 pub use node_lifecycle::{

--- a/crates/pinset-core/src/lockfile.rs
+++ b/crates/pinset-core/src/lockfile.rs
@@ -196,26 +196,41 @@ pub fn load_lockfile(path: &Path) -> Result<Lockfile> {
 }
 
 /// Loads a lockfile for a state-changing command that can refresh the historical
-/// pnpm/Bun target matrix before saving it again.
+/// pre-1.0 target matrices before saving it again.
 ///
 /// The relaxed result must never be used for installation or command resolution.
 /// Every artifact that is present is still validated strictly; the only tolerated
-/// gap is the Linux ARM64 artifact added to the pnpm/Bun matrix in Pinset 1.0.
-pub fn load_lockfile_for_target_refresh(path: &Path) -> Result<(Lockfile, bool)> {
+/// gaps are the exact provider matrices shipped before Linux ARM64 support was
+/// added in Pinset 1.0.
+pub fn load_lockfile_for_provider_refresh(path: &Path) -> Result<(Lockfile, Vec<String>)> {
     let lockfile = parse_lockfile(path)?;
     match validate_lockfile(&lockfile) {
-        Ok(()) => Ok((lockfile, false)),
+        Ok(()) => Ok((lockfile, Vec::new())),
         Err(strict_error) => {
-            validate_lockfile_with_npm_target_policy(
+            validate_lockfile_with_target_policy(
                 &lockfile,
-                NpmTargetPolicy::AllowLegacyLinuxArm64Gap,
+                TargetMatrixPolicy::AllowPreV1LinuxArm64Matrices,
             )?;
-            if !lockfile.tools.iter().any(has_legacy_npm_target_gap) {
+            let mut refresh_tools = lockfile
+                .tools
+                .iter()
+                .filter(|tool| has_pre_v1_target_matrix(tool))
+                .map(|tool| tool.name.clone())
+                .collect::<Vec<_>>();
+            refresh_tools.sort();
+            if refresh_tools.is_empty() {
                 return Err(strict_error);
             }
-            Ok((lockfile, true))
+            Ok((lockfile, refresh_tools))
         }
     }
+}
+
+/// Backwards-compatible target-refresh loader retained for callers that only
+/// need to know whether any historical provider matrix requires repair.
+pub fn load_lockfile_for_target_refresh(path: &Path) -> Result<(Lockfile, bool)> {
+    let (lockfile, refresh_tools) = load_lockfile_for_provider_refresh(path)?;
+    Ok((lockfile, !refresh_tools.is_empty()))
 }
 
 fn parse_lockfile(path: &Path) -> Result<Lockfile> {
@@ -326,18 +341,18 @@ pub fn validate_lock_matches_tools(
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NpmTargetPolicy {
+enum TargetMatrixPolicy {
     Current,
-    AllowLegacyLinuxArm64Gap,
+    AllowPreV1LinuxArm64Matrices,
 }
 
 fn validate_lockfile(lockfile: &Lockfile) -> Result<()> {
-    validate_lockfile_with_npm_target_policy(lockfile, NpmTargetPolicy::Current)
+    validate_lockfile_with_target_policy(lockfile, TargetMatrixPolicy::Current)
 }
 
-fn validate_lockfile_with_npm_target_policy(
+fn validate_lockfile_with_target_policy(
     lockfile: &Lockfile,
-    npm_target_policy: NpmTargetPolicy,
+    target_policy: TargetMatrixPolicy,
 ) -> Result<()> {
     if !matches!(lockfile.schema, 1 | 2 | LOCKFILE_SCHEMA) {
         return Err(Error::UnsupportedLockfileSchema {
@@ -356,7 +371,7 @@ fn validate_lockfile_with_npm_target_policy(
                 reason: format!("duplicate tool {}", tool.name),
             });
         }
-        validate_locked_tool_with_npm_target_policy(tool, npm_target_policy)?;
+        validate_locked_tool_with_target_policy(tool, target_policy)?;
         if lockfile.schema < LOCKFILE_SCHEMA && tool.requested != tool.version {
             return Err(Error::InvalidLockfile {
                 reason: format!(
@@ -376,13 +391,15 @@ fn validate_lockfile_with_npm_target_policy(
 
 #[cfg(test)]
 fn validate_locked_tool(tool: &LockedTool) -> Result<()> {
-    validate_locked_tool_with_npm_target_policy(tool, NpmTargetPolicy::Current)
+    validate_locked_tool_with_target_policy(tool, TargetMatrixPolicy::Current)
 }
 
-fn validate_locked_tool_with_npm_target_policy(
+fn validate_locked_tool_with_target_policy(
     tool: &LockedTool,
-    npm_target_policy: NpmTargetPolicy,
+    target_policy: TargetMatrixPolicy,
 ) -> Result<()> {
+    let pre_v1_target_matrix = target_policy == TargetMatrixPolicy::AllowPreV1LinuxArm64Matrices
+        && has_pre_v1_target_matrix(tool);
     if tool
         .released_at
         .as_deref()
@@ -437,7 +454,7 @@ fn validate_locked_tool_with_npm_target_policy(
             });
         }
         match tool.name.as_str() {
-            "node" => validate_locked_node_artifact(&tool.version, artifact)?,
+            "node" => validate_locked_node_artifact(&tool.version, artifact, pre_v1_target_matrix)?,
             "go" => validate_locked_go_artifact(&tool.version, artifact)?,
             "flutter" => validate_locked_flutter_artifact(&tool.version, artifact)?,
             "java" => validate_locked_java_artifact(tool, artifact)?,
@@ -449,8 +466,19 @@ fn validate_locked_tool_with_npm_target_policy(
         }
     }
     if tool.name == "node" {
-        validate_node_metadata(tool)?;
+        if pre_v1_target_matrix {
+            if !tool.metadata.is_empty() {
+                return Err(Error::InvalidLockfile {
+                    reason: "pre-1.0 Node lock cannot contain provider metadata".to_owned(),
+                });
+            }
+        } else {
+            validate_node_metadata(tool)?;
+        }
         for target in MVP_NODE_TARGETS {
+            if pre_v1_target_matrix && target == "linux-aarch64" {
+                continue;
+            }
             if !targets.contains(target) {
                 return Err(Error::InvalidLockfile {
                     reason: format!("missing Node MVP artifact for {target}"),
@@ -459,13 +487,16 @@ fn validate_locked_tool_with_npm_target_policy(
         }
     } else if tool.name == "go" {
         for target in GO_TARGETS {
+            if pre_v1_target_matrix && target == "linux-aarch64" {
+                continue;
+            }
             if !targets.contains(target) {
                 return Err(Error::InvalidLockfile {
                     reason: format!("missing Go artifact for {target}"),
                 });
             }
         }
-        if targets.len() != GO_TARGETS.len() {
+        if targets.len() != GO_TARGETS.len() && !pre_v1_target_matrix {
             return Err(Error::InvalidLockfile {
                 reason: "Go lock contains an unsupported artifact target".to_owned(),
             });
@@ -487,13 +518,16 @@ fn validate_locked_tool_with_npm_target_policy(
     } else if tool.name == "python" {
         validate_python_metadata(tool)?;
         for target in PYTHON_TARGETS {
+            if pre_v1_target_matrix && target == "linux-aarch64" {
+                continue;
+            }
             if !targets.contains(target) {
                 return Err(Error::InvalidLockfile {
                     reason: format!("missing Python artifact for {target}"),
                 });
             }
         }
-        if targets.len() != PYTHON_TARGETS.len() {
+        if targets.len() != PYTHON_TARGETS.len() && !pre_v1_target_matrix {
             return Err(Error::InvalidLockfile {
                 reason: "Python lock contains an unsupported artifact target".to_owned(),
             });
@@ -501,13 +535,16 @@ fn validate_locked_tool_with_npm_target_policy(
     } else if tool.name == "java" {
         validate_java_metadata(tool)?;
         for target in JAVA_TARGETS {
+            if pre_v1_target_matrix && target == "linux-aarch64" {
+                continue;
+            }
             if !targets.contains(target) {
                 return Err(Error::InvalidLockfile {
                     reason: format!("missing Java artifact for {target}"),
                 });
             }
         }
-        if targets.len() != JAVA_TARGETS.len() {
+        if targets.len() != JAVA_TARGETS.len() && !pre_v1_target_matrix {
             return Err(Error::InvalidLockfile {
                 reason: "Java lock contains an unsupported artifact target".to_owned(),
             });
@@ -515,13 +552,16 @@ fn validate_locked_tool_with_npm_target_policy(
     } else if tool.name == "rust" {
         validate_rust_metadata(tool)?;
         for target in RUST_TARGETS {
+            if pre_v1_target_matrix && target == "linux-aarch64" {
+                continue;
+            }
             if !targets.contains(target) {
                 return Err(Error::InvalidLockfile {
                     reason: format!("missing Rust artifact for {target}"),
                 });
             }
         }
-        if targets.len() != RUST_TARGETS.len() {
+        if targets.len() != RUST_TARGETS.len() && !pre_v1_target_matrix {
             return Err(Error::InvalidLockfile {
                 reason: "Rust lock contains an unsupported artifact target".to_owned(),
             });
@@ -529,22 +569,23 @@ fn validate_locked_tool_with_npm_target_policy(
     } else if tool.name == "dotnet" {
         validate_dotnet_metadata(tool)?;
         for target in DOTNET_TARGETS {
+            if pre_v1_target_matrix && target == "linux-aarch64" {
+                continue;
+            }
             if !targets.contains(target) {
                 return Err(Error::InvalidLockfile {
                     reason: format!("missing .NET SDK artifact for {target}"),
                 });
             }
         }
-        if targets.len() != DOTNET_TARGETS.len() {
+        if targets.len() != DOTNET_TARGETS.len() && !pre_v1_target_matrix {
             return Err(Error::InvalidLockfile {
                 reason: ".NET SDK lock contains an unsupported artifact target".to_owned(),
             });
         }
     } else {
         for (target, _) in npm_tool_targets(&tool.name) {
-            if npm_target_policy == NpmTargetPolicy::AllowLegacyLinuxArm64Gap
-                && *target == "linux-aarch64"
-            {
+            if pre_v1_target_matrix && *target == "linux-aarch64" {
                 continue;
             }
             if !targets.contains(target) {
@@ -553,10 +594,7 @@ fn validate_locked_tool_with_npm_target_policy(
                 });
             }
         }
-        if targets.len() != npm_tool_targets(&tool.name).len()
-            && !(npm_target_policy == NpmTargetPolicy::AllowLegacyLinuxArm64Gap
-                && has_legacy_npm_target_gap(tool))
-        {
+        if targets.len() != npm_tool_targets(&tool.name).len() && !pre_v1_target_matrix {
             return Err(Error::InvalidLockfile {
                 reason: format!("{} lock contains an unsupported artifact target", tool.name),
             });
@@ -570,10 +608,40 @@ fn validate_locked_tool_with_npm_target_policy(
     Ok(())
 }
 
-fn has_legacy_npm_target_gap(tool: &LockedTool) -> bool {
-    matches!(tool.name.as_str(), "pnpm" | "bun")
-        && tool.artifact("linux-aarch64").is_none()
-        && tool.artifacts.len() + 1 == npm_tool_targets(&tool.name).len()
+const PRE_V1_NODE_TARGETS: &[&str] = &[
+    "windows-x86_64",
+    "macos-aarch64",
+    "macos-x86_64",
+    "linux-x86_64",
+];
+const PRE_V1_PNPM_TARGETS: &[&str] = &["windows-x86_64", "linux-x86_64", "macos-aarch64"];
+const PRE_V1_BUN_TARGETS: &[&str] = &[
+    "windows-x86_64-avx2",
+    "windows-x86_64-baseline",
+    "linux-x86_64-avx2",
+    "linux-x86_64-baseline",
+    "macos-aarch64",
+];
+const PRE_V1_STANDARD_TARGETS: &[&str] = &[
+    "windows-x86_64",
+    "macos-aarch64",
+    "macos-x86_64",
+    "linux-x86_64",
+];
+
+fn has_pre_v1_target_matrix(tool: &LockedTool) -> bool {
+    let expected = match tool.name.as_str() {
+        "node" => PRE_V1_NODE_TARGETS,
+        "pnpm" => PRE_V1_PNPM_TARGETS,
+        "bun" => PRE_V1_BUN_TARGETS,
+        "go" | "python" | "java" | "rust" | "dotnet" => PRE_V1_STANDARD_TARGETS,
+        _ => return false,
+    };
+    tool.artifacts.len() == expected.len()
+        && tool
+            .artifacts
+            .iter()
+            .all(|artifact| expected.contains(&artifact.target.as_str()))
 }
 
 fn validate_node_metadata(tool: &LockedTool) -> Result<()> {
@@ -872,7 +940,11 @@ fn validate_locked_go_artifact(version: &str, artifact: &LockedArtifact) -> Resu
     Ok(())
 }
 
-fn validate_locked_node_artifact(version: &str, artifact: &LockedArtifact) -> Result<()> {
+fn validate_locked_node_artifact(
+    version: &str,
+    artifact: &LockedArtifact,
+    allow_pre_v1_verification: bool,
+) -> Result<()> {
     let plan = plan_node_artifact(&SourceConfig::default(), version, &artifact.target)?;
     let expected_format = match plan.format {
         NodeArchiveFormat::Zip => LockedArtifactFormat::Zip,
@@ -895,11 +967,16 @@ fn validate_locked_node_artifact(version: &str, artifact: &LockedArtifact) -> Re
             reason: format!("invalid SHA-256 for {}", artifact.target),
         });
     }
-    if artifact.verification != "nodejs-openpgp-sha256"
-        && !artifact
+    let current_verification = artifact.verification == "nodejs-openpgp-sha256"
+        || artifact
             .verification
-            .starts_with("nodejs-openpgp-sha256-source:")
-    {
+            .starts_with("nodejs-openpgp-sha256-source:");
+    let pre_v1_verification = allow_pre_v1_verification
+        && (artifact.verification == "nodejs-shasums-https"
+            || artifact
+                .verification
+                .starts_with("nodejs-shasums-https-source:"));
+    if !current_verification && !pre_v1_verification {
         return Err(Error::InvalidLockfile {
             reason: format!(
                 "unsupported Node verification for {}; regenerate this pre-1.0 lock with `pinset use node@<selector>`",
@@ -1266,7 +1343,7 @@ mod tests {
     }
 
     #[test]
-    fn target_refresh_loader_only_accepts_the_historical_npm_linux_arm64_gap() {
+    fn target_refresh_loader_accepts_only_known_pre_v1_provider_matrices() {
         let root = tempdir().expect("temp directory");
         let path = root.path().join(LOCKFILE_FILENAME);
         let legacy = Lockfile {
@@ -1282,10 +1359,14 @@ mod tests {
 
         let strict = load_lockfile(&path).expect_err("strict loader rejects the old matrix");
         assert!(strict.to_string().contains("linux-aarch64"));
-        let (loaded, requires_refresh) =
-            load_lockfile_for_target_refresh(&path).expect("refresh loader accepts old matrix");
-        assert!(requires_refresh);
+        let (loaded, refresh_tools) =
+            load_lockfile_for_provider_refresh(&path).expect("refresh loader accepts old matrix");
+        assert_eq!(refresh_tools, ["bun", "pnpm"]);
         assert_eq!(loaded.tools, legacy.tools);
+
+        let (_, requires_refresh) = load_lockfile_for_target_refresh(&path)
+            .expect("compatibility loader accepts old matrix");
+        assert!(requires_refresh);
 
         let mut corrupted = legacy;
         corrupted.tools[0].artifacts[0].canonical_url =
@@ -1295,9 +1376,44 @@ mod tests {
             toml::to_string_pretty(&corrupted).expect("corrupt TOML"),
         )
         .expect("corrupt lockfile");
-        let error = load_lockfile_for_target_refresh(&path)
+        let error = load_lockfile_for_provider_refresh(&path)
             .expect_err("refresh loader still validates every present artifact");
         assert!(error.to_string().contains("invalid npm artifact identity"));
+    }
+
+    #[test]
+    fn target_refresh_loader_detects_every_provider_expanded_in_v1() {
+        let root = tempdir().expect("temp directory");
+        let path = root.path().join(LOCKFILE_FILENAME);
+
+        for name in [
+            "node", "pnpm", "bun", "go", "python", "java", "rust", "dotnet",
+        ] {
+            let mut tool = locked_current_provider_tool(name);
+            tool.artifacts
+                .retain(|artifact| artifact.target != "linux-aarch64");
+            if name == "node" {
+                tool.metadata.clear();
+                for artifact in &mut tool.artifacts {
+                    artifact.verification = "nodejs-shasums-https".to_owned();
+                }
+            } else if name == "java" {
+                tool.metadata.remove("signature_link.linux-aarch64");
+            }
+            let legacy = Lockfile {
+                schema: 2,
+                generated_by: "pinset 0.9.0".to_owned(),
+                tools: vec![tool],
+            };
+            fs::write(&path, toml::to_string_pretty(&legacy).expect("legacy TOML"))
+                .expect("legacy lockfile");
+
+            load_lockfile(&path).expect_err("strict loader rejects the old matrix");
+            let (loaded, refresh_tools) = load_lockfile_for_provider_refresh(&path)
+                .unwrap_or_else(|error| panic!("refresh loader rejected {name}: {error}"));
+            assert_eq!(refresh_tools, [name]);
+            assert_eq!(loaded.tools, legacy.tools);
+        }
     }
 
     #[test]
@@ -1707,6 +1823,125 @@ mod tests {
             released_at: None,
             metadata: BTreeMap::new(),
             artifacts: vec![artifact],
+        }
+    }
+
+    fn locked_current_provider_tool(name: &str) -> LockedTool {
+        match name {
+            "node" => Lockfile::new_node(
+                "pinset test".to_owned(),
+                "24.0.0".to_owned(),
+                "5BE8A3F6C8A5C01D106C0AD820B1A390B168D356".to_owned(),
+                "official".to_owned(),
+                MVP_NODE_TARGETS.into_iter().map(locked_artifact).collect(),
+            )
+            .tools
+            .remove(0),
+            "pnpm" => locked_npm_tool("pnpm", "11.21.0", true),
+            "bun" => locked_npm_tool("bun", "1.3.14", true),
+            "go" => LockedTool {
+                name: "go".to_owned(),
+                requested: "1.25.1".to_owned(),
+                version: "1.25.1".to_owned(),
+                provider: "go-official".to_owned(),
+                released_at: None,
+                metadata: BTreeMap::new(),
+                artifacts: GO_TARGETS
+                    .into_iter()
+                    .map(|target| locked_go_artifact("1.25.1", target))
+                    .collect(),
+            },
+            "python" => LockedTool {
+                name: "python".to_owned(),
+                requested: "3.14.7+20260807".to_owned(),
+                version: "3.14.7+20260807".to_owned(),
+                provider: "python-build-standalone".to_owned(),
+                released_at: None,
+                metadata: BTreeMap::from([
+                    ("build_id".to_owned(), "20260807".to_owned()),
+                    (
+                        "distribution".to_owned(),
+                        "astral-sh/python-build-standalone".to_owned(),
+                    ),
+                    ("python_version".to_owned(), "3.14.7".to_owned()),
+                    ("variant".to_owned(), PYTHON_VARIANT.to_owned()),
+                ]),
+                artifacts: PYTHON_TARGETS
+                    .into_iter()
+                    .map(|target| locked_python_artifact("3.14.7+20260807", target))
+                    .collect(),
+            },
+            "java" => {
+                let version = "21.0.8+9";
+                let release_name = "jdk-21.0.8+9";
+                let artifacts = JAVA_TARGETS
+                    .into_iter()
+                    .map(|target| locked_java_artifact(version, release_name, target))
+                    .collect::<Vec<_>>();
+                let mut metadata = BTreeMap::from([
+                    ("distribution".to_owned(), "eclipse-temurin".to_owned()),
+                    ("vendor".to_owned(), "eclipse".to_owned()),
+                    ("image_type".to_owned(), "jdk".to_owned()),
+                    ("jvm_impl".to_owned(), "hotspot".to_owned()),
+                    ("heap_size".to_owned(), "normal".to_owned()),
+                    ("release_type".to_owned(), "ga".to_owned()),
+                    ("feature_version".to_owned(), "21".to_owned()),
+                    ("release_name".to_owned(), release_name.to_owned()),
+                    ("openjdk_version".to_owned(), "21.0.8+9-LTS".to_owned()),
+                ]);
+                for artifact in &artifacts {
+                    metadata.insert(
+                        format!("signature_link.{}", artifact.target),
+                        format!("{}.sig", artifact.canonical_url),
+                    );
+                }
+                LockedTool {
+                    name: "java".to_owned(),
+                    requested: version.to_owned(),
+                    version: version.to_owned(),
+                    provider: "adoptium-temurin".to_owned(),
+                    released_at: None,
+                    metadata,
+                    artifacts,
+                }
+            }
+            "rust" => LockedTool {
+                name: "rust".to_owned(),
+                requested: "1.97.1".to_owned(),
+                version: "1.97.1".to_owned(),
+                provider: "rust-official".to_owned(),
+                released_at: None,
+                metadata: BTreeMap::from([
+                    ("channel".to_owned(), "stable".to_owned()),
+                    ("components".to_owned(), RUST_COMPONENTS.to_owned()),
+                    ("manifest_date".to_owned(), "2026-07-16".to_owned()),
+                    ("manifest_sha256".to_owned(), "ab".repeat(32)),
+                    ("profile".to_owned(), RUST_PROFILE.to_owned()),
+                ]),
+                artifacts: RUST_TARGETS
+                    .into_iter()
+                    .map(|target| locked_rust_artifact("1.97.1", "2026-07-16", target))
+                    .collect(),
+            },
+            "dotnet" => LockedTool {
+                name: "dotnet".to_owned(),
+                requested: "10.0.400".to_owned(),
+                version: "10.0.400".to_owned(),
+                provider: "microsoft-dotnet-sdk".to_owned(),
+                released_at: None,
+                metadata: BTreeMap::from([
+                    ("channel".to_owned(), "10.0".to_owned()),
+                    ("release_date".to_owned(), "2026-08-11".to_owned()),
+                    ("release_type".to_owned(), "lts".to_owned()),
+                    ("release_version".to_owned(), "10.0.14".to_owned()),
+                    ("support_phase".to_owned(), "active".to_owned()),
+                ]),
+                artifacts: DOTNET_TARGETS
+                    .into_iter()
+                    .map(|target| locked_dotnet_artifact("10.0.400", target))
+                    .collect(),
+            },
+            other => panic!("unsupported provider fixture {other}"),
         }
     }
 

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -32,7 +32,7 @@ use pinset_core::{
     install_locked_python, install_locked_rust, install_payload_statistics,
     is_managed_command_shim, list_all_installed_tool_versions, list_download_cache,
     list_installed_tool_versions, load_global_config, load_lockfile,
-    load_lockfile_for_target_refresh, load_optional_global_config, load_optional_lockfile,
+    load_lockfile_for_provider_refresh, load_optional_global_config, load_optional_lockfile,
     load_project_config, load_project_python_environment, load_source_config, load_user_settings,
     lockfile_path, managed_runtime_arguments, path_with_selected_tools, pinset_home,
     plan_prune_tool_versions, plan_uninstall_tool_version, project_python_environment_path,
@@ -1480,6 +1480,7 @@ struct MigrationReport {
     to_lock_schema: u32,
     config_changed: bool,
     lock_changed: bool,
+    target_refresh_tools: Vec<String>,
     receipt_upgrade_needed: usize,
     changed: bool,
     dry_run: bool,
@@ -2958,6 +2959,8 @@ fn new_lockfile() -> Lockfile {
 }
 
 type ResolvedSelection = (String, String, LockedTool);
+type RefreshableLockfile = (Lockfile, Vec<String>);
+type ProjectImportState = (ProjectConfig, Option<Lockfile>, Vec<String>);
 
 fn select_tools(
     selections: &[String],
@@ -3062,12 +3065,21 @@ where
         let config_path = global_config_path(home);
         let mut config = load_optional_global_config(&config_path)?.unwrap_or_default();
         let lock_path = global_lockfile_path(home);
-        let (mut lockfile, requires_target_refresh) =
+        let (mut lockfile, legacy_target_tools) =
             load_optional_lockfile_for_target_refresh(&lock_path)?
-                .unwrap_or_else(|| (new_lockfile(), false));
-        if requires_target_refresh {
+                .unwrap_or_else(|| (new_lockfile(), Vec::new()));
+        if !legacy_target_tools.is_empty() {
             validate_lock_matches_tools(&lockfile, &config.tools, &config_path)?;
-            refresh_legacy_npm_target_records(&mut lockfile, resolved, &mut resolver)?;
+            let explicitly_replaced = resolved
+                .iter()
+                .map(|(tool, _, _)| tool.clone())
+                .collect::<BTreeSet<_>>();
+            refresh_legacy_target_records(
+                &mut lockfile,
+                &legacy_target_tools,
+                &explicitly_replaced,
+                &mut resolver,
+            )?;
         }
         lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
         apply_resolved_selections(&mut config.tools, &mut lockfile, resolved)?;
@@ -3078,12 +3090,21 @@ where
         let _guard = acquire_project_state_write_lock(home, &config_path)?;
         let mut project = load_project_config(&config_path)?;
         let lock_path = lockfile_path(&config_path);
-        let (mut lockfile, requires_target_refresh) =
+        let (mut lockfile, legacy_target_tools) =
             load_optional_lockfile_for_target_refresh(&lock_path)?
-                .unwrap_or_else(|| (new_lockfile(), false));
-        if requires_target_refresh {
+                .unwrap_or_else(|| (new_lockfile(), Vec::new()));
+        if !legacy_target_tools.is_empty() {
             validate_lock_matches_tools(&lockfile, &project.tools, &config_path)?;
-            refresh_legacy_npm_target_records(&mut lockfile, resolved, &mut resolver)?;
+            let explicitly_replaced = resolved
+                .iter()
+                .map(|(tool, _, _)| tool.clone())
+                .collect::<BTreeSet<_>>();
+            refresh_legacy_target_records(
+                &mut lockfile,
+                &legacy_target_tools,
+                &explicitly_replaced,
+                &mut resolver,
+            )?;
         }
         lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
         apply_resolved_selections(&mut project.tools, &mut lockfile, resolved)?;
@@ -3094,8 +3115,8 @@ where
 
 fn load_optional_lockfile_for_target_refresh(
     path: &Path,
-) -> Result<Option<(Lockfile, bool)>, Box<dyn std::error::Error>> {
-    match load_lockfile_for_target_refresh(path) {
+) -> Result<Option<RefreshableLockfile>, Box<dyn std::error::Error>> {
+    match load_lockfile_for_provider_refresh(path) {
         Ok(lockfile) => Ok(Some(lockfile)),
         Err(Error::ReadLockfile { source, .. }) if source.kind() == io::ErrorKind::NotFound => {
             Ok(None)
@@ -3104,31 +3125,36 @@ fn load_optional_lockfile_for_target_refresh(
     }
 }
 
-fn refresh_legacy_npm_target_records<F>(
+fn refresh_legacy_target_records<F>(
     lockfile: &mut Lockfile,
-    resolved: &[ResolvedSelection],
+    legacy_target_tools: &[String],
+    explicitly_replaced: &BTreeSet<String>,
     resolver: &mut F,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
     F: FnMut(&str, &str) -> Result<LockedTool, Box<dyn std::error::Error>>,
 {
-    let explicitly_resolved = resolved
-        .iter()
-        .map(|(tool, _, _)| tool.as_str())
-        .collect::<BTreeSet<_>>();
-    for tool in ["pnpm", "bun"] {
-        if explicitly_resolved.contains(tool) {
+    for tool in legacy_target_tools {
+        if explicitly_replaced.contains(tool) {
             continue;
         }
-        let Some((requested, version)) = lockfile.tool(tool).and_then(|locked| {
-            locked
-                .artifact("linux-aarch64")
-                .is_none()
-                .then(|| (locked.requested.clone(), locked.version.clone()))
-        }) else {
-            continue;
-        };
-        let mut refreshed = resolver(tool, &version)?;
+        let locked = lockfile
+            .tool(tool)
+            .ok_or_else(|| format!("legacy target refresh cannot find locked provider {tool:?}"))?;
+        let requested = locked.requested.clone();
+        let version = locked.version.clone();
+        let mut refreshed = resolver(tool, &version).map_err(|error| {
+            format!(
+                "failed to refresh pre-1.0 {tool}@{version} target matrix; state was not changed: {error}"
+            )
+        })?;
+        if refreshed.version != version {
+            return Err(format!(
+                "legacy target refresh for {tool}@{version} resolved unexpected version {}",
+                refreshed.version
+            )
+            .into());
+        }
         refreshed.requested = requested;
         lockfile.upsert_tool(refreshed)?;
     }
@@ -3349,7 +3375,7 @@ fn run_project_import(
 
     let config_path = report.target_config.clone();
     let lock_path = lockfile_path(&config_path);
-    let (project, _) = load_project_import_state(&config_path, catalog)?;
+    let (project, _, _) = load_project_import_state(&config_path, catalog)?;
 
     let selections = report
         .findings
@@ -3372,10 +3398,22 @@ fn run_project_import(
 
     let home = pinset_home()?;
     let _guard = acquire_project_state_write_lock(&home, &config_path)?;
-    let (mut project, existing_lockfile) = load_project_import_state(&config_path, catalog)?;
+    let (mut project, existing_lockfile, legacy_target_tools) =
+        load_project_import_state(&config_path, catalog)?;
     reject_import_replacement_conflict(&config_path, &project, &resolved, force, catalog)?;
 
     let mut lockfile = existing_lockfile.unwrap_or_else(new_lockfile);
+    let explicitly_replaced = resolved
+        .iter()
+        .map(|(tool, _, _)| tool.clone())
+        .collect::<BTreeSet<_>>();
+    let mut resolver = resolve_locked_tool;
+    refresh_legacy_target_records(
+        &mut lockfile,
+        &legacy_target_tools,
+        &explicitly_replaced,
+        &mut resolver,
+    )?;
     lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
     for (tool, selector, locked_tool) in &resolved {
         if selector != &locked_tool.version {
@@ -3441,7 +3479,7 @@ fn run_project_import(
 fn load_project_import_state(
     config_path: &Path,
     catalog: Catalog,
-) -> Result<(ProjectConfig, Option<Lockfile>), Box<dyn std::error::Error>> {
+) -> Result<ProjectImportState, Box<dyn std::error::Error>> {
     let config_exists = match fs::symlink_metadata(config_path) {
         Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
             return Err(match catalog.language() {
@@ -3484,12 +3522,12 @@ fn load_project_import_state(
                 }
             });
         }
-        Ok(_) => Some(load_lockfile(&lock_path)?),
+        Ok(_) => Some(load_lockfile_for_provider_refresh(&lock_path)?),
         Err(error) if error.kind() == io::ErrorKind::NotFound => None,
         Err(error) => return Err(error.into()),
     };
     match &lockfile {
-        Some(lockfile) => validate_lock_matches_tools(lockfile, &project.tools, config_path)?,
+        Some((lockfile, _)) => validate_lock_matches_tools(lockfile, &project.tools, config_path)?,
         None if !project.tools.is_empty() => {
             return Err(match catalog.language() {
                 Language::English => format!(
@@ -3506,7 +3544,10 @@ fn load_project_import_state(
         }
         None => {}
     }
-    Ok((project, lockfile))
+    let (lockfile, legacy_target_tools) = lockfile
+        .map(|(lockfile, tools)| (Some(lockfile), tools))
+        .unwrap_or_else(|| (None, Vec::new()));
+    Ok((project, lockfile, legacy_target_tools))
 }
 
 fn reject_import_replacement_conflict(
@@ -3574,19 +3615,47 @@ fn run_update(
             &selected_config_path,
         )?)
     };
-    let (scope, config_path, tools, mut lockfile) = if global {
+    let (scope, config_path, tools, mut lockfile, legacy_target_tools) = if global {
         let config_path = selected_config_path;
         let config = load_global_config(&config_path)?;
-        let lockfile = load_lockfile(&global_lockfile_path(&home))?;
+        let (lockfile, legacy_target_tools) =
+            load_lockfile_for_provider_refresh(&global_lockfile_path(&home))?;
         validate_lock_matches_tools(&lockfile, &config.tools, &config_path)?;
-        ("global", config_path, config.tools, lockfile)
+        (
+            "global",
+            config_path,
+            config.tools,
+            lockfile,
+            legacy_target_tools,
+        )
     } else {
         let config_path = selected_config_path;
         let config = load_project_config(&config_path)?;
-        let lockfile = load_lockfile(&lockfile_path(&config_path))?;
+        let (lockfile, legacy_target_tools) =
+            load_lockfile_for_provider_refresh(&lockfile_path(&config_path))?;
         validate_lock_matches_tools(&lockfile, &config.tools, &config_path)?;
-        ("project", config_path, config.tools, lockfile)
+        (
+            "project",
+            config_path,
+            config.tools,
+            lockfile,
+            legacy_target_tools,
+        )
     };
+
+    if !legacy_target_tools.is_empty() {
+        let explicitly_replaced = tools
+            .keys()
+            .filter(|selected_tool| tool.is_none_or(|tool| tool == selected_tool.as_str()))
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        refresh_legacy_target_records(
+            &mut lockfile,
+            &legacy_target_tools,
+            &explicitly_replaced,
+            &mut resolve_locked_tool,
+        )?;
+    }
 
     let mut reports = Vec::new();
     for (selected_tool, requested) in &tools {
@@ -3667,69 +3736,100 @@ fn run_migrate(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let cwd = effective_cwd(cwd)?;
     let home = pinset_home()?;
-    let (scope, config_path, lock_path, config_schema, lock_schema) = if global {
-        let config_path = global_config_path(&home);
-        let _guard = if dry_run {
-            None
-        } else {
-            Some(acquire_global_state_write_lock(&home)?)
-        };
-        let lock_path = global_lockfile_path(&home);
-        let config = load_global_config(&config_path)?;
-        let lockfile = load_optional_lockfile(&lock_path)?;
-        if let Some(lockfile) = &lockfile {
-            validate_lock_matches_tools(lockfile, &config.tools, &config_path)?;
-        }
-        let report = (
-            "global",
-            config_path.clone(),
-            lock_path.clone(),
-            config.schema,
-            lockfile.as_ref().map(|lockfile| lockfile.schema),
-        );
-        if !dry_run {
-            if let Some(lockfile) = &lockfile {
-                save_global_state_locked(&home, &config, lockfile)?;
+    let (scope, config_path, lock_path, config_schema, lock_schema, target_refresh_tools) =
+        if global {
+            let config_path = global_config_path(&home);
+            let _guard = if dry_run {
+                None
             } else {
-                save_global_config(&config_path, &config)?;
+                Some(acquire_global_state_write_lock(&home)?)
+            };
+            let lock_path = global_lockfile_path(&home);
+            let config = load_global_config(&config_path)?;
+            let lockfile = load_optional_lockfile_for_target_refresh(&lock_path)?;
+            if let Some((lockfile, _)) = &lockfile {
+                validate_lock_matches_tools(lockfile, &config.tools, &config_path)?;
             }
-        }
-        report
-    } else {
-        let config_path = find_project_config(&cwd)?;
-        let _guard = if dry_run {
-            None
+            let target_refresh_tools = lockfile
+                .as_ref()
+                .map(|(_, tools)| tools.clone())
+                .unwrap_or_default();
+            let report = (
+                "global",
+                config_path.clone(),
+                lock_path.clone(),
+                config.schema,
+                lockfile.as_ref().map(|(lockfile, _)| lockfile.schema),
+                target_refresh_tools.clone(),
+            );
+            if !dry_run {
+                if let Some((mut lockfile, legacy_target_tools)) = lockfile {
+                    let mut resolver = resolve_locked_tool;
+                    refresh_legacy_target_records(
+                        &mut lockfile,
+                        &legacy_target_tools,
+                        &BTreeSet::new(),
+                        &mut resolver,
+                    )?;
+                    lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
+                    save_global_state_locked(&home, &config, &lockfile)?;
+                } else {
+                    save_global_config(&config_path, &config)?;
+                }
+            }
+            report
         } else {
-            Some(acquire_project_state_write_lock(&home, &config_path)?)
-        };
-        let lock_path = lockfile_path(&config_path);
-        let config = load_project_config(&config_path)?;
-        let lockfile = load_optional_lockfile(&lock_path)?;
-        if let Some(lockfile) = &lockfile {
-            validate_lock_matches_tools(lockfile, &config.tools, &config_path)?;
-        }
-        let report = (
-            "project",
-            config_path.clone(),
-            lock_path.clone(),
-            config.schema,
-            lockfile.as_ref().map(|lockfile| lockfile.schema),
-        );
-        if !dry_run {
-            if let Some(lockfile) = &lockfile {
-                save_project_state_locked(&home, &config_path, &config, lockfile)?;
+            let config_path = find_project_config(&cwd)?;
+            let _guard = if dry_run {
+                None
             } else {
-                save_project_config(&config_path, &config)?;
+                Some(acquire_project_state_write_lock(&home, &config_path)?)
+            };
+            let lock_path = lockfile_path(&config_path);
+            let config = load_project_config(&config_path)?;
+            let lockfile = load_optional_lockfile_for_target_refresh(&lock_path)?;
+            if let Some((lockfile, _)) = &lockfile {
+                validate_lock_matches_tools(lockfile, &config.tools, &config_path)?;
             }
-        }
-        report
-    };
+            let target_refresh_tools = lockfile
+                .as_ref()
+                .map(|(_, tools)| tools.clone())
+                .unwrap_or_default();
+            let report = (
+                "project",
+                config_path.clone(),
+                lock_path.clone(),
+                config.schema,
+                lockfile.as_ref().map(|(lockfile, _)| lockfile.schema),
+                target_refresh_tools.clone(),
+            );
+            if !dry_run {
+                if let Some((mut lockfile, legacy_target_tools)) = lockfile {
+                    let mut resolver = resolve_locked_tool;
+                    refresh_legacy_target_records(
+                        &mut lockfile,
+                        &legacy_target_tools,
+                        &BTreeSet::new(),
+                        &mut resolver,
+                    )?;
+                    lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
+                    save_project_state_locked(&home, &config_path, &config, &lockfile)?;
+                } else {
+                    save_project_config(&config_path, &config)?;
+                }
+            }
+            report
+        };
     let to_config_schema = if global {
         pinset_core::GLOBAL_STATE_SCHEMA
     } else {
         PROJECT_CONFIG_SCHEMA
     };
     let receipt_upgrade_needed = legacy_receipt_count(&home)?;
+    let config_changed = config_schema != to_config_schema;
+    let lock_changed = lock_schema.is_some_and(|schema| schema != pinset_core::LOCKFILE_SCHEMA)
+        || !target_refresh_tools.is_empty();
+    let changed = config_changed || lock_changed || receipt_upgrade_needed > 0;
     let report = MigrationReport {
         scope,
         config: config_path,
@@ -3738,12 +3838,11 @@ fn run_migrate(
         from_lock_schema: lock_schema,
         to_config_schema,
         to_lock_schema: pinset_core::LOCKFILE_SCHEMA,
-        config_changed: config_schema != to_config_schema,
-        lock_changed: lock_schema.is_some_and(|schema| schema != pinset_core::LOCKFILE_SCHEMA),
+        config_changed,
+        lock_changed,
+        target_refresh_tools,
         receipt_upgrade_needed,
-        changed: config_schema != to_config_schema
-            || lock_schema.is_some_and(|schema| schema != pinset_core::LOCKFILE_SCHEMA)
-            || receipt_upgrade_needed > 0,
+        changed,
         dry_run,
     };
     if json {
@@ -3764,6 +3863,12 @@ fn run_migrate(
             println!(
                 "{} legacy installation receipt(s) require `pinset install <tool@version> --repair` or reinstall",
                 report.receipt_upgrade_needed
+            );
+        }
+        if !report.target_refresh_tools.is_empty() {
+            println!(
+                "refreshed pre-1.0 target matrices: {}",
+                report.target_refresh_tools.join(", ")
             );
         }
     } else {
@@ -3813,7 +3918,7 @@ fn unset_tool(
             );
             return Ok(());
         };
-        if config.tools.remove(tool).is_none() {
+        if !config.tools.contains_key(tool) {
             println!(
                 "{}",
                 catalog.selection_unset("global", tool, &config_path, false)
@@ -3821,8 +3926,24 @@ fn unset_tool(
             return Ok(());
         }
         let lock_path = global_lockfile_path(&home);
-        if let Some(mut lockfile) = load_optional_lockfile(&lock_path)? {
+        let lockfile = load_optional_lockfile_for_target_refresh(&lock_path)?;
+        if let Some((lockfile, _)) = &lockfile {
+            validate_lock_matches_tools(lockfile, &config.tools, &config_path)?;
+        }
+        config.tools.remove(tool);
+        if let Some((mut lockfile, legacy_target_tools)) = lockfile {
             lockfile.remove_tool(tool);
+            let remaining_legacy = legacy_target_tools
+                .into_iter()
+                .filter(|legacy| legacy != tool)
+                .collect::<Vec<_>>();
+            let mut resolver = resolve_locked_tool;
+            refresh_legacy_target_records(
+                &mut lockfile,
+                &remaining_legacy,
+                &BTreeSet::new(),
+                &mut resolver,
+            )?;
             lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
             let remove_empty_lock = lockfile.tools.is_empty();
             save_global_state_locked(&home, &config, &lockfile)?;
@@ -3843,7 +3964,7 @@ fn unset_tool(
     let home = pinset_home()?;
     let _guard = acquire_project_state_write_lock(&home, &config_path)?;
     let mut config = load_project_config(&config_path)?;
-    if config.tools.remove(tool).is_none() {
+    if !config.tools.contains_key(tool) {
         println!(
             "{}",
             catalog.selection_unset("project", tool, &config_path, false)
@@ -3851,8 +3972,24 @@ fn unset_tool(
         return Ok(());
     }
     let lock_path = lockfile_path(&config_path);
-    if let Some(mut lockfile) = load_optional_lockfile(&lock_path)? {
+    let lockfile = load_optional_lockfile_for_target_refresh(&lock_path)?;
+    if let Some((lockfile, _)) = &lockfile {
+        validate_lock_matches_tools(lockfile, &config.tools, &config_path)?;
+    }
+    config.tools.remove(tool);
+    if let Some((mut lockfile, legacy_target_tools)) = lockfile {
         lockfile.remove_tool(tool);
+        let remaining_legacy = legacy_target_tools
+            .into_iter()
+            .filter(|legacy| legacy != tool)
+            .collect::<Vec<_>>();
+        let mut resolver = resolve_locked_tool;
+        refresh_legacy_target_records(
+            &mut lockfile,
+            &remaining_legacy,
+            &BTreeSet::new(),
+            &mut resolver,
+        )?;
         lockfile.generated_by = format!("pinset {}", pinset_core::pinset_version());
         let remove_empty_lock = lockfile.tools.is_empty();
         save_project_state_locked(&home, &config_path, &config, &lockfile)?;
@@ -6868,7 +7005,7 @@ mod tests {
     }
 
     #[test]
-    fn repairs_pre_v1_npm_target_matrix_before_adding_a_global_selection() {
+    fn repairs_all_pre_v1_target_matrices_before_adding_a_global_selection() {
         let root = tempfile::tempdir().expect("temporary root");
         let home = root.path().join("home");
         let project = root.path().join("project");
@@ -6876,6 +7013,7 @@ mod tests {
 
         let mut config = GlobalConfig::default();
         config.set_tool("bun", "1.3.14");
+        config.set_tool("java", "21.0.8+9");
         config.set_tool("node", "24.0.0");
         config.set_tool("pnpm", "11.21.0");
         save_global_config(&global_config_path(&home), &config).expect("legacy global config");
@@ -6886,11 +7024,16 @@ mod tests {
         let mut pnpm = persistable_selection_lock("pnpm", "11.21.0", "11.21.0");
         pnpm.artifacts
             .retain(|artifact| artifact.target != "linux-aarch64");
+        let mut java = persistable_selection_lock("java", "21.0.8+9", "21.0.8+9");
+        java.artifacts
+            .retain(|artifact| artifact.target != "linux-aarch64");
+        java.metadata.remove("signature_link.linux-aarch64");
         let legacy_lock = Lockfile {
             schema: 2,
             generated_by: "pinset 0.9.0".to_owned(),
             tools: vec![
                 bun,
+                java,
                 persistable_selection_lock("node", "24.0.0", "24.0.0"),
                 pnpm,
             ],
@@ -6911,23 +7054,31 @@ mod tests {
             refreshed.push((tool.to_owned(), version.to_owned()));
             Ok(persistable_selection_lock(tool, version, version))
         })
-        .expect("repair legacy npm targets and save Go selection");
+        .expect("repair all legacy targets and save Go selection");
 
         assert_eq!(
             refreshed,
             [
-                ("pnpm".to_owned(), "11.21.0".to_owned()),
                 ("bun".to_owned(), "1.3.14".to_owned()),
+                ("java".to_owned(), "21.0.8+9".to_owned()),
+                ("pnpm".to_owned(), "11.21.0".to_owned()),
             ]
         );
         let saved_config =
             load_global_config(&global_config_path(&home)).expect("saved global config");
         assert_eq!(saved_config.tools["bun"], "1.3.14");
+        assert_eq!(saved_config.tools["java"], "21.0.8+9");
         assert_eq!(saved_config.tools["node"], "24.0.0");
         assert_eq!(saved_config.tools["pnpm"], "11.21.0");
         assert_eq!(saved_config.tools["go"], "latest");
         let saved_lock =
             load_lockfile(&global_lockfile_path(&home)).expect("strictly valid refreshed lock");
+        assert!(
+            saved_lock
+                .tool("java")
+                .and_then(|tool| tool.artifact("linux-aarch64"))
+                .is_some()
+        );
         assert!(
             saved_lock
                 .tool("bun")
@@ -6941,6 +7092,110 @@ mod tests {
                 .is_some()
         );
         assert_eq!(saved_lock.tool("go").unwrap().requested, "latest");
+    }
+
+    #[test]
+    fn legacy_target_refresh_failure_preserves_global_state_byte_for_byte() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        fs::create_dir_all(&project).expect("project directory");
+
+        let mut config = GlobalConfig::default();
+        config.set_tool("bun", "1.3.14");
+        config.set_tool("java", "21.0.8+9");
+        let config_path = global_config_path(&home);
+        save_global_config(&config_path, &config).expect("legacy global config");
+
+        let mut bun = persistable_selection_lock("bun", "1.3.14", "1.3.14");
+        bun.artifacts
+            .retain(|artifact| artifact.target != "linux-aarch64");
+        let mut java = persistable_selection_lock("java", "21.0.8+9", "21.0.8+9");
+        java.artifacts
+            .retain(|artifact| artifact.target != "linux-aarch64");
+        java.metadata.remove("signature_link.linux-aarch64");
+        let legacy_lock = Lockfile {
+            schema: 2,
+            generated_by: "pinset 0.9.0".to_owned(),
+            tools: vec![bun, java],
+        };
+        let lock_path = global_lockfile_path(&home);
+        fs::write(
+            &lock_path,
+            toml::to_string_pretty(&legacy_lock).expect("legacy lock TOML"),
+        )
+        .expect("legacy global lock");
+        let original_config = fs::read(&config_path).expect("original config bytes");
+        let original_lock = fs::read(&lock_path).expect("original lock bytes");
+
+        let resolved = vec![(
+            "go".to_owned(),
+            "latest".to_owned(),
+            persistable_selection_lock("go", "latest", "1.25.1"),
+        )];
+        let error = save_resolved_selection_batch_with(
+            &home,
+            &project,
+            true,
+            &resolved,
+            |tool, version| {
+                if tool == "java" {
+                    return Err("fixture Java metadata outage".into());
+                }
+                Ok(persistable_selection_lock(tool, version, version))
+            },
+        )
+        .expect_err("refresh failure must abort the batch");
+
+        assert!(error.to_string().contains("fixture Java metadata outage"));
+        assert_eq!(
+            fs::read(&config_path).expect("config after failure"),
+            original_config
+        );
+        assert_eq!(
+            fs::read(&lock_path).expect("lock after failure"),
+            original_lock
+        );
+    }
+
+    #[test]
+    fn legacy_target_refresh_preserves_requested_selector_and_exact_version() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let path = root.path().join("pinset.lock");
+        let mut java = persistable_selection_lock("java", "21", "21.0.8+9");
+        java.artifacts
+            .retain(|artifact| artifact.target != "linux-aarch64");
+        java.metadata.remove("signature_link.linux-aarch64");
+        let legacy_lock = Lockfile {
+            schema: pinset_core::LOCKFILE_SCHEMA,
+            generated_by: "pinset 2.1.4".to_owned(),
+            tools: vec![java],
+        };
+        fs::write(
+            &path,
+            toml::to_string_pretty(&legacy_lock).expect("legacy lock TOML"),
+        )
+        .expect("legacy lockfile");
+
+        let (mut lockfile, legacy_target_tools) =
+            load_lockfile_for_provider_refresh(&path).expect("legacy schema 3 lock");
+        let mut seen_selector = None;
+        refresh_legacy_target_records(
+            &mut lockfile,
+            &legacy_target_tools,
+            &BTreeSet::new(),
+            &mut |tool, selector| {
+                seen_selector = Some(selector.to_owned());
+                Ok(persistable_selection_lock(tool, selector, selector))
+            },
+        )
+        .expect("refresh exact Java version");
+
+        let java = lockfile.tool("java").expect("refreshed Java lock");
+        assert_eq!(seen_selector.as_deref(), Some("21.0.8+9"));
+        assert_eq!(java.requested, "21");
+        assert_eq!(java.version, "21.0.8+9");
+        assert!(java.artifact("linux-aarch64").is_some());
     }
 
     #[test]
@@ -7129,6 +7384,83 @@ mod tests {
                     provider: "go-official".to_owned(),
                     released_at: None,
                     metadata: BTreeMap::new(),
+                    artifacts,
+                }
+            }
+            "java" => {
+                assert_eq!(version, "21.0.8+9", "Java fixture version");
+                let release_name = format!("jdk-{version}");
+                let artifacts = pinset_core::JAVA_TARGETS
+                    .into_iter()
+                    .map(|target| {
+                        let (os, arch, extension) = match target {
+                            "windows-x86_64" => ("windows", "x64", "zip"),
+                            "linux-x86_64" => ("linux", "x64", "tar.gz"),
+                            "linux-aarch64" => ("linux", "aarch64", "tar.gz"),
+                            "macos-x86_64" => ("mac", "x64", "tar.gz"),
+                            "macos-aarch64" => ("mac", "aarch64", "tar.gz"),
+                            _ => unreachable!("known Java target"),
+                        };
+                        let package = format!(
+                            "OpenJDK21U-jdk_{arch}_{os}_hotspot_21.0.8_9.{extension}"
+                        );
+                        let canonical_url = format!(
+                            "https://github.com/adoptium/temurin21-binaries/releases/download/{}/{}",
+                            release_name.replace('+', "%2B"),
+                            package
+                        );
+                        let plan = pinset_core::plan_java_artifact(
+                            version,
+                            &release_name,
+                            target,
+                            &package,
+                            &canonical_url,
+                        )
+                        .expect("Java artifact plan");
+                        pinset_core::LockedArtifact {
+                            target: target.to_owned(),
+                            canonical_url: plan.canonical_url,
+                            artifact_path: plan.artifact_path,
+                            sha256: "ab".repeat(32),
+                            integrity: None,
+                            format: match plan.format {
+                                pinset_core::JavaArchiveFormat::Zip => {
+                                    pinset_core::LockedArtifactFormat::Zip
+                                }
+                                pinset_core::JavaArchiveFormat::TarGz => {
+                                    pinset_core::LockedArtifactFormat::TarGz
+                                }
+                            },
+                            archive_root: plan.archive_root,
+                            verification: "adoptium-api-sha256".to_owned(),
+                            overlays: Vec::new(),
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                let mut metadata = BTreeMap::from([
+                    ("distribution".to_owned(), "eclipse-temurin".to_owned()),
+                    ("vendor".to_owned(), "eclipse".to_owned()),
+                    ("image_type".to_owned(), "jdk".to_owned()),
+                    ("jvm_impl".to_owned(), "hotspot".to_owned()),
+                    ("heap_size".to_owned(), "normal".to_owned()),
+                    ("release_type".to_owned(), "ga".to_owned()),
+                    ("feature_version".to_owned(), "21".to_owned()),
+                    ("release_name".to_owned(), release_name),
+                    ("openjdk_version".to_owned(), "21.0.8+9-LTS".to_owned()),
+                ]);
+                for artifact in &artifacts {
+                    metadata.insert(
+                        format!("signature_link.{}", artifact.target),
+                        format!("{}.sig", artifact.canonical_url),
+                    );
+                }
+                LockedTool {
+                    name: tool.to_owned(),
+                    requested: requested.to_owned(),
+                    version: version.to_owned(),
+                    provider: "adoptium-temurin".to_owned(),
+                    released_at: None,
+                    metadata,
                     artifacts,
                 }
             }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -890,9 +890,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.4
+      - uses: Future-Element/pinset@v2.1.5
         with:
-          version: 2.1.4
+          version: 2.1.5
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -890,9 +890,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.1.4
+      - uses: Future-Element/pinset@v2.1.5
         with:
-          version: 2.1.4
+          version: 2.1.5
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/examples/devcontainer/.devcontainer/Dockerfile
+++ b/examples/devcontainer/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
-ARG PINSET_VERSION=2.1.4
+ARG PINSET_VERSION=2.1.5
 
 RUN set -eux; \
     architecture="$(dpkg --print-architecture)"; \

--- a/examples/devcontainer/.devcontainer/devcontainer.json
+++ b/examples/devcontainer/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-        "PINSET_VERSION": "2.1.4"
+        "PINSET_VERSION": "2.1.5"
     }
   },
   "postCreateCommand": "pinset install --locked",

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string] $Version = '2.1.4',
+    [string] $Version = '2.1.5',
     [string] $InstallDir = (Join-Path $env:LOCALAPPDATA 'Pinset\bin')
 )
 

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="2.1.4"
+DEFAULT_VERSION="2.1.5"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -22,7 +22,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 2.1.4.
+  --version VERSION       Install an exact release, for example 2.1.5.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pinset-website",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "private": true,
   "packageManager": "pnpm@10.15.0",
   "scripts": {


### PR DESCRIPTION
## Summary
- migrate every exact pre-v1 Provider target matrix that predates Linux ARM64 coverage
- re-resolve affected locks at their existing exact versions while preserving requested selectors and strict ordinary reads
- add regression coverage for all eight affected Providers, corrupt gaps, atomic failure, and API compatibility
- bump release metadata and documentation to 2.1.5

## Verification
- cargo check --workspace --all-targets --all-features --locked
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo test --workspace --all-features --locked
- cargo audit --deny warnings --ignore RUSTSEC-2023-0071
- Windows installer/uninstaller contract tests
- integration contracts and shim dependency graph
- website install, typecheck, build, and SEO validation