### PR TITLE
Add project tasks and environment contracts for 2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.3.0 - 2026-09-07
+
+- Add schema 5 project tasks with argument-array commands, optional project-relative working directories, environment profiles, descriptions, and appended arguments through `pinset run <task> -- <arguments...>`.
+- Add typed environment-variable contracts for strings, integers, booleans, URLs, and enums, with required fields, profile filters, non-secret defaults, and secret-default rejection. Validate contracts before command injection.
+- Add `pinset env check` and `pinset env diff` reports that expose readiness and variable structure without printing secret values or secret-derived hashes.
+- Preserve schema 4 projects until explicit migration, retain TOML comments during schema-only migration, and keep migration writes atomic under the existing project-state lock.
+
+Project configuration migrates to schema 5; the runtime lock remains schema 3. Schema 1-4 projects remain readable, and existing schema 4 encrypted environments continue to work before migration.
+
 ## 2.2.0 - 2026-09-07
 
 - Add `pinset [-C <directory>] [-e <profile> | --no-env] -- <command> [arguments...]` for managed tools, project Python commands, and explicit external programs. Preserve the existing `exec` and `x` contracts.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2734,7 +2734,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "clap",
  "flate2",
@@ -2760,7 +2760,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "atomic-write-file",
  "base64",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-env"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "age",
  "atomic-write-file",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.97"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Future Element"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ export PATH="$HOME/.local/bin:$PATH"
 Install an exact version or choose another directory:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.2.0
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.3.0
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -103,7 +103,7 @@ Remove-Item .\install.ps1
 Install an exact version:
 
 ```powershell
-.\install.ps1 -Version 2.2.0
+.\install.ps1 -Version 2.3.0
 ```
 
 Windows and WSL are separate environments and require separate installations. The installer registers Pinset and every built-in command route, but it does not pre-download language runtimes.
@@ -174,7 +174,7 @@ pnpm --version
 python --version
 ```
 
-`pinset.toml` stores selection intent and policy; `pinset.lock` stores exact versions and platform artifacts. Project configuration uses schema 4 while the runtime lock remains schema 3. Encrypted environments do not participate in runtime artifact resolution.
+`pinset.toml` stores selection intent, tasks, environment contracts, and policy; `pinset.lock` stores exact versions and platform artifacts. Project configuration uses schema 5 while the runtime lock remains schema 3. Encrypted environments do not participate in runtime artifact resolution.
 
 ### 3. Run another version temporarily
 
@@ -195,12 +195,35 @@ pinset import
 
 `detect` is read-only and offline. `import` does not delete or modify its source files.
 
+### 5. Save daily commands as tasks
+
+Declare argument arrays instead of shell strings so Pinset preserves boundaries and child exit status:
+
+```toml
+[tasks.dev]
+command = ["pnpm", "dev"]
+profile = "development"
+description = "Start the development server"
+
+[tasks.test]
+command = ["pnpm", "test"]
+cwd = "packages/app"
+profile = "test"
+```
+
+```sh
+pinset run dev
+pinset run test -- --watch
+```
+
+An explicit `-e` profile wins over `PINSET_ENV_PROFILE`, the task profile, the machine-local selection, and the project default. An unknown task is an error and never runs a same-named system command.
+
 ## Project policy
 
 Projects are strict by default: undeclared tools do not inherit global selections or silently use system commands. Change that behavior explicitly in `pinset.toml` when required:
 
 ```toml
-schema = 4
+schema = 5
 project-id = "4c5652e4-0000-4000-8000-000000000000"
 
 [policy]
@@ -281,9 +304,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.2.0
+      - uses: Future-Element/pinset@v2.3.0
         with:
-          version: 2.2.0
+          version: 2.3.0
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js
@@ -347,7 +370,7 @@ pinset <command> --help
 
 ## Migration and upgrades
 
-Preview an older project's migration to schema 4 before writing changes:
+Preview an older project's migration to schema 5 before writing changes:
 
 ```sh
 pinset migrate --dry-run
@@ -404,11 +427,22 @@ pinset env reset
 
 `env use` stores a machine-local preference per project/worktree without changing shared defaults; CI ignores it. `env share/unshare/members` simplify recipient management. Existing `exec`, trust requirements, and project/lock formats remain compatible. See the [command reference](docs/commands.md#short-execution-22) for selection precedence, noninteractive setup, and execution boundaries. Named tasks are not part of 2.2.
 
+### v2.3: tasks and environment contracts
+
+Pinset **2.3.0** stores repeatable project workflows and validates environment readiness:
+
+```sh
+pinset run dev
+pinset run test -- --watch
+pinset env check --profile test
+pinset env diff development test
+```
+
+Schema 5 adds `[tasks.<name>]` and `[environment.variables.<name>]`. Tasks can declare an argument array, project-relative directory, profile, and description. Contracts support `string`, `integer`, `boolean`, `url`, and `enum`, required fields, profile filters, and defaults for non-secret values. Schema 4 projects remain readable and keep working until `pinset migrate` explicitly enables schema 5.
+
 ### Future directions
 
-Pinset's next steps focus on making project environments easier to prepare, use, compare, and upgrade. The features and command forms below are planned and are not available in the current release.
-
-After 2.2, version 2.3 will add named tasks such as `pinset run dev`, task-bound profiles, and variable contracts. Existing commands and script interfaces remain compatible.
+Pinset's next steps focus on making project environments easier to diagnose, deliver, and upgrade. The features below are planned and are not available in the current release.
 
 | Direction | Planned capabilities |
 | --- | --- |
@@ -416,12 +450,11 @@ After 2.2, version 2.3 will add named tasks such as `pinset run dev`, task-bound
 | Deeper language support | Rust components, compilation targets, and date-pinned nightly toolchains; Java distributions and JDK/JRE selection; named Python environments. |
 | Workspaces and multiple projects | Explicit members, shared tool defaults with member overrides, batch installation and checks, and tool-reference visibility. |
 | Offline delivery and caching | Artifact prefetching, verified offline bundles, explicit offline installation, broader mirror support, concurrent downloads, and CI caching. |
-| Environment variable contracts | Required variables, types, descriptions, configuration defaults, and structural profile comparison. |
 | Candidate upgrades and recovery | Prepare candidate locks, test with candidate toolchains, apply verified selections, and restore previous toolchain configuration. |
 | A constrained Provider ecosystem | Declarative Providers for development CLIs, explicit source trust, manifest validation, and contributor tooling. |
-| Tasks and editor integration | Lightweight project tasks, followed by VS Code integration for toolchain status, environment selection, diagnostics, and task execution. |
+| Editor integration | VS Code toolchain status, environment selection, diagnostics, and task execution. |
 
-Planned compatible releases are 2.3 tasks/contracts, 2.4 diagnostics/CI, 2.5 offline delivery, 2.6 Rust/tool identity, 2.7 Java/Python, 2.8 workspaces, 2.9 candidate upgrades/recovery, 2.10 Providers, and 2.11 editor integration. These are delivery targets without promised dates. Breaking public contracts would require a separate 3.0 plan. Pinset will preserve explicit project boundaries, verified artifacts, and local-first operation.
+Planned compatible releases are 2.4 diagnostics/CI, 2.5 offline delivery, 2.6 Rust/tool identity, 2.7 Java/Python, 2.8 workspaces, 2.9 candidate upgrades/recovery, 2.10 Providers, and 2.11 editor integration. These are delivery targets without promised dates. Breaking public contracts would require a separate 3.0 plan. Pinset will preserve explicit project boundaries, verified artifacts, and local-first operation.
 
 ## Contributing and license
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -88,7 +88,7 @@ export PATH="$HOME/.local/bin:$PATH"
 安装指定版本或目录：
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.2.0
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.3.0
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -103,7 +103,7 @@ Remove-Item .\install.ps1
 指定版本：
 
 ```powershell
-.\install.ps1 -Version 2.2.0
+.\install.ps1 -Version 2.3.0
 ```
 
 Windows 与 WSL 是两个独立环境，需要分别安装。安装器只安装 Pinset 和所有内置命令路由，不会预先下载语言运行时。
@@ -174,7 +174,7 @@ pnpm --version
 python --version
 ```
 
-`pinset.toml` 保存用户选择与策略，`pinset.lock` 保存精确版本和平台制品。项目配置使用 schema 4，运行时锁继续使用 schema 3；加密环境不会参与运行时制品解析。
+`pinset.toml` 保存用户选择、任务、环境变量契约与策略，`pinset.lock` 保存精确版本和平台制品。项目配置使用 schema 5，运行时锁继续使用 schema 3；加密环境不会参与运行时制品解析。
 
 ### 3. 临时运行其他版本
 
@@ -195,12 +195,35 @@ pinset import
 
 `detect` 只读且不联网；`import` 不删除或修改来源文件。
 
+### 5. 把日常命令保存为任务
+
+任务使用参数数组，不使用 Shell 字符串，因此参数边界与子进程退出状态保持明确：
+
+```toml
+[tasks.dev]
+command = ["pnpm", "dev"]
+profile = "development"
+description = "启动开发服务器"
+
+[tasks.test]
+command = ["pnpm", "test"]
+cwd = "packages/app"
+profile = "test"
+```
+
+```sh
+pinset run dev
+pinset run test -- --watch
+```
+
+环境优先级为显式 `-e`、`PINSET_ENV_PROFILE`、任务 profile、本机选择、项目默认值。任务不存在时直接报错，不会执行系统中的同名命令。
+
 ## 项目策略
 
 项目默认严格：未声明的工具不会继承全局选择，也不会静默使用系统命令。需要时在 `pinset.toml` 中显式调整：
 
 ```toml
-schema = 4
+schema = 5
 project-id = "4c5652e4-0000-4000-8000-000000000000"
 
 [policy]
@@ -281,9 +304,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.2.0
+      - uses: Future-Element/pinset@v2.3.0
         with:
-          version: 2.2.0
+          version: 2.3.0
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js
@@ -347,7 +370,7 @@ pinset <命令> --help
 
 ## 迁移与升级
 
-旧项目升级到 schema 4 前可以先预览：
+旧项目升级到 schema 5 前可以先预览：
 
 ```sh
 pinset migrate --dry-run
@@ -404,11 +427,22 @@ pinset env reset
 
 `env use` 按项目路径和身份保存本机环境，worktree 互相隔离，CI 忽略本机偏好；`env share/unshare/members` 简化接收人操作。现有 `exec`、项目信任要求、配置和锁格式保持兼容。[命令文档](docs/commands.zh-CN.md#短执行入口22) 说明了选择优先级、非交互初始化和参数边界。2.2 不包含具名任务。
 
+### v2.3：任务与环境变量契约
+
+Pinset **2.3.0** 可以保存重复执行的项目流程，并在启动前检查环境是否就绪：
+
+```sh
+pinset run dev
+pinset run test -- --watch
+pinset env check --profile test
+pinset env diff development test
+```
+
+schema 5 增加 `[tasks.<名称>]` 与 `[environment.variables.<名称>]`。任务可以声明参数数组、项目内工作目录、profile 和说明；变量契约支持 `string`、`integer`、`boolean`、`url`、`enum`、必填、profile 过滤，以及非密钥变量的默认值。schema 4 项目继续可读可用，只有显式运行 `pinset migrate` 才会启用 schema 5。
+
 ### 未来方向
 
-Pinset 接下来会围绕项目环境的准备、使用、比较和升级展开。以下功能与命令形式均为规划内容，当前版本尚不支持。
-
-2.2 之后，2.3 将提供 `pinset run dev` 等具名任务、任务绑定环境和变量契约，进一步减少重复输入，同时保留现有命令和脚本接口的兼容性。
+Pinset 接下来会围绕项目环境的诊断、交付和升级展开。以下能力仍在规划中，当前版本尚不支持。
 
 | 方向 | 计划能力 |
 | --- | --- |
@@ -416,12 +450,11 @@ Pinset 接下来会围绕项目环境的准备、使用、比较和升级展开�
 | 语言能力深化 | Rust 组件、编译目标与固定日期 nightly；Java 发行版及 JDK/JRE 选择；Python 具名环境。 |
 | Workspace 与多项目 | 显式成员、共享工具默认值与成员覆盖、批量安装检查，以及工具引用关系查看。 |
 | 离线交付与缓存 | 制品预下载、可验证离线包、显式离线安装、更多镜像支持、并发下载与 CI 缓存。 |
-| 环境变量契约 | 必填变量、类型、说明、普通配置默认值、环境比较，以及配置结构比较。 |
 | 候选升级与恢复 | 准备候选锁、使用候选工具链测试、应用已验证的选择，以及恢复之前的工具链配置。 |
 | 受约束的 Provider 生态 | 开发辅助 CLI 的声明式 Provider、显式来源信任、清单验证与贡献者工具。 |
-| 任务与编辑器集成 | 轻量项目任务，以及后续用于工具链状态、环境选择、诊断和任务执行的 VS Code 集成。 |
+| 编辑器集成 | VS Code 工具链状态、环境选择、诊断和任务执行。 |
 
-后续按兼容的 2.x 功能版本推进：2.3 任务与变量契约，2.4 诊断与 CI，2.5 离线交付，2.6 Rust 与工具身份，2.7 Java/Python，2.8 Workspace，2.9 候选升级与恢复，2.10 Provider，2.11 编辑器集成。版本号是交付目标，不承诺发布日期；破坏公开兼容性的变更另立 3.0 计划。Pinset 继续保持明确的项目边界、制品验证和本地优先原则。
+后续按兼容的 2.x 功能版本推进：2.4 诊断与 CI，2.5 离线交付，2.6 Rust 与工具身份，2.7 Java/Python，2.8 Workspace，2.9 候选升级与恢复，2.10 Provider，2.11 编辑器集成。版本号是交付目标，不承诺发布日期；破坏公开兼容性的变更另立 3.0 计划。Pinset 继续保持明确的项目边界、制品验证和本地优先原则。
 
 ## 贡献与许可证
 

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   version:
     description: Exact Pinset release version without the leading v.
     required: false
-    default: 2.2.0
+    default: 2.3.0
   install:
     description: Run pinset install --locked after Pinset is available.
     required: false
@@ -16,7 +16,7 @@ inputs:
     required: false
     default: .
   trust-project-id:
-    description: Expected non-secret schema 4 project-id to trust for encrypted environment injection.
+    description: Expected non-secret schema 4 or 5 project-id to trust for encrypted environment injection.
     required: false
     default: ""
 

--- a/crates/pinset-core/Cargo.toml
+++ b/crates/pinset-core/Cargo.toml
@@ -24,12 +24,12 @@ go-metadata = ["lockfile", "sources", "dep:reqwest", "dep:serde_json"]
 go-provider = ["sources"]
 flutter-metadata = ["lockfile", "sources", "dep:reqwest", "dep:serde_json"]
 flutter-provider = ["sources"]
-java-metadata = ["lockfile", "dep:reqwest", "dep:serde_json", "dep:url"]
-java-provider = ["dep:url"]
-rust-metadata = ["lockfile", "dep:reqwest", "dep:sha2", "dep:url"]
-rust-provider = ["dep:url"]
-dotnet-metadata = ["lockfile", "dep:reqwest", "dep:serde_json", "dep:url"]
-dotnet-provider = ["dep:url"]
+java-metadata = ["lockfile", "dep:reqwest", "dep:serde_json"]
+java-provider = []
+rust-metadata = ["lockfile", "dep:reqwest", "dep:sha2"]
+rust-provider = []
+dotnet-metadata = ["lockfile", "dep:reqwest", "dep:serde_json"]
+dotnet-provider = []
 python-metadata = ["lockfile", "sources", "dep:reqwest", "dep:serde_json"]
 python-provider = ["sources"]
 lockfile = ["node-provider", "go-provider", "flutter-provider", "java-provider", "rust-provider", "dotnet-provider", "python-provider", "dep:atomic-write-file", "dep:base64", "dep:hex"]
@@ -50,7 +50,6 @@ provider-registry = ["dep:hex", "dep:pgp", "dep:serde_json"]
 state-write = ["dep:atomic-write-file", "dep:fs4"]
 sources = [
     "dep:atomic-write-file",
-    "dep:url",
 ]
 
 [dependencies]
@@ -73,7 +72,7 @@ tar = { workspace = true, optional = true }
 tempfile = { workspace = true, optional = true }
 thiserror.workspace = true
 toml.workspace = true
-url = { workspace = true, optional = true }
+url.workspace = true
 uuid = { workspace = true, optional = true }
 xz2 = { workspace = true, optional = true }
 zip = { workspace = true, optional = true }

--- a/crates/pinset-core/src/config.rs
+++ b/crates/pinset-core/src/config.rs
@@ -381,7 +381,10 @@ fn validate_environment_config(config: &ProjectConfig) -> Result<()> {
     }
 
     for (name, task) in &config.tasks {
-        if !valid_task_name(name) || task.command.is_empty() || task.command.iter().any(String::is_empty) {
+        if !valid_task_name(name)
+            || task.command.is_empty()
+            || task.command.iter().any(String::is_empty)
+        {
             return Err(Error::InvalidProjectConfig {
                 reason: format!("task {name} requires a non-empty command array"),
             });
@@ -390,7 +393,14 @@ fn validate_environment_config(config: &ProjectConfig) -> Result<()> {
             let path = Path::new(cwd);
             if path.as_os_str().is_empty()
                 || path.is_absolute()
-                || path.components().any(|component| matches!(component, std::path::Component::ParentDir | std::path::Component::RootDir | std::path::Component::Prefix(_)))
+                || path.components().any(|component| {
+                    matches!(
+                        component,
+                        std::path::Component::ParentDir
+                            | std::path::Component::RootDir
+                            | std::path::Component::Prefix(_)
+                    )
+                })
             {
                 return Err(Error::InvalidProjectConfig {
                     reason: format!("task {name} cwd must stay within the project"),
@@ -399,16 +409,19 @@ fn validate_environment_config(config: &ProjectConfig) -> Result<()> {
         }
     }
     let Some(environment) = &config.environment else {
-        if let Some((name, task)) = config.tasks.iter().find(|(_, task)| task.profile.is_some()) {
+        if let Some((name, _)) = config.tasks.iter().find(|(_, task)| task.profile.is_some()) {
             return Err(Error::InvalidProjectConfig {
-                reason: format!("task {name} references an environment profile, but no environment is declared"),
+                reason: format!(
+                    "task {name} references an environment profile, but no environment is declared"
+                ),
             });
         }
         return Ok(());
     };
     if config.schema < PROJECT_CONFIG_SCHEMA && !environment.variables.is_empty() {
         return Err(Error::InvalidProjectConfig {
-            reason: "environment variable contracts require schema 5; run `pinset migrate`".to_owned(),
+            reason: "environment variable contracts require schema 5; run `pinset migrate`"
+                .to_owned(),
         });
     }
     if let Some(profile) = &environment.auto_profile
@@ -447,20 +460,30 @@ fn validate_environment_config(config: &ProjectConfig) -> Result<()> {
     }
     for (name, contract) in &environment.variables {
         if !valid_environment_variable_name(name) {
-            return Err(Error::InvalidProjectConfig { reason: format!("invalid environment variable name: {name}") });
+            return Err(Error::InvalidProjectConfig {
+                reason: format!("invalid environment variable name: {name}"),
+            });
         }
         if contract.secret && contract.default.is_some() {
-            return Err(Error::InvalidProjectConfig { reason: format!("secret variable {name} cannot declare a default") });
+            return Err(Error::InvalidProjectConfig {
+                reason: format!("secret variable {name} cannot declare a default"),
+            });
         }
         if contract.kind == EnvironmentVariableType::Enum && contract.values.is_empty() {
-            return Err(Error::InvalidProjectConfig { reason: format!("enum variable {name} requires values") });
+            return Err(Error::InvalidProjectConfig {
+                reason: format!("enum variable {name} requires values"),
+            });
         }
         if contract.kind != EnvironmentVariableType::Enum && !contract.values.is_empty() {
-            return Err(Error::InvalidProjectConfig { reason: format!("only enum variable {name} may declare values") });
+            return Err(Error::InvalidProjectConfig {
+                reason: format!("only enum variable {name} may declare values"),
+            });
         }
         for profile in &contract.profiles {
             if !environment.profiles.contains_key(profile) {
-                return Err(Error::InvalidProjectConfig { reason: format!("variable {name} references undeclared profile {profile}") });
+                return Err(Error::InvalidProjectConfig {
+                    reason: format!("variable {name} references undeclared profile {profile}"),
+                });
             }
         }
         if let Some(value) = &contract.default {
@@ -471,7 +494,9 @@ fn validate_environment_config(config: &ProjectConfig) -> Result<()> {
         if let Some(profile) = &task.profile
             && !environment.profiles.contains_key(profile)
         {
-            return Err(Error::InvalidProjectConfig { reason: format!("task {name} references undeclared profile {profile}") });
+            return Err(Error::InvalidProjectConfig {
+                reason: format!("task {name} references undeclared profile {profile}"),
+            });
         }
     }
     Ok(())
@@ -501,8 +526,7 @@ fn serialize_project_config_preserving_comments(
             ));
         }
     }
-    toml::to_string_pretty(normalized)
-        .map_err(|source| Error::SerializeProjectConfig { source })
+    toml::to_string_pretty(normalized).map_err(|source| Error::SerializeProjectConfig { source })
 }
 
 #[cfg(feature = "project-write")]
@@ -518,8 +542,7 @@ fn rewrite_schema_header(original: &str, schema: u32, project_id: Option<&str>) 
                 if after_name[whitespace..].starts_with('=') {
                     let equals = leading + "schema".len() + whitespace;
                     let after_equals = equals + 1;
-                    let value_start = after_equals
-                        + line[after_equals..].len()
+                    let value_start = after_equals + line[after_equals..].len()
                         - line[after_equals..].trim_start().len();
                     let value_end = value_start
                         + line[value_start..]
@@ -561,20 +584,31 @@ pub fn validate_environment_variable_value(
         EnvironmentVariableType::Url => url::Url::parse(value).is_ok_and(|url| url.has_host()),
         EnvironmentVariableType::Enum => contract.values.iter().any(|candidate| candidate == value),
     };
-    if valid { Ok(()) } else { Err(Error::InvalidProjectConfig { reason: format!("variable {name} does not match its declared type") }) }
+    if valid {
+        Ok(())
+    } else {
+        Err(Error::InvalidProjectConfig {
+            reason: format!("variable {name} does not match its declared type"),
+        })
+    }
 }
 
 fn valid_environment_variable_name(name: &str) -> bool {
     let mut bytes = name.bytes();
-    bytes.next().is_some_and(|byte| byte.is_ascii_alphabetic() || byte == b'_')
+    bytes
+        .next()
+        .is_some_and(|byte| byte.is_ascii_alphabetic() || byte == b'_')
         && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
         && !name.eq_ignore_ascii_case("PATH")
         && !name.to_ascii_uppercase().starts_with("PINSET_")
 }
 
 fn valid_task_name(name: &str) -> bool {
-    !name.is_empty() && name.len() <= 64
-        && name.bytes().all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+    !name.is_empty()
+        && name.len() <= 64
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
 }
 
 fn valid_profile_name(name: &str) -> bool {
@@ -975,7 +1009,10 @@ default = "unsafe"
             environment: None,
         };
         save_project_config(&path, &config).expect("save schema four");
-        assert_eq!(load_project_config(&path).expect("load schema four").schema, 4);
+        assert_eq!(
+            load_project_config(&path).expect("load schema four").schema,
+            4
+        );
     }
 
     #[test]

--- a/crates/pinset-core/src/config.rs
+++ b/crates/pinset-core/src/config.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 pub const PROJECT_CONFIG_FILENAME: &str = "pinset.toml";
-pub const PROJECT_CONFIG_SCHEMA: u32 = 4;
+pub const PROJECT_CONFIG_SCHEMA: u32 = 5;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectConfig {
@@ -36,6 +36,8 @@ pub struct ProjectConfig {
     pub policy: ProjectPolicy,
     #[serde(default)]
     pub tools: BTreeMap<String, String>,
+    #[serde(default)]
+    pub tasks: BTreeMap<String, ProjectTask>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub environment: Option<ProjectEnvironment>,
 }
@@ -58,6 +60,53 @@ pub struct ProjectEnvironment {
     pub collision: EnvironmentCollision,
     #[serde(default)]
     pub profiles: BTreeMap<String, EnvironmentProfile>,
+    #[serde(default)]
+    pub variables: BTreeMap<String, EnvironmentVariableContract>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct ProjectTask {
+    pub command: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EnvironmentVariableType {
+    String,
+    Integer,
+    Boolean,
+    Url,
+    Enum,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct EnvironmentVariableContract {
+    #[serde(rename = "type", default = "default_variable_type")]
+    pub kind: EnvironmentVariableType,
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default)]
+    pub secret: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
+    #[serde(default)]
+    pub profiles: Vec<String>,
+    #[serde(default)]
+    pub values: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+const fn default_variable_type() -> EnvironmentVariableType {
+    EnvironmentVariableType::String
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -227,7 +276,7 @@ pub fn load_project_config(path: &Path) -> Result<ProjectConfig> {
             source,
         })?;
 
-    if !matches!(config.schema, 1 | 2 | 3 | PROJECT_CONFIG_SCHEMA) {
+    if !matches!(config.schema, 1 | 2 | 3 | 4 | PROJECT_CONFIG_SCHEMA) {
         return Err(Error::UnsupportedSchema {
             actual: config.schema,
         });
@@ -275,19 +324,20 @@ pub fn create_project_config(directory: &Path) -> Result<PathBuf> {
 
 #[cfg(feature = "project-write")]
 pub fn save_project_config(path: &Path, config: &ProjectConfig) -> Result<()> {
-    if !matches!(config.schema, 1 | 2 | 3 | PROJECT_CONFIG_SCHEMA) {
+    if !matches!(config.schema, 1 | 2 | 3 | 4 | PROJECT_CONFIG_SCHEMA) {
         return Err(Error::UnsupportedSchema {
             actual: config.schema,
         });
     }
     validate_environment_config(config)?;
     let mut normalized = config.clone();
-    normalized.schema = PROJECT_CONFIG_SCHEMA;
+    // Preserve schema 4 until the user explicitly runs `pinset migrate`. Schemas 1-3
+    // keep the established automatic upgrade to schema 4 for compatibility.
+    normalized.schema = if config.schema < 4 { 4 } else { config.schema };
     if normalized.project_id.is_none() {
         normalized.project_id = Some(uuid::Uuid::new_v4().to_string());
     }
-    let serialized = toml::to_string_pretty(&normalized)
-        .map_err(|source| Error::SerializeProjectConfig { source })?;
+    let serialized = serialize_project_config_preserving_comments(path, &normalized)?;
     let mut file =
         AtomicWriteFile::options()
             .open(path)
@@ -304,7 +354,12 @@ pub fn save_project_config(path: &Path, config: &ProjectConfig) -> Result<()> {
 }
 
 fn validate_environment_config(config: &ProjectConfig) -> Result<()> {
-    if config.schema < PROJECT_CONFIG_SCHEMA {
+    if config.schema < PROJECT_CONFIG_SCHEMA && !config.tasks.is_empty() {
+        return Err(Error::InvalidProjectConfig {
+            reason: "tasks require schema 5; run `pinset migrate`".to_owned(),
+        });
+    }
+    if config.schema < 4 {
         if config.project_id.is_some() || config.environment.is_some() {
             return Err(Error::InvalidProjectConfig {
                 reason: "project-id and environment require schema 4".to_owned(),
@@ -317,7 +372,7 @@ fn validate_environment_config(config: &ProjectConfig) -> Result<()> {
         .project_id
         .as_deref()
         .ok_or_else(|| Error::InvalidProjectConfig {
-            reason: "schema 4 requires project-id".to_owned(),
+            reason: format!("schema {} requires project-id", config.schema),
         })?;
     if !valid_project_id(project_id) {
         return Err(Error::InvalidProjectConfig {
@@ -325,9 +380,37 @@ fn validate_environment_config(config: &ProjectConfig) -> Result<()> {
         });
     }
 
+    for (name, task) in &config.tasks {
+        if !valid_task_name(name) || task.command.is_empty() || task.command.iter().any(String::is_empty) {
+            return Err(Error::InvalidProjectConfig {
+                reason: format!("task {name} requires a non-empty command array"),
+            });
+        }
+        if let Some(cwd) = &task.cwd {
+            let path = Path::new(cwd);
+            if path.as_os_str().is_empty()
+                || path.is_absolute()
+                || path.components().any(|component| matches!(component, std::path::Component::ParentDir | std::path::Component::RootDir | std::path::Component::Prefix(_)))
+            {
+                return Err(Error::InvalidProjectConfig {
+                    reason: format!("task {name} cwd must stay within the project"),
+                });
+            }
+        }
+    }
     let Some(environment) = &config.environment else {
+        if let Some((name, task)) = config.tasks.iter().find(|(_, task)| task.profile.is_some()) {
+            return Err(Error::InvalidProjectConfig {
+                reason: format!("task {name} references an environment profile, but no environment is declared"),
+            });
+        }
         return Ok(());
     };
+    if config.schema < PROJECT_CONFIG_SCHEMA && !environment.variables.is_empty() {
+        return Err(Error::InvalidProjectConfig {
+            reason: "environment variable contracts require schema 5; run `pinset migrate`".to_owned(),
+        });
+    }
     if let Some(profile) = &environment.auto_profile
         && !environment.profiles.contains_key(profile)
     {
@@ -362,7 +445,136 @@ fn validate_environment_config(config: &ProjectConfig) -> Result<()> {
             }
         }
     }
+    for (name, contract) in &environment.variables {
+        if !valid_environment_variable_name(name) {
+            return Err(Error::InvalidProjectConfig { reason: format!("invalid environment variable name: {name}") });
+        }
+        if contract.secret && contract.default.is_some() {
+            return Err(Error::InvalidProjectConfig { reason: format!("secret variable {name} cannot declare a default") });
+        }
+        if contract.kind == EnvironmentVariableType::Enum && contract.values.is_empty() {
+            return Err(Error::InvalidProjectConfig { reason: format!("enum variable {name} requires values") });
+        }
+        if contract.kind != EnvironmentVariableType::Enum && !contract.values.is_empty() {
+            return Err(Error::InvalidProjectConfig { reason: format!("only enum variable {name} may declare values") });
+        }
+        for profile in &contract.profiles {
+            if !environment.profiles.contains_key(profile) {
+                return Err(Error::InvalidProjectConfig { reason: format!("variable {name} references undeclared profile {profile}") });
+            }
+        }
+        if let Some(value) = &contract.default {
+            validate_environment_variable_value(name, contract, value)?;
+        }
+    }
+    for (name, task) in &config.tasks {
+        if let Some(profile) = &task.profile
+            && !environment.profiles.contains_key(profile)
+        {
+            return Err(Error::InvalidProjectConfig { reason: format!("task {name} references undeclared profile {profile}") });
+        }
+    }
     Ok(())
+}
+
+#[cfg(feature = "project-write")]
+fn serialize_project_config_preserving_comments(
+    path: &Path,
+    normalized: &ProjectConfig,
+) -> Result<String> {
+    if let Ok(original) = fs::read_to_string(path)
+        && let Ok(mut existing) = toml::from_str::<ProjectConfig>(&original)
+    {
+        let add_project_id = existing.project_id.is_none();
+        existing.schema = normalized.schema;
+        existing.project_id.clone_from(&normalized.project_id);
+        if existing == *normalized {
+            return Ok(rewrite_schema_header(
+                &original,
+                normalized.schema,
+                add_project_id.then_some(
+                    normalized
+                        .project_id
+                        .as_deref()
+                        .expect("normalized project config has a project-id"),
+                ),
+            ));
+        }
+    }
+    toml::to_string_pretty(normalized)
+        .map_err(|source| Error::SerializeProjectConfig { source })
+}
+
+#[cfg(feature = "project-write")]
+fn rewrite_schema_header(original: &str, schema: u32, project_id: Option<&str>) -> String {
+    let mut rewritten = String::with_capacity(original.len() + 64);
+    let mut replaced = false;
+    for line in original.split_inclusive('\n') {
+        if !replaced {
+            let leading = line.len() - line.trim_start().len();
+            let candidate = &line[leading..];
+            if let Some(after_name) = candidate.strip_prefix("schema") {
+                let whitespace = after_name.len() - after_name.trim_start().len();
+                if after_name[whitespace..].starts_with('=') {
+                    let equals = leading + "schema".len() + whitespace;
+                    let after_equals = equals + 1;
+                    let value_start = after_equals
+                        + line[after_equals..].len()
+                        - line[after_equals..].trim_start().len();
+                    let value_end = value_start
+                        + line[value_start..]
+                            .bytes()
+                            .take_while(|byte| byte.is_ascii_digit())
+                            .count();
+                    rewritten.push_str(&line[..value_start]);
+                    rewritten.push_str(&schema.to_string());
+                    rewritten.push_str(&line[value_end..]);
+                    if let Some(project_id) = project_id {
+                        if !line.ends_with('\n') {
+                            rewritten.push('\n');
+                        }
+                        rewritten.push_str(&format!("project-id = \"{project_id}\"\n"));
+                    }
+                    replaced = true;
+                    continue;
+                }
+            }
+        }
+        rewritten.push_str(line);
+    }
+    if replaced {
+        rewritten
+    } else {
+        format!("schema = {schema}\n{rewritten}")
+    }
+}
+
+pub fn validate_environment_variable_value(
+    name: &str,
+    contract: &EnvironmentVariableContract,
+    value: &str,
+) -> Result<()> {
+    let valid = match contract.kind {
+        EnvironmentVariableType::String => true,
+        EnvironmentVariableType::Integer => value.parse::<i64>().is_ok(),
+        EnvironmentVariableType::Boolean => matches!(value, "true" | "false"),
+        EnvironmentVariableType::Url => url::Url::parse(value).is_ok_and(|url| url.has_host()),
+        EnvironmentVariableType::Enum => contract.values.iter().any(|candidate| candidate == value),
+    };
+    if valid { Ok(()) } else { Err(Error::InvalidProjectConfig { reason: format!("variable {name} does not match its declared type") }) }
+}
+
+fn valid_environment_variable_name(name: &str) -> bool {
+    let mut bytes = name.bytes();
+    bytes.next().is_some_and(|byte| byte.is_ascii_alphabetic() || byte == b'_')
+        && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+        && !name.eq_ignore_ascii_case("PATH")
+        && !name.to_ascii_uppercase().starts_with("PINSET_")
+}
+
+fn valid_task_name(name: &str) -> bool {
+    !name.is_empty() && name.len() <= 64
+        && name.bytes().all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
 }
 
 fn valid_profile_name(name: &str) -> bool {
@@ -567,10 +779,98 @@ mod tests {
     fn rejects_unknown_schema() {
         let root = tempdir().expect("temp directory");
         let config_path = root.path().join("pinset.toml");
-        fs::write(&config_path, "schema = 5\n[tools]\nnode = \"20\"\n").expect("config");
+        fs::write(&config_path, "schema = 6\n[tools]\nnode = \"20\"\n").expect("config");
 
         let error = load_project_config(&config_path).expect_err("schema must fail");
-        assert!(matches!(error, Error::UnsupportedSchema { actual: 5 }));
+        assert!(matches!(error, Error::UnsupportedSchema { actual: 6 }));
+    }
+
+    #[test]
+    fn schema_five_validates_tasks_and_variable_contracts() {
+        let root = tempdir().expect("temp directory");
+        let path = root.path().join(PROJECT_CONFIG_FILENAME);
+        fs::write(
+            &path,
+            r#"schema = 5
+project-id = "4c5652e4-0000-4000-8000-000000000004"
+
+[tools]
+
+[tasks.test]
+command = ["cargo", "test"]
+profile = "test"
+
+[environment.profiles.test]
+file = "pinset.env/test.age"
+recipients = ["age1test"]
+
+[environment.variables.PORT]
+type = "integer"
+required = true
+profiles = ["test"]
+
+[environment.variables.MODE]
+type = "enum"
+default = "development"
+values = ["development", "production"]
+"#,
+        )
+        .expect("schema five config");
+
+        let config = load_project_config(&path).expect("valid schema five config");
+        assert_eq!(config.tasks["test"].command, vec!["cargo", "test"]);
+        assert_eq!(
+            config.environment.as_ref().expect("environment").variables["PORT"].kind,
+            EnvironmentVariableType::Integer
+        );
+
+        fs::write(
+            &path,
+            r#"schema = 4
+project-id = "4c5652e4-0000-4000-8000-000000000004"
+[tools]
+[tasks.test]
+command = ["cargo", "test"]
+"#,
+        )
+        .expect("legacy config with task");
+        assert!(matches!(
+            load_project_config(&path),
+            Err(Error::InvalidProjectConfig { .. })
+        ));
+    }
+
+    #[test]
+    fn variable_contracts_reject_invalid_defaults_and_secret_defaults() {
+        let contract = EnvironmentVariableContract {
+            kind: EnvironmentVariableType::Integer,
+            required: false,
+            secret: false,
+            default: None,
+            profiles: Vec::new(),
+            values: Vec::new(),
+            description: None,
+        };
+        assert!(validate_environment_variable_value("PORT", &contract, "42").is_ok());
+        assert!(validate_environment_variable_value("PORT", &contract, "4.2").is_err());
+
+        let root = tempdir().expect("temp directory");
+        let path = root.path().join(PROJECT_CONFIG_FILENAME);
+        fs::write(
+            &path,
+            r#"schema = 5
+project-id = "4c5652e4-0000-4000-8000-000000000005"
+[tools]
+[environment.variables.TOKEN]
+secret = true
+default = "unsafe"
+"#,
+        )
+        .expect("invalid secret default");
+        assert!(matches!(
+            load_project_config(&path),
+            Err(Error::InvalidProjectConfig { .. })
+        ));
     }
 
     #[cfg(feature = "project-write")]
@@ -661,6 +961,23 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "project-write")]
+    #[test]
+    fn saving_schema_four_does_not_enable_schema_five_implicitly() {
+        let root = tempdir().expect("temp directory");
+        let path = root.path().join(PROJECT_CONFIG_FILENAME);
+        let config = ProjectConfig {
+            schema: 4,
+            project_id: Some("4c5652e4-0000-4000-8000-000000000006".to_owned()),
+            policy: ProjectPolicy::default(),
+            tools: BTreeMap::new(),
+            tasks: BTreeMap::new(),
+            environment: None,
+        };
+        save_project_config(&path, &config).expect("save schema four");
+        assert_eq!(load_project_config(&path).expect("load schema four").schema, 4);
+    }
+
     #[test]
     fn parses_optional_provenance_policy_without_changing_schema_three() {
         let root = tempdir().expect("project");
@@ -706,6 +1023,7 @@ mod tests {
             project_id: Some(uuid::Uuid::new_v4().to_string()),
             policy: ProjectPolicy::default(),
             tools: BTreeMap::new(),
+            tasks: BTreeMap::new(),
             environment: None,
         };
         let lockfile = Lockfile {

--- a/crates/pinset-core/src/error.rs
+++ b/crates/pinset-core/src/error.rs
@@ -22,7 +22,9 @@ pub enum Error {
         source: toml::de::Error,
     },
 
-    #[error("unsupported pinset.toml schema {actual}; this version supports schemas 1, 2, 3 and 4")]
+    #[error(
+        "unsupported pinset.toml schema {actual}; this version supports schemas 1, 2, 3, 4 and 5"
+    )]
     UnsupportedSchema { actual: u32 },
 
     #[error("invalid pinset.toml configuration: {reason}")]

--- a/crates/pinset-core/src/lib.rs
+++ b/crates/pinset-core/src/lib.rs
@@ -97,9 +97,11 @@ mod user_settings;
 #[cfg(feature = "lockfile")]
 pub use config::validate_project_lock_policy;
 pub use config::{
-    EnvironmentCollision, EnvironmentProfile, PROJECT_CONFIG_FILENAME, PROJECT_CONFIG_SCHEMA,
-    ProjectBoundary, ProjectConfig, ProjectContext, ProjectEnvironment, ProjectPolicy,
+    EnvironmentCollision, EnvironmentProfile, EnvironmentVariableContract,
+    EnvironmentVariableType, PROJECT_CONFIG_FILENAME, PROJECT_CONFIG_SCHEMA, ProjectBoundary,
+    ProjectConfig, ProjectContext, ProjectEnvironment, ProjectPolicy, ProjectTask,
     find_optional_project_config, find_project_config, find_project_context, load_project_config,
+    validate_environment_variable_value,
 };
 #[cfg(feature = "project-write")]
 pub use config::{create_project_config, save_project_config};

--- a/crates/pinset-core/src/lib.rs
+++ b/crates/pinset-core/src/lib.rs
@@ -97,10 +97,10 @@ mod user_settings;
 #[cfg(feature = "lockfile")]
 pub use config::validate_project_lock_policy;
 pub use config::{
-    EnvironmentCollision, EnvironmentProfile, EnvironmentVariableContract,
-    EnvironmentVariableType, PROJECT_CONFIG_FILENAME, PROJECT_CONFIG_SCHEMA, ProjectBoundary,
-    ProjectConfig, ProjectContext, ProjectEnvironment, ProjectPolicy, ProjectTask,
-    find_optional_project_config, find_project_config, find_project_context, load_project_config,
+    EnvironmentCollision, EnvironmentProfile, EnvironmentVariableContract, EnvironmentVariableType,
+    PROJECT_CONFIG_FILENAME, PROJECT_CONFIG_SCHEMA, ProjectBoundary, ProjectConfig, ProjectContext,
+    ProjectEnvironment, ProjectPolicy, ProjectTask, find_optional_project_config,
+    find_project_config, find_project_context, load_project_config,
     validate_environment_variable_value,
 };
 #[cfg(feature = "project-write")]

--- a/crates/pinset-core/src/lock_audit.rs
+++ b/crates/pinset-core/src/lock_audit.rs
@@ -1309,7 +1309,7 @@ mod tests {
         fs::create_dir(&project).expect("project");
         fs::write(
             project.join(PROJECT_CONFIG_FILENAME),
-            "schema = 4\nproject-id = \"11111111-1111-4111-8111-111111111111\"\n\n[policy]\ninherit-global = false\nsystem-fallback = false\nboundary = \"git\"\n\n[tools]\nnode = \"24.0.0\"\n",
+            "schema = 5\nproject-id = \"11111111-1111-4111-8111-111111111111\"\n\n[policy]\ninherit-global = false\nsystem-fallback = false\nboundary = \"git\"\n\n[tools]\nnode = \"24.0.0\"\n",
         )
         .expect("project config");
         save_lockfile(&project.join("pinset.lock"), &node_lockfile("24.0.0")).expect("lockfile");

--- a/crates/pinset/src/environment.rs
+++ b/crates/pinset/src/environment.rs
@@ -7,8 +7,8 @@ use std::{
 
 use clap::Subcommand;
 use pinset_core::{
-    EnvironmentCollision, EnvironmentProfile, EnvironmentVariableContract, PROJECT_CONFIG_SCHEMA,
-    ProjectConfig, ProjectEnvironment, encode_environment, find_project_config,
+    EnvironmentCollision, EnvironmentProfile, EnvironmentVariableContract, ProjectConfig,
+    ProjectEnvironment, encode_environment, find_project_config,
     load_project_config, pinset_home, save_project_config, validate_environment_variable_value,
 };
 use pinset_env::{
@@ -477,11 +477,14 @@ pub(crate) fn run_env_command(
             let config = load_project_config(&config_path)?;
             let issues = contract_issues(&config, &profile_name, &document.variables);
             if json {
-                print_json("env.check", serde_json::json!({
-                    "profile": profile_name,
-                    "ok": issues.is_empty(),
-                    "issues": issues,
-                }))?;
+                print_json(
+                    "env.check",
+                    serde_json::json!({
+                        "profile": profile_name,
+                        "ok": issues.is_empty(),
+                        "issues": issues,
+                    }),
+                )?;
             } else if issues.is_empty() {
                 println!("environment profile {profile_name} is ready");
             } else {
@@ -496,26 +499,44 @@ pub(crate) fn run_env_command(
                 return Err("environment contract check failed".into());
             }
         }
-        EnvCommands::Diff { left, right, json, cwd } => {
+        EnvCommands::Diff {
+            left,
+            right,
+            json,
+            cwd,
+        } => {
             let cwd = effective_cwd(cwd)?;
             let (config_path, _, _, left_document) = load_profile(&cwd, Some(&left))?;
             let (_, _, _, right_document) = load_profile(&cwd, Some(&right))?;
             let config = load_project_config(&config_path)?;
             let left_names = effective_contract_names(&config, &left, &left_document.variables);
             let right_names = effective_contract_names(&config, &right, &right_document.variables);
-            let only_left = left_names.difference(&right_names).cloned().collect::<Vec<_>>();
-            let only_right = right_names.difference(&left_names).cloned().collect::<Vec<_>>();
+            let only_left = left_names
+                .difference(&right_names)
+                .cloned()
+                .collect::<Vec<_>>();
+            let only_right = right_names
+                .difference(&left_names)
+                .cloned()
+                .collect::<Vec<_>>();
             if json {
-                print_json("env.diff", serde_json::json!({
-                    "left": left, "right": right,
-                    "only_left": only_left, "only_right": only_right,
-                    "equal": only_left.is_empty() && only_right.is_empty(),
-                }))?;
+                print_json(
+                    "env.diff",
+                    serde_json::json!({
+                        "left": left, "right": right,
+                        "only_left": only_left, "only_right": only_right,
+                        "equal": only_left.is_empty() && only_right.is_empty(),
+                    }),
+                )?;
             } else if only_left.is_empty() && only_right.is_empty() {
                 println!("{left} and {right} have the same variable structure");
             } else {
-                for name in only_left { println!("- {left}: {name}"); }
-                for name in only_right { println!("+ {right}: {name}"); }
+                for name in only_left {
+                    println!("- {left}: {name}");
+                }
+                for name in only_right {
+                    println!("+ {right}: {name}");
+                }
             }
         }
         EnvCommands::Reveal { name, profile, cwd } => {
@@ -666,10 +687,19 @@ pub(crate) fn resolve_environment(
     let mut document = read_encrypted_profile(root, &selected.file, &identities)?;
     let issues = contract_issues(&config, profile, &document.variables);
     if !issues.is_empty() {
-        return Err(format!("environment contract check failed: {}", issues.iter().map(|issue| format!("{} {}", issue.name, issue.reason)).collect::<Vec<_>>().join(", ")).into());
+        return Err(format!(
+            "environment contract check failed: {}",
+            issues
+                .iter()
+                .map(|issue| format!("{} {}", issue.name, issue.reason))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+        .into());
     }
     for (name, contract) in &environment.variables {
-        if applies_to_profile(contract, profile) && !contains_case_insensitive(&document.variables, name)
+        if applies_to_profile(contract, profile)
+            && !contains_case_insensitive(&document.variables, name)
             && let Some(default) = &contract.default
         {
             document.variables.insert(name.clone(), default.clone());
@@ -686,23 +716,41 @@ struct ContractIssue {
 }
 
 fn applies_to_profile(contract: &EnvironmentVariableContract, profile: &str) -> bool {
-    contract.profiles.is_empty() || contract.profiles.iter().any(|candidate| candidate == profile)
+    contract.profiles.is_empty()
+        || contract
+            .profiles
+            .iter()
+            .any(|candidate| candidate == profile)
 }
 
 fn contains_case_insensitive(values: &BTreeMap<String, String>, name: &str) -> bool {
     find_case_insensitive(values, name).is_some()
 }
 
-fn contract_issues(config: &ProjectConfig, profile: &str, values: &BTreeMap<String, String>) -> Vec<ContractIssue> {
+fn contract_issues(
+    config: &ProjectConfig,
+    profile: &str,
+    values: &BTreeMap<String, String>,
+) -> Vec<ContractIssue> {
     let mut issues = Vec::new();
-    let Some(environment) = &config.environment else { return issues; };
+    let Some(environment) = &config.environment else {
+        return issues;
+    };
     for (name, contract) in &environment.variables {
-        if !applies_to_profile(contract, profile) { continue; }
+        if !applies_to_profile(contract, profile) {
+            continue;
+        }
         let value = find_case_insensitive(values, name).or(contract.default.as_deref());
         match value {
-            None if contract.required => issues.push(ContractIssue { name: name.clone(), reason: "is required but missing" }),
+            None if contract.required => issues.push(ContractIssue {
+                name: name.clone(),
+                reason: "is required but missing",
+            }),
             Some(value) if validate_environment_variable_value(name, contract, value).is_err() => {
-                issues.push(ContractIssue { name: name.clone(), reason: "has an invalid value" });
+                issues.push(ContractIssue {
+                    name: name.clone(),
+                    reason: "has an invalid value",
+                });
             }
             _ => {}
         }
@@ -710,10 +758,23 @@ fn contract_issues(config: &ProjectConfig, profile: &str, values: &BTreeMap<Stri
     issues
 }
 
-fn effective_contract_names(config: &ProjectConfig, profile: &str, values: &BTreeMap<String, String>) -> BTreeSet<String> {
-    let mut names = values.keys().map(|name| name.to_ascii_uppercase()).collect::<BTreeSet<_>>();
+fn effective_contract_names(
+    config: &ProjectConfig,
+    profile: &str,
+    values: &BTreeMap<String, String>,
+) -> BTreeSet<String> {
+    let mut names = values
+        .keys()
+        .map(|name| name.to_ascii_uppercase())
+        .collect::<BTreeSet<_>>();
     if let Some(environment) = &config.environment {
-        names.extend(environment.variables.iter().filter(|(_, contract)| applies_to_profile(contract, profile)).map(|(name, _)| name.to_ascii_uppercase()));
+        names.extend(
+            environment
+                .variables
+                .iter()
+                .filter(|(_, contract)| applies_to_profile(contract, profile))
+                .map(|(name, _)| name.to_ascii_uppercase()),
+        );
     }
     names
 }
@@ -789,7 +850,9 @@ fn init_profile(
         .ok_or("project configuration has no parent")?;
     let mut config = load_project_config(&config_path)?;
     if config.schema < 4 {
-        return Err("encrypted environments require schema 4 or newer; run `pinset migrate` first".into());
+        return Err(
+            "encrypted environments require schema 4 or newer; run `pinset migrate` first".into(),
+        );
     }
     if config
         .environment
@@ -899,7 +962,9 @@ fn selected_profile(
     let config_path = find_project_config(cwd)?;
     let config = load_project_config(&config_path)?;
     if config.schema < 4 {
-        return Err("encrypted environments require schema 4 or newer; run `pinset migrate` first".into());
+        return Err(
+            "encrypted environments require schema 4 or newer; run `pinset migrate` first".into(),
+        );
     }
     let environment = config
         .environment

--- a/crates/pinset/src/environment.rs
+++ b/crates/pinset/src/environment.rs
@@ -7,9 +7,9 @@ use std::{
 
 use clap::Subcommand;
 use pinset_core::{
-    EnvironmentCollision, EnvironmentProfile, PROJECT_CONFIG_SCHEMA, ProjectConfig,
-    ProjectEnvironment, encode_environment, find_project_config, load_project_config, pinset_home,
-    save_project_config,
+    EnvironmentCollision, EnvironmentProfile, EnvironmentVariableContract, PROJECT_CONFIG_SCHEMA,
+    ProjectConfig, ProjectEnvironment, encode_environment, find_project_config,
+    load_project_config, pinset_home, save_project_config, validate_environment_variable_value,
 };
 use pinset_env::{
     EnvironmentDocument, backup_identity, generate_identity, import_identity, list_identities,
@@ -18,6 +18,7 @@ use pinset_env::{
     trust_project, validate_variable_name, verify_project_trust, write_encrypted_profile,
 };
 use secrecy::{ExposeSecret, SecretString};
+use serde::Serialize;
 use zeroize::Zeroize;
 
 type SelectedProfile = (PathBuf, String, EnvironmentProfile, Vec<SecretString>);
@@ -105,6 +106,24 @@ pub(crate) enum EnvCommands {
     List {
         #[arg(long)]
         profile: Option<String>,
+        #[arg(long)]
+        json: bool,
+        #[arg(long)]
+        cwd: Option<PathBuf>,
+    },
+    /// Validate required values and declared variable types for one profile.
+    Check {
+        #[arg(long)]
+        profile: Option<String>,
+        #[arg(long)]
+        json: bool,
+        #[arg(long)]
+        cwd: Option<PathBuf>,
+    },
+    /// Compare variable names and contracts between two profiles without revealing values.
+    Diff {
+        left: String,
+        right: String,
         #[arg(long)]
         json: bool,
         #[arg(long)]
@@ -229,7 +248,7 @@ pub(crate) enum TrustCommands {
 pub(crate) fn run_env_command(
     command: Option<EnvCommands>,
     default_profile: Option<&str>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<i32, Box<dyn std::error::Error>> {
     let Some(command) = command else {
         let config_path = find_project_config(&env::current_dir()?)?;
         let config = load_project_config(&config_path)?;
@@ -273,7 +292,7 @@ pub(crate) fn run_env_command(
                 }
             );
         }
-        return Ok(());
+        return Ok(0);
     };
     match command {
         EnvCommands::Init {
@@ -451,6 +470,54 @@ pub(crate) fn run_env_command(
                 }
             }
         }
+        EnvCommands::Check { profile, json, cwd } => {
+            let cwd = effective_cwd(cwd)?;
+            let (config_path, profile_name, _, document) =
+                load_profile(&cwd, profile.as_deref().or(default_profile))?;
+            let config = load_project_config(&config_path)?;
+            let issues = contract_issues(&config, &profile_name, &document.variables);
+            if json {
+                print_json("env.check", serde_json::json!({
+                    "profile": profile_name,
+                    "ok": issues.is_empty(),
+                    "issues": issues,
+                }))?;
+            } else if issues.is_empty() {
+                println!("environment profile {profile_name} is ready");
+            } else {
+                for issue in &issues {
+                    println!("{}: {}", issue.name, issue.reason);
+                }
+            }
+            if !issues.is_empty() {
+                if json {
+                    return Ok(1);
+                }
+                return Err("environment contract check failed".into());
+            }
+        }
+        EnvCommands::Diff { left, right, json, cwd } => {
+            let cwd = effective_cwd(cwd)?;
+            let (config_path, _, _, left_document) = load_profile(&cwd, Some(&left))?;
+            let (_, _, _, right_document) = load_profile(&cwd, Some(&right))?;
+            let config = load_project_config(&config_path)?;
+            let left_names = effective_contract_names(&config, &left, &left_document.variables);
+            let right_names = effective_contract_names(&config, &right, &right_document.variables);
+            let only_left = left_names.difference(&right_names).cloned().collect::<Vec<_>>();
+            let only_right = right_names.difference(&left_names).cloned().collect::<Vec<_>>();
+            if json {
+                print_json("env.diff", serde_json::json!({
+                    "left": left, "right": right,
+                    "only_left": only_left, "only_right": only_right,
+                    "equal": only_left.is_empty() && only_right.is_empty(),
+                }))?;
+            } else if only_left.is_empty() && only_right.is_empty() {
+                println!("{left} and {right} have the same variable structure");
+            } else {
+                for name in only_left { println!("- {left}: {name}"); }
+                for name in only_right { println!("+ {right}: {name}"); }
+            }
+        }
         EnvCommands::Reveal { name, profile, cwd } => {
             if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
                 return Err("env reveal requires an interactive terminal".into());
@@ -494,7 +561,7 @@ pub(crate) fn run_env_command(
         EnvCommands::Recipient { command } => run_recipient(command)?,
         EnvCommands::Identity { command } => run_identity(command)?,
     }
-    Ok(())
+    Ok(0)
 }
 
 pub(crate) fn run_trust_command(command: TrustCommands) -> Result<(), Box<dyn std::error::Error>> {
@@ -596,9 +663,59 @@ pub(crate) fn resolve_environment(
         .get(profile)
         .ok_or("selected environment profile is not declared")?;
     let identities = selected_identities(&pinset_home()?)?;
-    let document = read_encrypted_profile(root, &selected.file, &identities)?;
+    let mut document = read_encrypted_profile(root, &selected.file, &identities)?;
+    let issues = contract_issues(&config, profile, &document.variables);
+    if !issues.is_empty() {
+        return Err(format!("environment contract check failed: {}", issues.iter().map(|issue| format!("{} {}", issue.name, issue.reason)).collect::<Vec<_>>().join(", ")).into());
+    }
+    for (name, contract) in &environment.variables {
+        if applies_to_profile(contract, profile) && !contains_case_insensitive(&document.variables, name)
+            && let Some(default) = &contract.default
+        {
+            document.variables.insert(name.clone(), default.clone());
+        }
+    }
     ensure_environment_size(&document.variables)?;
     Ok((environment.collision, document.variables))
+}
+
+#[derive(Debug, Serialize)]
+struct ContractIssue {
+    name: String,
+    reason: &'static str,
+}
+
+fn applies_to_profile(contract: &EnvironmentVariableContract, profile: &str) -> bool {
+    contract.profiles.is_empty() || contract.profiles.iter().any(|candidate| candidate == profile)
+}
+
+fn contains_case_insensitive(values: &BTreeMap<String, String>, name: &str) -> bool {
+    find_case_insensitive(values, name).is_some()
+}
+
+fn contract_issues(config: &ProjectConfig, profile: &str, values: &BTreeMap<String, String>) -> Vec<ContractIssue> {
+    let mut issues = Vec::new();
+    let Some(environment) = &config.environment else { return issues; };
+    for (name, contract) in &environment.variables {
+        if !applies_to_profile(contract, profile) { continue; }
+        let value = find_case_insensitive(values, name).or(contract.default.as_deref());
+        match value {
+            None if contract.required => issues.push(ContractIssue { name: name.clone(), reason: "is required but missing" }),
+            Some(value) if validate_environment_variable_value(name, contract, value).is_err() => {
+                issues.push(ContractIssue { name: name.clone(), reason: "has an invalid value" });
+            }
+            _ => {}
+        }
+    }
+    issues
+}
+
+fn effective_contract_names(config: &ProjectConfig, profile: &str, values: &BTreeMap<String, String>) -> BTreeSet<String> {
+    let mut names = values.keys().map(|name| name.to_ascii_uppercase()).collect::<BTreeSet<_>>();
+    if let Some(environment) = &config.environment {
+        names.extend(environment.variables.iter().filter(|(_, contract)| applies_to_profile(contract, profile)).map(|(name, _)| name.to_ascii_uppercase()));
+    }
+    names
 }
 
 pub(crate) fn write_internal_environment(
@@ -671,8 +788,8 @@ fn init_profile(
         .parent()
         .ok_or("project configuration has no parent")?;
     let mut config = load_project_config(&config_path)?;
-    if config.schema != PROJECT_CONFIG_SCHEMA {
-        return Err("encrypted environments require schema 4; run `pinset migrate` first".into());
+    if config.schema < 4 {
+        return Err("encrypted environments require schema 4 or newer; run `pinset migrate` first".into());
     }
     if config
         .environment
@@ -781,8 +898,8 @@ fn selected_profile(
 ) -> Result<SelectedProfile, Box<dyn std::error::Error>> {
     let config_path = find_project_config(cwd)?;
     let config = load_project_config(&config_path)?;
-    if config.schema != PROJECT_CONFIG_SCHEMA {
-        return Err("encrypted environments require schema 4; run `pinset migrate` first".into());
+    if config.schema < 4 {
+        return Err("encrypted environments require schema 4 or newer; run `pinset migrate` first".into());
     }
     let environment = config
         .environment
@@ -951,7 +1068,7 @@ fn required_project_id(config: &ProjectConfig) -> Result<&str, Box<dyn std::erro
     config
         .project_id
         .as_deref()
-        .ok_or_else(|| "schema 4 project-id is missing".into())
+        .ok_or_else(|| "schema 4 or newer project-id is missing".into())
 }
 
 fn ensure_environment_size(

--- a/crates/pinset/src/environment.rs
+++ b/crates/pinset/src/environment.rs
@@ -8,8 +8,8 @@ use std::{
 use clap::Subcommand;
 use pinset_core::{
     EnvironmentCollision, EnvironmentProfile, EnvironmentVariableContract, ProjectConfig,
-    ProjectEnvironment, encode_environment, find_project_config,
-    load_project_config, pinset_home, save_project_config, validate_environment_variable_value,
+    ProjectEnvironment, encode_environment, find_project_config, load_project_config, pinset_home,
+    save_project_config, validate_environment_variable_value,
 };
 use pinset_env::{
     EnvironmentDocument, backup_identity, generate_identity, import_identity, list_identities,

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -1128,7 +1128,12 @@ fn run(cli: Cli, catalog: Catalog) -> Result<i32, Box<dyn std::error::Error>> {
     if cli.profile.is_some()
         && !matches!(
             cli.command,
-            Some(Commands::Env { .. } | Commands::Run { .. } | Commands::Exec { .. } | Commands::X { .. })
+            Some(
+                Commands::Env { .. }
+                    | Commands::Run { .. }
+                    | Commands::Exec { .. }
+                    | Commands::X { .. }
+            )
         )
     {
         return Err("-e/--profile requires env, run, exec, x, or a command after --".into());
@@ -1377,7 +1382,7 @@ fn run(cli: Cli, catalog: Catalog) -> Result<i32, Box<dyn std::error::Error>> {
         }
         Commands::Venv { command } => run_venv_command(command, catalog)?,
         Commands::Env { command } => {
-            return environment::run_env_command(command, cli.profile.as_deref())
+            return environment::run_env_command(command, cli.profile.as_deref());
         }
         Commands::Trust { command } => environment::run_trust_command(command)?,
         Commands::InternalEnvResolve {
@@ -4895,15 +4900,22 @@ fn run_project_task(
     if config.schema < PROJECT_CONFIG_SCHEMA {
         return Err("project tasks require schema 5; run `pinset migrate --dry-run` and then `pinset migrate`".into());
     }
-    let task = config.tasks.get(task_name)
+    let task = config
+        .tasks
+        .get(task_name)
         .ok_or_else(|| format!("project task {task_name:?} is not declared"))?;
-    let root = config_path.parent().ok_or("project configuration has no parent")?;
+    let root = config_path
+        .parent()
+        .ok_or("project configuration has no parent")?;
     let task_cwd = match &task.cwd {
         Some(relative) => {
             let root = fs::canonicalize(root)?;
             let resolved = fs::canonicalize(root.join(relative))?;
             if !resolved.starts_with(&root) || !resolved.is_dir() {
-                return Err(format!("task {task_name:?} cwd must be an existing directory within the project").into());
+                return Err(format!(
+                    "task {task_name:?} cwd must be an existing directory within the project"
+                )
+                .into());
             }
             resolved
         }
@@ -4911,7 +4923,8 @@ fn run_project_task(
     };
     let mut command = task.command.iter().map(OsString::from).collect::<Vec<_>>();
     command.extend_from_slice(appended);
-    let task_profile = if explicit_profile.is_some() || env::var_os("PINSET_ENV_PROFILE").is_some() {
+    let task_profile = if explicit_profile.is_some() || env::var_os("PINSET_ENV_PROFILE").is_some()
+    {
         explicit_profile
     } else {
         task.profile.as_deref()

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -232,7 +232,7 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// Upgrade project configuration to schema 4 and runtime lock data to schema 3.
+    /// Upgrade project configuration to schema 5 and runtime lock data to schema 3.
     Migrate {
         /// Migrate the global selection state instead of a project.
         #[arg(long, conflicts_with = "cwd")]
@@ -288,6 +288,14 @@ enum Commands {
     Cache {
         #[command(subcommand)]
         command: CacheCommands,
+    },
+    /// Run a named project task from pinset.toml.
+    Run {
+        /// Task name declared under [tasks.<name>].
+        task: String,
+        /// Arguments appended after the task command, normally separated with --.
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        arguments: Vec<OsString>,
     },
     /// Execute through the selected runtime without enabling direct command routing.
     Exec {
@@ -613,6 +621,8 @@ impl EnvCommands {
     fn json_command(&self) -> Option<&'static str> {
         match self {
             Self::List { json: true, .. } => Some("env.list"),
+            Self::Check { json: true, .. } => Some("env.check"),
+            Self::Diff { json: true, .. } => Some("env.diff"),
             Self::Identity {
                 command: environment::IdentityCommands::List { json: true },
             } => Some("env.identity.list"),
@@ -1118,18 +1128,18 @@ fn run(cli: Cli, catalog: Catalog) -> Result<i32, Box<dyn std::error::Error>> {
     if cli.profile.is_some()
         && !matches!(
             cli.command,
-            Some(Commands::Env { .. } | Commands::Exec { .. } | Commands::X { .. })
+            Some(Commands::Env { .. } | Commands::Run { .. } | Commands::Exec { .. } | Commands::X { .. })
         )
     {
-        return Err("-e/--profile requires env, exec, x, or a command after --".into());
+        return Err("-e/--profile requires env, run, exec, x, or a command after --".into());
     }
     if cli.no_env
         && !matches!(
             cli.command,
-            Some(Commands::Exec { .. } | Commands::X { .. })
+            Some(Commands::Run { .. } | Commands::Exec { .. } | Commands::X { .. })
         )
     {
-        return Err("--no-env requires exec, x, or a command after --".into());
+        return Err("--no-env requires run, exec, x, or a command after --".into());
     }
     let Some(command) = cli.command else {
         if let Some(language) = cli.lang {
@@ -1306,6 +1316,16 @@ fn run(cli: Cli, catalog: Catalog) -> Result<i32, Box<dyn std::error::Error>> {
         } => run_prune(cwd, &project, dry_run, json)?,
         Commands::Lock { command } => return run_lock_command(command, catalog),
         Commands::Cache { command } => run_cache(command, catalog)?,
+        Commands::Run { task, arguments } => {
+            return run_project_task(
+                &env::current_dir()?,
+                &task,
+                &arguments,
+                cli.profile.as_deref(),
+                cli.no_env,
+                catalog,
+            );
+        }
         Commands::Exec {
             cwd,
             profile,
@@ -1356,7 +1376,9 @@ fn run(cli: Cli, catalog: Catalog) -> Result<i32, Box<dyn std::error::Error>> {
             }
         }
         Commands::Venv { command } => run_venv_command(command, catalog)?,
-        Commands::Env { command } => environment::run_env_command(command, cli.profile.as_deref())?,
+        Commands::Env { command } => {
+            return environment::run_env_command(command, cli.profile.as_deref())
+        }
         Commands::Trust { command } => environment::run_trust_command(command)?,
         Commands::InternalEnvResolve {
             cwd,
@@ -2750,7 +2772,7 @@ fn run_cache(command: CacheCommands, catalog: Catalog) -> Result<(), Box<dyn std
     Ok(())
 }
 
-const COMPLETION_COMMANDS: &str = "init detect import global use unset install paths which current list outdated update migrate uninstall prune lock cache exec x doctor venv shim env trust activate completions source provider self";
+const COMPLETION_COMMANDS: &str = "init detect import global use unset install paths which current list outdated update migrate uninstall prune lock cache run exec x doctor venv shim env trust activate completions source provider self";
 const COMPLETION_SHELLS: &str = "bash zsh fish powershell";
 const COMPLETION_LOCK_COMMANDS: &str = "audit";
 const COMPLETION_CACHE_COMMANDS: &str = "list info verify repair clean import";
@@ -3623,6 +3645,7 @@ fn load_project_import_state(
             project_id: Some(uuid::Uuid::new_v4().to_string()),
             policy: Default::default(),
             tools: BTreeMap::new(),
+            tasks: BTreeMap::new(),
             environment: None,
         }
     };
@@ -3904,7 +3927,7 @@ fn run_migrate(
                 Some(acquire_project_state_write_lock(&home, &config_path)?)
             };
             let lock_path = lockfile_path(&config_path);
-            let config = load_project_config(&config_path)?;
+            let mut config = load_project_config(&config_path)?;
             let lockfile = load_optional_lockfile_for_target_refresh(&lock_path)?;
             if let Some((lockfile, _)) = &lockfile {
                 validate_lock_matches_tools(lockfile, &config.tools, &config_path)?;
@@ -3922,6 +3945,10 @@ fn run_migrate(
                 target_refresh_tools.clone(),
             );
             if !dry_run {
+                config.schema = PROJECT_CONFIG_SCHEMA;
+                if config.project_id.is_none() {
+                    config.project_id = Some(uuid::Uuid::new_v4().to_string());
+                }
                 if let Some((mut lockfile, legacy_target_tools)) = lockfile {
                     let mut resolver = resolve_locked_tool;
                     refresh_legacy_target_records(
@@ -4853,6 +4880,51 @@ fn print_current(
         );
     }
     Ok(())
+}
+
+fn run_project_task(
+    cwd: &Path,
+    task_name: &str,
+    appended: &[OsString],
+    explicit_profile: Option<&str>,
+    no_environment: bool,
+    catalog: Catalog,
+) -> Result<i32, Box<dyn std::error::Error>> {
+    let config_path = find_project_config(cwd)?;
+    let config = load_project_config(&config_path)?;
+    if config.schema < PROJECT_CONFIG_SCHEMA {
+        return Err("project tasks require schema 5; run `pinset migrate --dry-run` and then `pinset migrate`".into());
+    }
+    let task = config.tasks.get(task_name)
+        .ok_or_else(|| format!("project task {task_name:?} is not declared"))?;
+    let root = config_path.parent().ok_or("project configuration has no parent")?;
+    let task_cwd = match &task.cwd {
+        Some(relative) => {
+            let root = fs::canonicalize(root)?;
+            let resolved = fs::canonicalize(root.join(relative))?;
+            if !resolved.starts_with(&root) || !resolved.is_dir() {
+                return Err(format!("task {task_name:?} cwd must be an existing directory within the project").into());
+            }
+            resolved
+        }
+        None => root.to_path_buf(),
+    };
+    let mut command = task.command.iter().map(OsString::from).collect::<Vec<_>>();
+    command.extend_from_slice(appended);
+    let task_profile = if explicit_profile.is_some() || env::var_os("PINSET_ENV_PROFILE").is_some() {
+        explicit_profile
+    } else {
+        task.profile.as_deref()
+    };
+    execute_selected(
+        &task_cwd,
+        &command,
+        false,
+        task_profile,
+        no_environment,
+        true,
+        catalog,
+    )
 }
 
 fn execute_selected(
@@ -6865,6 +6937,7 @@ mod tests {
                 ("go".to_owned(), "1.24.0".to_owned()),
                 ("node".to_owned(), "22.0.0".to_owned()),
             ]),
+            tasks: BTreeMap::new(),
             environment: None,
         };
         let node = LockedTool {
@@ -7077,6 +7150,7 @@ mod tests {
                 project_id: Some(uuid::Uuid::new_v4().to_string()),
                 policy: Default::default(),
                 tools: BTreeMap::new(),
+                tasks: BTreeMap::new(),
                 environment: None,
             },
         )
@@ -7412,6 +7486,7 @@ mod tests {
                 project_id: Some(uuid::Uuid::new_v4().to_string()),
                 policy: Default::default(),
                 tools: BTreeMap::new(),
+                tasks: BTreeMap::new(),
                 environment: None,
             },
         )

--- a/crates/pinset/tests/environment_cli.rs
+++ b/crates/pinset/tests/environment_cli.rs
@@ -221,7 +221,10 @@ fn environment_contracts_validate_without_revealing_values_and_apply_defaults() 
         .expect("diff environment profiles");
     assert!(diff.status.success());
     let report: serde_json::Value = serde_json::from_slice(&diff.stdout).expect("diff JSON");
-    assert_eq!(report["data"]["only_left"], serde_json::json!(["UNDECLARED"]));
+    assert_eq!(
+        report["data"]["only_left"],
+        serde_json::json!(["UNDECLARED"])
+    );
     assert!(!String::from_utf8_lossy(&diff.stdout).contains("test-secret"));
 
     write_encrypted_profile(
@@ -247,7 +250,10 @@ fn environment_contracts_validate_without_revealing_values_and_apply_defaults() 
     let resolved = broker(&project, &home, identity.secret().expose_secret());
     assert!(resolved.status.success());
     let variables = decode_environment(&resolved.stdout).expect("resolved environment");
-    assert_eq!(variables.get("MODE").map(String::as_str), Some("development"));
+    assert_eq!(
+        variables.get("MODE").map(String::as_str),
+        Some("development")
+    );
     assert_eq!(variables.get("PORT").map(String::as_str), Some("3000"));
 }
 

--- a/crates/pinset/tests/environment_cli.rs
+++ b/crates/pinset/tests/environment_cli.rs
@@ -1,7 +1,8 @@
 use std::{collections::BTreeMap, fs, process::Command};
 
 use pinset_core::{
-    EnvironmentProfile, ProjectConfig, ProjectEnvironment, decode_environment, save_project_config,
+    EnvironmentProfile, EnvironmentVariableContract, EnvironmentVariableType, ProjectConfig,
+    ProjectEnvironment, decode_environment, save_project_config,
 };
 use pinset_env::{EnvironmentDocument, generate_identity, trust_project, write_encrypted_profile};
 use secrecy::ExposeSecret;
@@ -35,6 +36,7 @@ fn hidden_broker_requires_bound_trust_and_returns_only_the_selected_profile() {
             project_id: Some(project_id.to_owned()),
             policy: Default::default(),
             tools: BTreeMap::new(),
+            tasks: BTreeMap::new(),
             environment: Some(environment.clone()),
         },
     )
@@ -81,12 +83,172 @@ fn hidden_broker_requires_bound_trust_and_returns_only_the_selected_profile() {
         project_id: Some(project_id.to_owned()),
         policy: Default::default(),
         tools: BTreeMap::new(),
+        tasks: BTreeMap::new(),
         environment: Some(changed),
     };
     save_project_config(&project.join("pinset.toml"), &changed_config).expect("changed config");
     let invalidated = broker(&project, &home, identity.secret().expose_secret());
     assert!(!invalidated.status.success());
     assert!(!String::from_utf8_lossy(&invalidated.stderr).contains("secret-value"));
+}
+
+#[test]
+fn environment_contracts_validate_without_revealing_values_and_apply_defaults() {
+    let temporary = tempdir().expect("temporary root");
+    let project = temporary.path().join("project");
+    let home = temporary.path().join("home");
+    fs::create_dir(&project).expect("project directory");
+
+    let identity = generate_identity();
+    let recipient = identity.record.recipient.clone();
+    let profiles = ["dev", "test"]
+        .into_iter()
+        .map(|name| {
+            (
+                name.to_owned(),
+                EnvironmentProfile {
+                    file: format!("pinset.env/{name}.age"),
+                    recipients: vec![recipient.clone()],
+                },
+            )
+        })
+        .collect();
+    let environment = ProjectEnvironment {
+        auto_profile: Some("dev".to_owned()),
+        profiles,
+        variables: BTreeMap::from([
+            (
+                "MODE".to_owned(),
+                EnvironmentVariableContract {
+                    kind: EnvironmentVariableType::Enum,
+                    default: Some("development".to_owned()),
+                    values: vec!["development".to_owned(), "production".to_owned()],
+                    required: true,
+                    secret: false,
+                    profiles: Vec::new(),
+                    description: None,
+                },
+            ),
+            (
+                "PORT".to_owned(),
+                EnvironmentVariableContract {
+                    kind: EnvironmentVariableType::Integer,
+                    required: true,
+                    secret: false,
+                    default: None,
+                    profiles: Vec::new(),
+                    values: Vec::new(),
+                    description: None,
+                },
+            ),
+            (
+                "TOKEN".to_owned(),
+                EnvironmentVariableContract {
+                    kind: EnvironmentVariableType::String,
+                    required: true,
+                    secret: true,
+                    default: None,
+                    profiles: Vec::new(),
+                    values: Vec::new(),
+                    description: None,
+                },
+            ),
+        ]),
+        ..ProjectEnvironment::default()
+    };
+    let project_id = "4c5652e4-0000-4000-8000-000000000003";
+    save_project_config(
+        &project.join("pinset.toml"),
+        &ProjectConfig {
+            schema: 5,
+            project_id: Some(project_id.to_owned()),
+            policy: Default::default(),
+            tools: BTreeMap::new(),
+            tasks: BTreeMap::new(),
+            environment: Some(environment.clone()),
+        },
+    )
+    .expect("project config");
+    write_encrypted_profile(
+        &project,
+        "pinset.env/dev.age",
+        &EnvironmentDocument {
+            schema: 1,
+            variables: BTreeMap::from([
+                ("PORT".to_owned(), "not-an-integer".to_owned()),
+                ("UNDECLARED".to_owned(), "must-not-appear".to_owned()),
+            ]),
+        },
+        std::slice::from_ref(&recipient),
+    )
+    .expect("development profile");
+    write_encrypted_profile(
+        &project,
+        "pinset.env/test.age",
+        &EnvironmentDocument {
+            schema: 1,
+            variables: BTreeMap::from([
+                ("PORT".to_owned(), "42".to_owned()),
+                ("TOKEN".to_owned(), "test-secret".to_owned()),
+            ]),
+        },
+        std::slice::from_ref(&recipient),
+    )
+    .expect("test profile");
+
+    let check = Command::new(env!("CARGO_BIN_EXE_pinset"))
+        .current_dir(&project)
+        .env("PINSET_HOME", &home)
+        .env("PINSET_LANG", "en")
+        .env("PINSET_IDENTITY", identity.secret().expose_secret())
+        .args(["env", "check", "--profile", "dev", "--json"])
+        .output()
+        .expect("check environment contract");
+    assert_eq!(check.status.code(), Some(1));
+    let report: serde_json::Value = serde_json::from_slice(&check.stdout).expect("check JSON");
+    assert_eq!(report["data"]["ok"], false);
+    assert_eq!(report["data"]["issues"].as_array().map(Vec::len), Some(2));
+    let output = String::from_utf8_lossy(&check.stdout);
+    assert!(!output.contains("must-not-appear"));
+
+    let diff = Command::new(env!("CARGO_BIN_EXE_pinset"))
+        .current_dir(&project)
+        .env("PINSET_HOME", &home)
+        .env("PINSET_LANG", "en")
+        .env("PINSET_IDENTITY", identity.secret().expose_secret())
+        .args(["env", "diff", "dev", "test", "--json"])
+        .output()
+        .expect("diff environment profiles");
+    assert!(diff.status.success());
+    let report: serde_json::Value = serde_json::from_slice(&diff.stdout).expect("diff JSON");
+    assert_eq!(report["data"]["only_left"], serde_json::json!(["UNDECLARED"]));
+    assert!(!String::from_utf8_lossy(&diff.stdout).contains("test-secret"));
+
+    write_encrypted_profile(
+        &project,
+        "pinset.env/dev.age",
+        &EnvironmentDocument {
+            schema: 1,
+            variables: BTreeMap::from([
+                ("PORT".to_owned(), "3000".to_owned()),
+                ("TOKEN".to_owned(), "development-secret".to_owned()),
+            ]),
+        },
+        std::slice::from_ref(&recipient),
+    )
+    .expect("valid development profile");
+    trust_project(
+        &home,
+        &project,
+        project_id,
+        &toml::to_string(&environment).expect("environment TOML"),
+    )
+    .expect("trust project");
+    let resolved = broker(&project, &home, identity.secret().expose_secret());
+    assert!(resolved.status.success());
+    let variables = decode_environment(&resolved.stdout).expect("resolved environment");
+    assert_eq!(variables.get("MODE").map(String::as_str), Some("development"));
+    assert_eq!(variables.get("PORT").map(String::as_str), Some("3000"));
 }
 
 fn broker(

--- a/crates/pinset/tests/init_cli.rs
+++ b/crates/pinset/tests/init_cli.rs
@@ -18,7 +18,7 @@ fn init_creates_a_minimal_config_without_runtime_side_effects() {
     );
     let config_path = project.join("pinset.toml");
     let config = fs::read_to_string(&config_path).expect("created config");
-    assert!(config.starts_with("schema = 4\nproject-id = \""));
+    assert!(config.starts_with("schema = 5\nproject-id = \""));
     assert!(config.contains("\n[policy]\ninherit-global = false\n"));
     assert!(config.ends_with("\n[tools]\n"));
     assert!(String::from_utf8_lossy(&output.stdout).contains(&config_path.display().to_string()));

--- a/crates/pinset/tests/lock_audit_cli.rs
+++ b/crates/pinset/tests/lock_audit_cli.rs
@@ -115,8 +115,8 @@ fn lock_audit_json_exposes_provenance_policy_reason_codes() {
 
 fn write_project(project: &Path, version: &str) {
     let config = ProjectConfig {
-        schema: 3,
-        project_id: None,
+        schema: 5,
+        project_id: Some("4c5652e4-0000-4000-8000-000000000007".to_owned()),
         policy: Default::default(),
         tools: BTreeMap::from([("node".to_owned(), version.to_owned())]),
         tasks: BTreeMap::new(),

--- a/crates/pinset/tests/lock_audit_cli.rs
+++ b/crates/pinset/tests/lock_audit_cli.rs
@@ -90,6 +90,7 @@ fn lock_audit_json_exposes_provenance_policy_reason_codes() {
         project_id: None,
         policy: Default::default(),
         tools: BTreeMap::from([("node".to_owned(), "24.0.0".to_owned())]),
+        tasks: BTreeMap::new(),
         environment: None,
     };
     config.policy.verification_strength = Some(VerificationStrength::Provenance);
@@ -118,6 +119,7 @@ fn write_project(project: &Path, version: &str) {
         project_id: None,
         policy: Default::default(),
         tools: BTreeMap::from([("node".to_owned(), version.to_owned())]),
+        tasks: BTreeMap::new(),
         environment: None,
     };
     save_project_config(&project.join("pinset.toml"), &config).expect("project config");

--- a/crates/pinset/tests/mvp_cli.rs
+++ b/crates/pinset/tests/mvp_cli.rs
@@ -784,7 +784,7 @@ fn migrate_previews_and_upgrades_schema_two_without_resolving_versions() {
     assert!(
         fs::read_to_string(&config_path)
             .expect("unchanged config")
-            .starts_with("schema = 2")
+            .contains("schema = 2 # schema comment")
     );
 
     let migrated = pinset(&project, &home, &["migrate"]);

--- a/crates/pinset/tests/mvp_cli.rs
+++ b/crates/pinset/tests/mvp_cli.rs
@@ -64,6 +64,7 @@ fn current_keeps_requested_selector_separate_from_locked_version() {
         project_id: None,
         policy: Default::default(),
         tools: BTreeMap::from([("node".to_owned(), "24".to_owned())]),
+        tasks: BTreeMap::new(),
         environment: None,
     };
     save_project_config(&config_path, &config).expect("project config");
@@ -749,7 +750,11 @@ fn migrate_previews_and_upgrades_schema_two_without_resolving_versions() {
     fs::create_dir(&project).expect("project");
     let config_path = project.join("pinset.toml");
     let lock_path = project.join("pinset.lock");
-    fs::write(&config_path, "schema = 2\n\n[tools]\nnode = \"24.0.0\"\n").expect("legacy config");
+    fs::write(
+        &config_path,
+        "# project comment\nschema = 2 # schema comment\n\n[tools]\n# node comment\nnode = \"24.0.0\"\n",
+    )
+    .expect("legacy config");
     let artifacts = MVP_NODE_TARGETS
         .into_iter()
         .map(|target| locked_artifact("24.0.0", target))
@@ -774,7 +779,7 @@ fn migrate_previews_and_upgrades_schema_two_without_resolving_versions() {
         serde_json::from_slice(&preview.stdout).expect("migration preview JSON");
     assert_eq!(preview["data"]["from_config_schema"], 2);
     assert_eq!(preview["data"]["from_lock_schema"], 2);
-    assert_eq!(preview["data"]["to_config_schema"], 4);
+    assert_eq!(preview["data"]["to_config_schema"], 5);
     assert_eq!(preview["data"]["to_lock_schema"], 3);
     assert!(
         fs::read_to_string(&config_path)
@@ -789,9 +794,11 @@ fn migrate_previews_and_upgrades_schema_two_without_resolving_versions() {
         String::from_utf8_lossy(&migrated.stderr)
     );
     let config = fs::read_to_string(config_path).expect("migrated config");
-    assert!(config.starts_with("schema = 4"));
+    assert!(config.contains("schema = 5"));
     assert!(config.contains("project-id = \""));
-    assert!(config.contains("inherit-global = false"));
+    assert!(config.contains("# project comment"));
+    assert!(config.contains("# schema comment"));
+    assert!(config.contains("# node comment"));
     assert!(
         fs::read_to_string(lock_path)
             .expect("migrated lock")
@@ -821,7 +828,8 @@ fn migrate_upgrades_a_config_only_project_without_inventing_a_lockfile() {
         String::from_utf8_lossy(&migrated.stderr)
     );
     let config = fs::read_to_string(config_path).expect("migrated config");
-    assert!(config.starts_with("schema = 4\nproject-id = \""));
+    assert!(config.contains("schema = 5"));
+    assert!(config.contains("project-id = \""));
     assert!(!project.join("pinset.lock").exists());
 }
 
@@ -832,6 +840,7 @@ fn write_project(project: &Path, configured_version: &str, locked_version: &str)
         project_id: None,
         policy: Default::default(),
         tools: BTreeMap::from([("node".to_owned(), configured_version.to_owned())]),
+        tasks: BTreeMap::new(),
         environment: None,
     };
     save_project_config(&config_path, &config).expect("project config");

--- a/crates/pinset/tests/short_execution_cli.rs
+++ b/crates/pinset/tests/short_execution_cli.rs
@@ -1,4 +1,4 @@
-use pinset_core::{EnvironmentProfile, ProjectEnvironment};
+use pinset_core::{EnvironmentProfile, ProjectEnvironment, ProjectTask};
 use pinset_env::{EnvironmentDocument, generate_identity, trust_project, write_encrypted_profile};
 use secrecy::ExposeSecret;
 use std::{
@@ -49,6 +49,28 @@ fn print_variable(cmd: &mut Command) {
         "-c",
         "printf 'profile=%s\\n' \"$APP_TEST_VALUE\"",
     ]);
+}
+
+fn environment_probe_task(profile: &str) -> ProjectTask {
+    #[cfg(windows)]
+    let command = vec![
+        "cmd.exe".to_owned(),
+        "/d".to_owned(),
+        "/c".to_owned(),
+        "echo profile=%APP_TEST_VALUE%".to_owned(),
+    ];
+    #[cfg(not(windows))]
+    let command = vec![
+        "sh".to_owned(),
+        "-c".to_owned(),
+        "printf 'profile=%s\\n' \"$APP_TEST_VALUE\"".to_owned(),
+    ];
+    ProjectTask {
+        command,
+        cwd: None,
+        profile: Some(profile.to_owned()),
+        description: Some("Print the selected test profile".to_owned()),
+    }
 }
 
 #[test]
@@ -130,6 +152,9 @@ fn local_profiles_apply_to_execution_and_broker_with_explicit_and_ci_overrides()
             .collect(),
         ..Default::default()
     });
+    config
+        .tasks
+        .insert("show-profile".to_owned(), environment_probe_task("dev"));
     pinset_core::save_project_config(&config_path, &config).unwrap();
     let original = fs::read(&config_path).unwrap();
     for name in ["dev", "test"] {
@@ -169,6 +194,26 @@ fn local_profiles_apply_to_execution_and_broker_with_explicit_and_ci_overrides()
         &toml::to_string(config.environment.as_ref().unwrap()).unwrap(),
     )
     .unwrap();
+
+    let task_profile = cli(&project, &home)
+        .env("PINSET_IDENTITY", identity.secret().expose_secret())
+        .args(["run", "show-profile"])
+        .output()
+        .unwrap();
+    assert!(success(&task_profile).contains("profile=dev"));
+    let explicit_task_profile = cli(&project, &home)
+        .env("PINSET_IDENTITY", identity.secret().expose_secret())
+        .args(["-e", "test", "run", "show-profile"])
+        .output()
+        .unwrap();
+    assert!(success(&explicit_task_profile).contains("profile=test"));
+    let process_task_profile = cli(&project, &home)
+        .env("PINSET_IDENTITY", identity.secret().expose_secret())
+        .env("PINSET_ENV_PROFILE", "test")
+        .args(["run", "show-profile"])
+        .output()
+        .unwrap();
+    assert!(success(&process_task_profile).contains("profile=test"));
 
     for (flags, ci, process, expected) in [
         (vec![], false, None, "test"),

--- a/crates/pinset/tests/tasks_cli.rs
+++ b/crates/pinset/tests/tasks_cli.rs
@@ -1,0 +1,158 @@
+use std::{
+    collections::BTreeMap,
+    ffi::OsStr,
+    fs,
+    path::Path,
+    process::{Command, Output, Stdio},
+};
+
+use pinset_core::{ProjectConfig, ProjectPolicy, ProjectTask, save_project_config};
+use tempfile::tempdir;
+
+fn cli(root: &Path, home: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_pinset"));
+    command
+        .current_dir(root)
+        .env("PINSET_HOME", home)
+        .env("PINSET_LANG", "en")
+        .stdin(Stdio::null());
+    for name in [
+        "PINSET_ENV_PROFILE",
+        "PINSET_ENV_DISABLE",
+        "CI",
+        "GITHUB_ACTIONS",
+        "GITLAB_CI",
+        "TF_BUILD",
+    ] {
+        command.env_remove(name);
+    }
+    command
+}
+
+fn success(output: &Output) -> String {
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout.clone()).expect("UTF-8 output")
+}
+
+fn task(command: impl IntoIterator<Item = impl AsRef<OsStr>>) -> ProjectTask {
+    ProjectTask {
+        command: command
+            .into_iter()
+            .map(|value| value.as_ref().to_string_lossy().into_owned())
+            .collect(),
+        cwd: None,
+        profile: None,
+        description: None,
+    }
+}
+
+#[test]
+fn named_tasks_preserve_arguments_cwd_and_exit_status_without_path_fallback() {
+    let temporary = tempdir().expect("temporary root");
+    let project = temporary.path().join("project");
+    let home = temporary.path().join("home");
+    let package = project.join("package");
+    fs::create_dir_all(&package).expect("task directory");
+
+    #[cfg(windows)]
+    let argument_task = task([
+        "powershell.exe",
+        "-NoProfile",
+        "-Command",
+        "Write-Output ('arg=' + $args[0])",
+    ]);
+    #[cfg(not(windows))]
+    let argument_task = task(["sh", "-c", "printf 'arg=%s\\n' \"$1\"", "probe"]);
+
+    #[cfg(windows)]
+    let exit_task = task(["cmd.exe", "/d", "/c", "exit 31"]);
+    #[cfg(not(windows))]
+    let exit_task = task(["sh", "-c", "exit 31"]);
+
+    #[cfg(windows)]
+    let mut cwd_task = task(["cmd.exe", "/d", "/c", "cd"]);
+    #[cfg(not(windows))]
+    let mut cwd_task = task(["pwd"]);
+    cwd_task.cwd = Some("package".to_owned());
+
+    let config = ProjectConfig {
+        schema: 5,
+        project_id: Some("4c5652e4-0000-4000-8000-000000000001".to_owned()),
+        policy: ProjectPolicy {
+            system_fallback: true,
+            ..ProjectPolicy::default()
+        },
+        tools: BTreeMap::new(),
+        tasks: BTreeMap::from([
+            ("args".to_owned(), argument_task),
+            ("cwd".to_owned(), cwd_task),
+            ("exit".to_owned(), exit_task),
+            (
+                "version".to_owned(),
+                task([env!("CARGO_BIN_EXE_pinset"), "--version"]),
+            ),
+        ]),
+        environment: None,
+    };
+    save_project_config(&project.join("pinset.toml"), &config).expect("project config");
+
+    let version = cli(&project, &home)
+        .args(["run", "version"])
+        .output()
+        .expect("run version task");
+    assert!(success(&version).contains(pinset_core::pinset_version()));
+
+    let arguments = cli(&project, &home)
+        .args(["run", "args", "--", "watch"])
+        .output()
+        .expect("run task with appended argument");
+    assert!(success(&arguments).contains("arg=watch"));
+
+    let cwd = cli(&project, &home)
+        .args(["run", "cwd"])
+        .output()
+        .expect("run task cwd");
+    let printed_cwd = success(&cwd);
+    assert!(
+        printed_cwd
+            .trim()
+            .eq_ignore_ascii_case(&package.to_string_lossy())
+    );
+
+    let exit = cli(&project, &home)
+        .args(["run", "exit"])
+        .output()
+        .expect("run failing task");
+    assert_eq!(exit.status.code(), Some(31));
+
+    let unknown = cli(&project, &home)
+        .args(["run", "pinset"])
+        .output()
+        .expect("run unknown task");
+    assert!(!unknown.status.success());
+    assert!(String::from_utf8_lossy(&unknown.stderr).contains("is not declared"));
+}
+
+#[test]
+fn task_cwd_cannot_escape_the_project() {
+    let temporary = tempdir().expect("temporary root");
+    let project = temporary.path().join("project");
+    fs::create_dir(&project).expect("project");
+    let config = format!(
+        "schema = 5\nproject-id = \"4c5652e4-0000-4000-8000-000000000002\"\n\n[tasks.bad]\ncommand = [\"{}\", \"--version\"]\ncwd = \"../\"\n\n[tools]\n",
+        env!("CARGO_BIN_EXE_pinset").replace('\\', "\\\\")
+    );
+    fs::write(project.join("pinset.toml"), config).expect("invalid project config");
+
+    let output = cli(&project, &temporary.path().join("home"))
+        .args(["run", "bad"])
+        .output()
+        .expect("run invalid task");
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("cwd must stay within the project"));
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -54,7 +54,7 @@ The tables below repeat exceptional behavior where it matters. Otherwise the com
 | --- | --- |
 | Purpose | Create a minimal project configuration in the current directory. |
 | Syntax and arguments | `pinset init`; no command-specific options. |
-| Modifies state | **Yes.** Creates schema 4 `pinset.toml` with a unique `project-id` and strict project policy; it does not select or install a runtime. |
+| Modifies state | **Yes.** Creates schema 5 `pinset.toml` with a unique `project-id` and strict project policy; it does not select or install a runtime. |
 | Example | `mkdir app && cd app && pinset init` |
 | JSON | No. |
 | Exit | `0` success; `2` if the file cannot be safely created. |
@@ -78,7 +78,7 @@ Recognized selection sources include `.nvmrc`, `.node-version`, `.bun-version`, 
 
 | Field | Description |
 | --- | --- |
-| Purpose | Re-scan and import every safe traditional selection into schema 4 `pinset.toml` and schema 3 `pinset.lock`. |
+| Purpose | Re-scan and import every safe traditional selection into schema 5 `pinset.toml` and schema 3 `pinset.lock`. |
 | Syntax and arguments | `pinset import [--cwd <path>] [--force] [--no-install]`. `--force` replaces only discovered tools whose existing requested selector differs. |
 | Modifies state | **Yes.** Resolves metadata, atomically replaces the lock file and then the config file, and installs all project selections by default. `--no-install` skips runtime archives and Python `.venv`, but still resolves and locks metadata. |
 | Example | `pinset import --no-install` |
@@ -202,7 +202,7 @@ Import never reads installed state from another runtime manager, executes manage
 
 | Field | Description |
 | --- | --- |
-| Purpose | Validate and rewrite schema 1–3 project configuration as schema 4 while retaining schema 3 runtime locks. It also repairs safely recognized pre-1.0 Provider records at their existing exact versions. Use `--global` to migrate an old global lock manually. |
+| Purpose | Validate and rewrite schema 1–4 project configuration as schema 5 while retaining schema 3 runtime locks. Schema-only changes preserve comments and use atomic replacement. It also repairs safely recognized pre-1.0 Provider records at their existing exact versions. Use `--global` to migrate an old global lock manually. |
 | Syntax and arguments | `pinset migrate [--global | --cwd <path>] [--dry-run] [--json]`. |
 | Modifies state | **Yes**, unless `--dry-run`; normalizes the config and lock with atomic per-file replacement only. |
 | Example | `pinset migrate --cwd ./app --dry-run` |
@@ -633,7 +633,13 @@ pinset --no-env -- node app.js
 
 Put Pinset options before the top-level `--`; everything after it belongs to the child, including `--json`, `--lang`, and further `--` separators. `-C` / `--cwd` changes the invocation directory before project discovery. `-e` / `--profile` overrides the profile for execution or ordinary environment operations; it cannot be combined with `--no-env`. Legacy subcommand `--cwd` and `--profile` remain valid, with subcommand options taking precedence over root options.
 
-The short entry resolves managed commands, project Python environment commands, explicit executable paths, then other commands on the system PATH. A configured but broken runtime is an error; it cannot silently fall back to a system version. Arbitrary commands require the explicit `--` boundary: `pinset typo` remains an error. Commands are argument arrays, not shell expressions; invoke a shell explicitly when shell syntax is needed. The existing `exec` and `x` syntax, runtime-only resolution, and child exit behavior remain available. Named tasks (`pinset run`) are planned for 2.3 and are not included here.
+The short entry resolves managed commands, project Python environment commands, explicit executable paths, then other commands on the system PATH. A configured but broken runtime is an error; it cannot silently fall back to a system version. Arbitrary commands require the explicit `--` boundary: `pinset typo` remains an error. Commands are argument arrays, not shell expressions; invoke a shell explicitly when shell syntax is needed. The existing `exec` and `x` syntax, runtime-only resolution, and child exit behavior remain available.
+
+### `run`
+
+`pinset run <task> [-- <arguments...>]` executes a task declared under `[tasks.<name>]`. A task contains a nonempty `command` string array and may add a project-relative `cwd`, a `profile`, and a human-readable `description`. Arguments after `--` are appended without shell parsing. The task's child exit status is preserved.
+
+Task environment selection uses root `-e`, then `PINSET_ENV_PROFILE`, then the task profile, then machine-local and project defaults. `--no-env` disables injection. A missing task is always an error and never falls back to a system program. Task working directories must already exist within the project after canonical path resolution.
 
 The initialization wizard chooses a profile, recovery setup, and a new or existing device identity. After creating the profile it saves a local preference and asks separately whether to trust the project. A fully explicit `env init` keeps the existing behavior: use `--auto` for a shared default or `env use` for a local one. No new project or lock schema is introduced.
 
@@ -668,7 +674,7 @@ Pinset manages project-scoped string environment variables in independent [age](
 The normal first-computer workflow is:
 
 ```sh
-# Existing schema 1–3 projects only; a new `pinset init` project is already schema 4.
+# Existing schema 1–4 projects only; a new `pinset init` project is already schema 5.
 pinset migrate
 
 # Creates pinset.env/development.age, a device identity, and an encrypted recovery identity.
@@ -706,10 +712,10 @@ The `[environment].collision` policy is case-insensitive and defaults to `error`
 | --- | --- |
 | Purpose | Create one empty encrypted profile, a device age X25519 identity, and normally a separate recovery identity. |
 | Syntax and arguments | `pinset env init [<name> \| --profile <name>] [--auto] [--recovery <path> \| --no-recovery] [--identity-file <path> \| --identity <id>] [--cwd <path>]`. Missing profile or recovery choice opens an interactive wizard. Noninteractive setup must supply both choices; `--identity` reuses a stored device identity. `--identity-file` stores the device identity in a passphrase-protected file instead of the system keyring. |
-| Modifies state | **Yes.** Creates `pinset.env/<profile>.age`, updates schema 4 `pinset.toml`, stores the device identity, and may create a recovery file. `--auto` sets this profile as `auto-profile`. |
+| Modifies state | **Yes.** Creates `pinset.env/<profile>.age`, updates a schema 4 or 5 `pinset.toml`, stores the device identity, and may create a recovery file. `--auto` sets this profile as `auto-profile`. |
 | Example | `pinset env init --profile ci --recovery ~/pinset-ci-recovery.age` |
 | JSON | No. |
-| Key errors | Project is not schema 4, profile/file already exists, invalid profile name, unavailable keyring, unsafe path, existing recovery output, or encryption/write failure. A final configuration-write failure removes the new ciphertext; an identity or recovery file created earlier in the operation may remain and should be reviewed. |
+| Key errors | Project is older than schema 4, profile/file already exists, invalid profile name, unavailable keyring, unsafe path, existing recovery output, or encryption/write failure. A final configuration-write failure removes the new ciphertext; an identity or recovery file created earlier in the operation may remain and should be reviewed. |
 
 Use `--no-recovery` only when another tested identity-backup procedure exists. On Linux/SSH systems without a usable keyring, use `--identity-file <path>` and set `PINSET_IDENTITY_FILE` to that protected file for later interactive commands.
 
@@ -747,6 +753,38 @@ Portable names match `[A-Za-z_][A-Za-z0-9_]*`. Names are unique ignoring ASCII c
 | Example | `pinset env list --profile ci --json` |
 | JSON | **Yes**; command name `env.list`, with `profile` and `names`. Values are never included. |
 | Key errors | No selected profile, missing matching identity, unsafe/damaged ciphertext, or unsupported profile schema. |
+
+### Environment variable contracts
+
+Schema 5 can declare expected structure without storing secret values in `pinset.toml`:
+
+```toml
+[environment.variables.DATABASE_URL]
+type = "url"
+required = true
+secret = true
+profiles = ["development", "test"]
+
+[environment.variables.PORT]
+type = "integer"
+default = "3000"
+
+[environment.variables.MODE]
+type = "enum"
+required = true
+default = "development"
+values = ["development", "production"]
+```
+
+Types are `string`, `integer`, `boolean`, `url`, and `enum`. Boolean values are exactly `true` or `false`; URLs require a host; enums require at least one allowed value. Secret contracts cannot declare defaults. Contracts are checked before injection, and applicable non-secret defaults are added only when the encrypted profile does not contain that name.
+
+### `env check`
+
+`pinset env check [--profile <name>] [--json] [--cwd <path>]` decrypts one profile in memory and reports missing required variables or invalid declared types. It exits `0` when ready, `1` after a complete check with contract issues, and `2` when checking cannot start. JSON uses command `env.check`, returns `data.ok` and issue names/reasons, and never includes values or value hashes.
+
+### `env diff`
+
+`pinset env diff <left> <right> [--json] [--cwd <path>]` compares case-insensitive variable names and applicable contract names. It reports only names present on one side. JSON uses command `env.diff`; values and value-derived hashes are never emitted.
 
 ### `env reveal`
 
@@ -932,9 +970,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.2.0
+      - uses: Future-Element/pinset@v2.3.0
         with:
-          version: 2.2.0
+          version: 2.3.0
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js
@@ -952,6 +990,6 @@ Self updates use a cross-process lock and a 60-second HTTP timeout. Windows repl
 
 ## Stable protocol boundary
 
-Pinset v2.0 writes schema 4 project configuration and schema 3 global configuration/runtime locks. Schema 1–3 projects remain readable and are migrated explicitly. Installation receipts use independent schema 3 while schema 1/2 receipts remain readable. Project `[policy]` accepts optional `verification-strength = "checksum" | "signed-checksum" | "provenance"` and `minimum-release-age = "<positive integer><d|h|m|s>"`. New locks may record the optional upstream `released-at` timestamp. A configured policy is enforced during state writes, project installation, updates including dry runs, and lock audits; unavailable release time fails closed, and replacing an existing tool lock with weaker verification is rejected.
+Pinset v2.3 writes schema 5 project configuration and schema 3 global configuration/runtime locks. Schema 1–4 projects remain readable and are migrated explicitly. Existing schema 4 encrypted environments continue to operate before migration. Installation receipts use independent schema 3 while schema 1/2 receipts remain readable. Project `[policy]` accepts optional `verification-strength = "checksum" | "signed-checksum" | "provenance"` and `minimum-release-age = "<positive integer><d|h|m|s>"`. New locks may record the optional upstream `released-at` timestamp. A configured policy is enforced during state writes, project installation, updates including dry runs, and lock audits; unavailable release time fails closed, and replacing an existing tool lock with weaker verification is rejected.
 
 The JSON schema 1 envelope remains unchanged in v2.0. New JSON commands include `paths`, `env.list`, `env.identity.list`, `trust.status`, and `self.outdated`. Automation should branch on stable command and reason/code fields, not human-facing messages. JSON output and errors never include environment values, identities, or passphrases.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -8,7 +8,7 @@
 
 ### 选择器与作用域
 
-选择表达式格式为 `<tool>@<selector>`，例如 `node@22`、`pnpm@latest`、`java@lts` 或 `rust@stable`。schema 4 项目配置会保留这个请求选择器，schema 3 锁文件记录精确解析版本。
+选择表达式格式为 `<tool>@<selector>`，例如 `node@22`、`pnpm@latest`、`java@lts` 或 `rust@stable`。schema 4 与 5 项目配置会保留这个请求选择器，schema 3 锁文件记录精确解析版本。
 
 支持的工具为 Node.js、pnpm、Bun、Go、Python、Java、Rust、.NET 和 Flutter。Dart 由所选 Flutter SDK 提供。项目发现默认在最近的 Git 根目录停止；没有 Git 标记时只检查起始目录。项目默认严格：未声明工具不会继承全局状态，也不会回退系统命令；只有 `[policy]` 显式启用 `inherit-global` 或 `system-fallback` 时才允许。项目之外仍按全局状态、系统 `PATH` 的顺序解析。
 
@@ -54,7 +54,7 @@
 | --- | --- |
 | 用途 | 在当前目录创建最小项目配置。 |
 | 语法与参数 | `pinset init`；没有命令专属选项。 |
-| 修改状态 | **是。** 创建包含唯一 `project-id` 与严格项目策略的 schema 4 `pinset.toml`，但不选择或安装运行时。 |
+| 修改状态 | **是。** 创建包含唯一 `project-id` 与严格项目策略的 schema 5 `pinset.toml`，但不选择或安装运行时。 |
 | 示例 | `mkdir app && cd app && pinset init` |
 | JSON | 不支持。 |
 | 退出码 | 成功为 `0`；无法安全创建文件为 `2`。 |
@@ -78,7 +78,7 @@
 
 | 字段 | 说明 |
 | --- | --- |
-| 用途 | 重新扫描，并把所有可安全映射的传统选择导入 schema 4 `pinset.toml` 与 schema 3 `pinset.lock`。 |
+| 用途 | 重新扫描，并把所有可安全映射的传统选择导入 schema 5 `pinset.toml` 与 schema 3 `pinset.lock`。 |
 | 语法与参数 | `pinset import [--cwd <目录>] [--force] [--no-install]`。`--force` 只替换本次发现且现有请求选择器不同的工具。 |
 | 修改状态 | **是。** 解析元数据，先锁文件、后配置分别进行原子文件替换，并默认安装项目全部选择。`--no-install` 跳过运行时归档和 Python `.venv`，但仍解析并锁定元数据。 |
 | 示例 | `pinset import --no-install` |
@@ -202,7 +202,7 @@
 
 | 字段 | 说明 |
 | --- | --- |
-| 用途 | 验证并把 schema 1–3 项目配置重写为 schema 4，同时保持运行时锁为 schema 3；还会按原精确版本修复可安全识别的 pre-1.0 Provider 记录。使用 `--global` 可手动迁移旧的全局锁。 |
+| 用途 | 验证并把 schema 1–4 项目配置重写为 schema 5，同时保持运行时锁为 schema 3；只涉及 schema 的变更会保留注释并原子替换文件。还会按原精确版本修复可安全识别的 pre-1.0 Provider 记录。使用 `--global` 可手动迁移旧的全局锁。 |
 | 语法与参数 | `pinset migrate [--global | --cwd <path>] [--dry-run] [--json]`。 |
 | 修改状态 | **是**，但 `--dry-run` 时不修改；仅以逐文件原子替换方式规范化配置与锁。 |
 | 示例 | `pinset migrate --cwd ./app --dry-run` |
@@ -633,7 +633,13 @@ pinset --no-env -- node app.js
 
 Pinset 参数放在顶层 `--` 之前，之后的全部内容都传给子进程，包括 `--json`、`--lang` 和后续 `--`。`-C` / `--cwd` 在项目查找之前设置本次执行目录。`-e` / `--profile` 临时覆盖执行或常用环境操作的 profile，不能与 `--no-env` 同用。原有子命令上的 `--cwd`、`--profile` 保留，子命令参数优先于顶层参数。
 
-短入口支持受管命令、项目 Python 环境命令、明确的可执行文件路径，以及系统 PATH 中的其他程序。已配置但损坏的运行时会报错，不会绕过配置使用系统版本。任意程序必须经过明确的 `--` 边界，`pinset typo` 仍会报错。参数按数组传递，不作为 Shell 表达式解析；需要 Shell 语法时显式调用 Shell。原有 `exec`、`x` 的语法、运行时命令解析和子进程退出行为保留。具名任务 `pinset run` 属于 2.3，当前未实现。
+短入口支持受管命令、项目 Python 环境命令、明确的可执行文件路径，以及系统 PATH 中的其他程序。已配置但损坏的运行时会报错，不会绕过配置使用系统版本。任意程序必须经过明确的 `--` 边界，`pinset typo` 仍会报错。参数按数组传递，不作为 Shell 表达式解析；需要 Shell 语法时显式调用 Shell。原有 `exec`、`x` 的语法、运行时命令解析和子进程退出行为保留。
+
+### `run`
+
+`pinset run <任务> [-- <追加参数...>]` 执行 `[tasks.<名称>]` 中声明的任务。任务包含非空 `command` 字符串数组，还可声明项目内相对 `cwd`、`profile` 和说明 `description`。`--` 后的参数不经过 Shell 解析，直接追加到命令数组；子进程退出状态保持不变。
+
+任务环境按根参数 `-e`、`PINSET_ENV_PROFILE`、任务 profile、本机选择、项目默认值依次选择。`--no-env` 关闭注入。任务不存在时始终报错，不会回退执行系统程序。任务工作目录经过规范化后必须已经存在并位于项目内。
 
 `env init` 未指定 profile 或恢复方式时进入交互向导：选择 profile、恢复方式、新建或复用本机 identity。创建成功后记住本机环境，并单独询问是否信任项目。非交互调用必须提供 profile 和 `--recovery <路径>` 或显式 `--no-recovery`。新增位置参数 `env init dev` 和 `--identity <id>`，原有 `--profile`、`--identity-file` 保留；完全显式的初始化仍需用 `--auto` 设置共享默认，或另行 `env use` 设置本机默认。项目配置与锁文件 schema 不变。
 
@@ -668,7 +674,7 @@ Pinset 用相互独立的 [age](https://age-encryption.org/) 密文 profile 管�
 第一台电脑的常规流程如下：
 
 ```sh
-# 仅现有 schema 1–3 项目需要；新的 `pinset init` 项目已是 schema 4。
+# 仅现有 schema 1–4 项目需要；新的 `pinset init` 项目已是 schema 5。
 pinset migrate
 
 # 创建 pinset.env/development.age、设备身份和已加密的恢复身份。
@@ -706,10 +712,10 @@ Profile 名称限制为 1–64 位 ASCII 字母、数字、点、下划线或短
 | --- | --- |
 | 用途 | 创建一个空的加密 profile、一个设备 age X25519 identity，通常还会创建独立恢复 identity。 |
 | 语法与参数 | `pinset env init [<名称> \| --profile <名称>] [--auto] [--recovery <路径> \| --no-recovery] [--identity-file <路径> \| --identity <id>] [--cwd <路径>]`。`--identity-file` 会把设备 identity 保存到口令保护文件，而非系统密钥库。 |
-| 修改状态 | **是。** 创建 `pinset.env/<profile>.age`、更新 schema 4 `pinset.toml`、保存设备 identity，并可能创建恢复文件。`--auto` 把该 profile 设为 `auto-profile`。 |
+| 修改状态 | **是。** 创建 `pinset.env/<profile>.age`、更新 schema 4 或 5 的 `pinset.toml`、保存设备 identity，并可能创建恢复文件。`--auto` 把该 profile 设为 `auto-profile`。 |
 | 示例 | `pinset env init --profile ci --recovery ~/pinset-ci-recovery.age` |
 | JSON | 不支持。 |
-| 关键错误 | 项目不是 schema 4、profile/文件已存在、profile 名无效、密钥库不可用、路径不安全、恢复输出已存在或加密/写入失败。最后配置写入失败时会删除新密文；操作前面已创建的 identity 或恢复文件可能仍保留，需人工检查。 |
+| 关键错误 | 项目早于 schema 4、profile/文件已存在、profile 名无效、密钥库不可用、路径不安全、恢复输出已存在或加密/写入失败。最后配置写入失败时会删除新密文；操作前面已创建的 identity 或恢复文件可能仍保留，需人工检查。 |
 
 只有在已有其他经过验证的 identity 备份方案时才使用 `--no-recovery`。在没有可用系统密钥库的 Linux/SSH 环境中，使用 `--identity-file <路径>`，后续交互命令通过 `PINSET_IDENTITY_FILE` 指向该受保护文件。
 
@@ -747,6 +753,38 @@ Profile 名称限制为 1–64 位 ASCII 字母、数字、点、下划线或短
 | 示例 | `pinset env list --profile ci --json` |
 | JSON | **支持。** 命令名为 `env.list`，包含 `profile` 和 `names`，永远不包含值。 |
 | 关键错误 | 没有选中 profile、没有匹配 identity、密文不安全/已损坏或 profile schema 不支持。 |
+
+### 环境变量契约
+
+schema 5 可以声明环境结构，而不在 `pinset.toml` 中保存密钥值：
+
+```toml
+[environment.variables.DATABASE_URL]
+type = "url"
+required = true
+secret = true
+profiles = ["development", "test"]
+
+[environment.variables.PORT]
+type = "integer"
+default = "3000"
+
+[environment.variables.MODE]
+type = "enum"
+required = true
+default = "development"
+values = ["development", "production"]
+```
+
+类型包括 `string`、`integer`、`boolean`、`url` 和 `enum`。布尔值必须为 `true` 或 `false`，URL 必须包含主机，枚举至少声明一个允许值。密钥变量不能声明默认值。Pinset 会在注入前检查契约；仅当密文 profile 中缺少同名变量时，才补入适用的非密钥默认值。
+
+### `env check`
+
+`pinset env check [--profile <名称>] [--json] [--cwd <路径>]` 在内存中解密一个 profile，并报告缺少的必填变量或类型错误。就绪时退出码为 `0`，完成检查但存在契约问题时为 `1`，无法开始检查时为 `2`。JSON 命令名为 `env.check`，在 `data.ok` 与问题列表中返回变量名和原因，不包含变量值或由变量值生成的摘要。
+
+### `env diff`
+
+`pinset env diff <左侧> <右侧> [--json] [--cwd <路径>]` 按不区分大小写的变量名及适用契约名比较两个 profile，只报告单侧存在的名称。JSON 命令名为 `env.diff`，不会输出变量值或值摘要。
 
 ### `env reveal`
 
@@ -932,9 +970,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.2.0
+      - uses: Future-Element/pinset@v2.3.0
         with:
-          version: 2.2.0
+          version: 2.3.0
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js
@@ -952,6 +990,6 @@ Action 输入不是秘密，也不保存 identity。Pinset 会在子进程启动
 
 ## 稳定协议边界
 
-Pinset v2.0 写入 schema 4 项目配置，以及 schema 3 全局配置/运行时锁。schema 1–3 项目仍可读取，并通过显式迁移升级。安装收据独立使用 schema 3，同时继续读取 schema 1/2。项目 `[policy]` 支持可选的 `verification-strength = "checksum" | "signed-checksum" | "provenance"` 和 `minimum-release-age = "<正整数><d|h|m|s>"`；新锁可以记录可选的上游 `released-at`。配置策略会在状态写入、项目安装、包括 dry-run 在内的更新和锁审计中执行；缺少发布时间会失败关闭，已有工具锁也不允许被更弱验证静默替换。
+Pinset v2.3 写入 schema 5 项目配置，以及 schema 3 全局配置/运行时锁。schema 1–4 项目仍可读取，并通过显式迁移升级；现有 schema 4 加密环境在迁移前继续可用。安装收据独立使用 schema 3，同时继续读取 schema 1/2。项目 `[policy]` 支持可选的 `verification-strength = "checksum" | "signed-checksum" | "provenance"` 和 `minimum-release-age = "<正整数><d|h|m|s>"`；新锁可以记录可选的上游 `released-at`。配置策略会在状态写入、项目安装、包括 dry-run 在内的更新和锁审计中执行；缺少发布时间会失败关闭，已有工具锁也不允许被更弱验证静默替换。
 
 v2.0 不修改 JSON schema 1 外层结构。新增 JSON 命令包括 `paths`、`env.list`、`env.identity.list`、`trust.status` 与 `self.outdated`。自动化应依据稳定的 command 与 reason/code 字段分支，不要匹配面向用户的消息；JSON 输出和错误绝不包含环境变量值、身份或口令。

--- a/examples/devcontainer/.devcontainer/Dockerfile
+++ b/examples/devcontainer/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
-ARG PINSET_VERSION=2.2.0
+ARG PINSET_VERSION=2.3.0
 
 RUN set -eux; \
     architecture="$(dpkg --print-architecture)"; \

--- a/examples/devcontainer/.devcontainer/devcontainer.json
+++ b/examples/devcontainer/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-        "PINSET_VERSION": "2.2.0"
+        "PINSET_VERSION": "2.3.0"
     }
   },
   "postCreateCommand": "pinset install --locked",

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string] $Version = '2.2.0',
+    [string] $Version = '2.3.0',
     [string] $InstallDir = (Join-Path $env:LOCALAPPDATA 'Pinset\bin')
 )
 

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="2.2.0"
+DEFAULT_VERSION="2.3.0"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -22,7 +22,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 2.2.0.
+  --version VERSION       Install an exact release, for example 2.3.0.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.

--- a/schemas/pinset.schema.json
+++ b/schemas/pinset.schema.json
@@ -7,7 +7,7 @@
   "additionalProperties": false,
   "required": ["schema", "project-id", "tools"],
   "properties": {
-    "schema": { "const": 4 },
+    "schema": { "const": 5 },
     "project-id": {
       "type": "string",
       "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
@@ -43,6 +43,29 @@
         "dotnet": { "$ref": "#/$defs/selector" }
       }
     },
+    "tasks": {
+      "type": "object",
+      "propertyNames": { "$ref": "#/$defs/taskName" },
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["command"],
+        "properties": {
+          "command": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "cwd": {
+            "type": "string",
+            "minLength": 1,
+            "not": { "pattern": "(^|[\\\\/])\\.\\.([\\\\/]|$)" }
+          },
+          "profile": { "$ref": "#/$defs/profileName" },
+          "description": { "type": "string" }
+        }
+      }
+    },
     "environment": {
       "type": "object",
       "additionalProperties": false,
@@ -69,6 +92,36 @@
               }
             }
           }
+        },
+        "variables": {
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^(?!PATH$)(?!PINSET_)[A-Za-z_][A-Za-z0-9_]*$"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "enum": ["string", "integer", "boolean", "url", "enum"],
+                "default": "string"
+              },
+              "required": { "type": "boolean", "default": false },
+              "secret": { "type": "boolean", "default": false },
+              "default": { "type": "string" },
+              "profiles": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": { "$ref": "#/$defs/profileName" }
+              },
+              "values": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": { "type": "string" }
+              },
+              "description": { "type": "string" }
+            }
+          }
         }
       }
     }
@@ -76,6 +129,12 @@
   "$defs": {
     "selector": { "type": "string", "minLength": 1 },
     "profileName": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[A-Za-z0-9._-]+$"
+    },
+    "taskName": {
       "type": "string",
       "minLength": 1,
       "maxLength": 64,

--- a/scripts/tests/environment_wizard_test.py
+++ b/scripts/tests/environment_wizard_test.py
@@ -134,7 +134,7 @@ with tempfile.TemporaryDirectory(prefix="pinset-wizard-") as temporary:
         ("[y/N]: ", "y"),
     ])
     config = tomllib.loads((project / "pinset.toml").read_text())
-    assert config["schema"] == 4
+    assert config["schema"] == 5
     assert "auto-profile" not in config["environment"]
     assert len(config["environment"]["profiles"]["dev"]["recipients"]) == 2
     assert identity.is_file() and recovery.is_file()

--- a/website/lib/site.ts
+++ b/website/lib/site.ts
@@ -16,7 +16,7 @@ export const siteConfig = {
   titleEn: "Pinset — Polyglot Runtime Version Manager",
   descriptionZh: "Pinset 是面向多语言项目的运行时版本管理器，用一份配置与锁文件管理 Node.js、Python、Rust、Go、Java、.NET、Flutter 等工具链。",
   descriptionEn: "Pinset is a runtime version manager for polyglot projects, using one configuration and lockfile for Node.js, Python, Rust, Go, Java, .NET, Flutter, and more.",
-  contentUpdatedAt: "2026-08-31T00:00:00.000Z",
+  contentUpdatedAt: "2026-09-07T00:00:00.000Z",
 };
 
 export type Locale = "zh-CN" | "en";

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pinset-website",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "packageManager": "pnpm@10.15.0",
   "scripts": {


### PR DESCRIPTION
Schema 4 projects cannot save repeatable commands or describe the variables required by each environment, so developers must repeat long invocations and discover configuration errors only after a child process starts. This change introduces schema 5 project tasks and typed environment contracts while keeping schema 1-4 readable and preserving existing schema 4 encrypted-environment behavior.

- Add `pinset run <task> -- <arguments...>` with argument arrays, project-relative directories, task profiles, descriptions, exact child exit propagation, and no unknown-task PATH fallback.
- Add string, integer, boolean, URL, and enum variable contracts with required/profile/default rules; reject defaults for secrets and validate before injection.
- Add value-free `env check` and `env diff` text/JSON reports.
- Keep schema 4 until explicit migration, preserve TOML comments for schema-only upgrades, and use the existing atomic project-state transaction.
- Synchronize schema, bilingual documentation, installers, Action, Dev Container, website metadata, and version 2.3.0.

Validation is intentionally delegated to GitHub Actions under the repository contribution policy. The PR adds core and cross-platform CLI regressions for task arguments, working directories, exit status, profile precedence, unknown tasks, contract failures, secret-safe reports, defaults, schema compatibility, and comment-preserving migration.
