### PR TITLE
Fix historical schema 3 migrations in 2.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 2.11.1 - 2026-09-08
+
+- Restore the schema 3 selector contract for every built-in runtime Provider. Historical locks may keep selectors such as `lts`, `latest`, a major version, or a channel in `requested` while recording the exact resolved release in `version`.
+- Allow project/global migration and self-update compatibility repair to read those valid schema 3 locks, while continuing to reject selector mismatches in schema 1/2, configuration/lock disagreements, unknown Providers, malformed artifacts, and unsupported target gaps.
+- Add regression coverage for Node.js, pnpm, Bun, Go, Flutter, Python, Java, Rust, and .NET SDK selectors, every pre-1.0 Linux ARM64 target refresh, and the reported `pinset migrate --global` path.
+
+No configuration or lock schema changes are introduced. Explicit migration still upgrades schema 3 locks to schema 4 atomically and preserves both the requested selector and exact resolved version.
+
 ## 2.11.0 - 2026-09-08
 
 - Add portable `status` and strict `check` diagnostics, redacted report schema 1, saved-report comparison, repair previews, and verified GitHub Action cache restores.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2734,7 +2734,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "atomic-write-file",
  "clap",
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "atomic-write-file",
  "base64",
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-env"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "age",
  "atomic-write-file",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.97"
-version = "2.11.0"
+version = "2.11.1"
 authors = ["Future Element"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ export PATH="$HOME/.local/bin:$PATH"
 Install an exact version or choose another directory:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.11.0
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.11.1
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -106,7 +106,7 @@ Remove-Item .\install.ps1
 Install an exact version:
 
 ```powershell
-.\install.ps1 -Version 2.11.0
+.\install.ps1 -Version 2.11.1
 ```
 
 Windows and WSL are separate environments and require separate installations. The installer registers Pinset and every built-in command route, but it does not pre-download language runtimes.
@@ -311,9 +311,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.11.0
+      - uses: Future-Element/pinset@v2.11.1
         with:
-          version: 2.11.0
+          version: 2.11.1
           install: "true"
           cache: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
@@ -507,7 +507,7 @@ Pinset verifies the signed Registry, exact release asset URLs, upstream SHA-256 
 
 ### VS Code integration
 
-The [Pinset VS Code extension](editors/vscode/README.md) is released as `pinset-vscode-1.0.0.vsix` with Pinset 2.11.0. It reads the versioned `pinset editor context --json` protocol and provides per-folder status, diagnostics, environment selection, declared tasks, and cancellable task terminals in single-root and multi-root workspaces:
+The [Pinset VS Code extension](editors/vscode/README.md) is released as `pinset-vscode-1.0.0.vsix` with Pinset 2.11.1. It reads the versioned `pinset editor context --json` protocol and provides per-folder status, diagnostics, environment selection, declared tasks, and cancellable task terminals in single-root and multi-root workspaces:
 
 ```sh
 code --install-extension pinset-vscode-1.0.0.vsix

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -91,7 +91,7 @@ export PATH="$HOME/.local/bin:$PATH"
 安装指定版本或目录：
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.11.0
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.11.1
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -106,7 +106,7 @@ Remove-Item .\install.ps1
 指定版本：
 
 ```powershell
-.\install.ps1 -Version 2.11.0
+.\install.ps1 -Version 2.11.1
 ```
 
 Windows 与 WSL 是两个独立环境，需要分别安装。安装器只安装 Pinset 和所有内置命令路由，不会预先下载语言运行时。
@@ -311,9 +311,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.11.0
+      - uses: Future-Element/pinset@v2.11.1
         with:
-          version: 2.11.0
+          version: 2.11.1
           install: "true"
           cache: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
@@ -507,7 +507,7 @@ Pinset 在路由命令前验证 Registry 签名、精确 Release 制品 URL、�
 
 ### VS Code 集成
 
-[Pinset VS Code 扩展](editors/vscode/README.md)随 Pinset 2.11.0 提供 `pinset-vscode-1.0.0.vsix`。扩展读取版本化的 `pinset editor context --json` 协议，在单根和多根工作区中按文件夹显示状态、诊断与环境选择，并提供已声明任务和可取消的任务终端：
+[Pinset VS Code 扩展](editors/vscode/README.md)随 Pinset 2.11.1 提供 `pinset-vscode-1.0.0.vsix`。扩展读取版本化的 `pinset editor context --json` 协议，在单根和多根工作区中按文件夹显示状态、诊断与环境选择，并提供已声明任务和可取消的任务终端：
 
 ```sh
 code --install-extension pinset-vscode-1.0.0.vsix

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   version:
     description: Exact Pinset release version without the leading v.
     required: false
-    default: 2.11.0
+    default: 2.11.1
   install:
     description: Run pinset install --locked after Pinset is available.
     required: false

--- a/crates/pinset-core/src/lockfile.rs
+++ b/crates/pinset-core/src/lockfile.rs
@@ -445,7 +445,10 @@ fn validate_lockfile_with_target_policy(
             });
         }
         validate_locked_tool_with_target_policy(tool, target_policy)?;
-        if lockfile.schema < LOCKFILE_SCHEMA && tool.requested != tool.version {
+        // Schema 3 introduced independent requested selectors (for example,
+        // `bun = "latest"`) while keeping the resolved version exact in the lock.
+        // Only schema 1/2 require the two values to be identical.
+        if lockfile.schema < 3 && tool.requested != tool.version {
             return Err(Error::InvalidLockfile {
                 reason: format!(
                     "schema {} requires {} requested and resolved versions to match",
@@ -1743,33 +1746,88 @@ mod tests {
     }
 
     #[test]
+    fn schema_three_provider_refresh_accepts_selectors_for_every_legacy_matrix() {
+        let root = tempdir().expect("temp directory");
+        let path = root.path().join(LOCKFILE_FILENAME);
+
+        for (name, requested) in [
+            ("node", "24"),
+            ("pnpm", "11"),
+            ("bun", "latest"),
+            ("go", "1.25"),
+            ("python", "3.14"),
+            ("java", "21"),
+            ("rust", "stable"),
+            ("dotnet", "10.0"),
+        ] {
+            let mut tool = locked_current_provider_tool(name);
+            tool.requested = requested.to_owned();
+            tool.artifacts
+                .retain(|artifact| artifact.target != "linux-aarch64");
+            if name == "node" {
+                tool.metadata.clear();
+                for artifact in &mut tool.artifacts {
+                    artifact.verification = "nodejs-shasums-https".to_owned();
+                }
+            } else if name == "java" {
+                tool.metadata.remove("signature_link.linux-aarch64");
+            }
+            let legacy = Lockfile {
+                schema: 3,
+                generated_by: "pinset 2.1.6".to_owned(),
+                tools: vec![tool],
+            };
+            fs::write(&path, toml::to_string_pretty(&legacy).expect("legacy TOML"))
+                .expect("legacy lockfile");
+
+            load_lockfile(&path).expect_err("strict loader rejects the old matrix");
+            let (loaded, refresh_tools) = load_lockfile_for_provider_refresh(&path)
+                .unwrap_or_else(|error| panic!("refresh loader rejected {name}: {error}"));
+            assert_eq!(refresh_tools, [name]);
+            assert_eq!(loaded.tools[0].requested, requested);
+        }
+    }
+
+    #[test]
     fn schema_three_separates_requested_selector_from_resolved_version() {
-        let artifacts = MVP_NODE_TARGETS
-            .into_iter()
-            .map(locked_artifact)
-            .collect::<Vec<_>>();
-        let mut lockfile = Lockfile::new_node(
-            "pinset 1.5.0".to_owned(),
-            "24.0.0".to_owned(),
-            "5BE8A3F6C8A5C01D106C0AD820B1A390B168D356".to_owned(),
-            "official".to_owned(),
-            artifacts,
-        );
-        lockfile.tools[0].requested = "24".to_owned();
+        for (name, requested) in [
+            ("node", "24"),
+            ("pnpm", "11"),
+            ("bun", "latest"),
+            ("go", "1.25"),
+            ("flutter", "stable"),
+            ("python", "3.14"),
+            ("java", "21"),
+            ("rust", "stable"),
+            ("dotnet", "10.0"),
+        ] {
+            let mut tool = locked_current_provider_tool(name);
+            tool.requested = requested.to_owned();
+            let resolved = tool.version.clone();
+            let mut lockfile = Lockfile {
+                schema: 3,
+                generated_by: "pinset 1.5.0".to_owned(),
+                tools: vec![tool],
+            };
 
-        validate_lockfile(&lockfile).expect("schema 3 accepts a selector");
-        assert_eq!(
-            validate_lock_matches_selection(&lockfile, "24", Path::new("pinset.toml"))
-                .expect("selector matches")
-                .version,
-            "24.0.0"
-        );
+            validate_lockfile(&lockfile)
+                .unwrap_or_else(|error| panic!("schema 3 rejected {name} selector: {error}"));
+            assert_eq!(
+                validate_lock_matches_tool(&lockfile, name, requested, Path::new("pinset.toml"),)
+                    .unwrap_or_else(|error| panic!("{name} selector mismatch: {error}"))
+                    .version,
+                resolved
+            );
 
-        lockfile.schema = 2;
-        assert!(matches!(
-            validate_lockfile(&lockfile),
-            Err(Error::InvalidLockfile { .. })
-        ));
+            lockfile.schema = 2;
+            assert!(
+                matches!(
+                    validate_lockfile(&lockfile),
+                    Err(Error::InvalidLockfile { .. })
+                ),
+                "schema 2 unexpectedly accepted {name} selector"
+            );
+        }
     }
 
     #[test]
@@ -2254,6 +2312,23 @@ mod tests {
                 artifacts: GO_TARGETS
                     .into_iter()
                     .map(|target| locked_go_artifact("1.25.1", target))
+                    .collect(),
+            },
+            "flutter" => LockedTool {
+                name: "flutter".to_owned(),
+                requested: "3.47.0".to_owned(),
+                version: "3.47.0".to_owned(),
+                provider: "flutter-official".to_owned(),
+                released_at: None,
+                metadata: BTreeMap::from([
+                    ("channel".to_owned(), "stable".to_owned()),
+                    ("dart_version".to_owned(), "3.13.0".to_owned()),
+                    ("release_hash".to_owned(), "cd".repeat(20)),
+                ]),
+                options: Default::default(),
+                artifacts: FLUTTER_TARGETS
+                    .into_iter()
+                    .map(|target| locked_flutter_artifact("3.47.0", target))
                     .collect(),
             },
             "python" => LockedTool {

--- a/crates/pinset/src/main.rs
+++ b/crates/pinset/src/main.rs
@@ -9664,7 +9664,7 @@ mod tests {
             .retain(|artifact| artifact.target != "linux-aarch64");
         java.metadata.remove("signature_link.linux-aarch64");
         let legacy_lock = Lockfile {
-            schema: pinset_core::LOCKFILE_SCHEMA,
+            schema: 3,
             generated_by: "pinset 2.1.4".to_owned(),
             tools: vec![java],
         };

--- a/crates/pinset/tests/multi_provider_cli.rs
+++ b/crates/pinset/tests/multi_provider_cli.rs
@@ -1,10 +1,78 @@
 use std::{
+    collections::BTreeMap,
     fs,
     path::{Path, PathBuf},
     process::{Command, Output},
 };
 
 use tempfile::tempdir;
+
+#[test]
+fn migrates_a_schema_three_global_bun_selector() {
+    let root = tempdir().expect("root");
+    let project = root.path().join("project");
+    let home = root.path().join("home");
+    let state = home.join("state");
+    fs::create_dir(&project).expect("project");
+    fs::create_dir_all(&state).expect("global state");
+    fs::write(
+        state.join("global.toml"),
+        "schema = 2\n\n[tools]\nbun = \"latest\"\n",
+    )
+    .expect("historical global config");
+
+    let version = "1.3.14";
+    let artifacts = pinset_core::BUN_TARGETS
+        .iter()
+        .map(|target| {
+            let package_base = target.package.rsplit('/').next().expect("npm package name");
+            let artifact_path = format!("{}/-/{package_base}-{version}.tgz", target.package);
+            pinset_core::LockedArtifact {
+                target: target.target.to_owned(),
+                canonical_url: format!("https://registry.npmjs.org/{artifact_path}"),
+                artifact_path,
+                sha256: String::new(),
+                integrity: Some(format!("sha512:{}", "ab".repeat(64))),
+                format: pinset_core::LockedArtifactFormat::TarGz,
+                archive_root: "package".to_owned(),
+                verification: "npm-registry-signature-sha512".to_owned(),
+                overlays: Vec::new(),
+            }
+        })
+        .collect();
+    let historical_lock = pinset_core::Lockfile {
+        schema: 3,
+        generated_by: "pinset 2.1.6".to_owned(),
+        tools: vec![pinset_core::LockedTool {
+            name: "bun".to_owned(),
+            requested: "latest".to_owned(),
+            version: version.to_owned(),
+            provider: "bun-npm".to_owned(),
+            released_at: None,
+            metadata: BTreeMap::new(),
+            options: BTreeMap::new(),
+            artifacts,
+        }],
+    };
+    fs::write(
+        state.join("global.lock"),
+        toml::to_string_pretty(&historical_lock).expect("historical lock TOML"),
+    )
+    .expect("historical global lock");
+
+    let migrated = pinset(&project, &home, &["migrate", "--global"]);
+    assert_success_contains(&migrated, "lock-schema=3 -> 4");
+
+    let config = pinset_core::load_global_config(&state.join("global.toml"))
+        .expect("migrated global config");
+    assert_eq!(config.schema, pinset_core::GLOBAL_STATE_SCHEMA);
+    assert_eq!(config.tools["bun"], "latest");
+    let lock =
+        pinset_core::load_lockfile(&state.join("global.lock")).expect("migrated global lock");
+    assert_eq!(lock.schema, pinset_core::LOCKFILE_SCHEMA);
+    assert_eq!(lock.tool("bun").expect("Bun lock").requested, "latest");
+    assert_eq!(lock.tool("bun").expect("Bun lock").version, version);
+}
 
 #[test]
 fn resolves_lists_and_executes_pnpm_with_its_declared_node_dependency() {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1108,9 +1108,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.11.0
+      - uses: Future-Element/pinset@v2.11.1
         with:
-          version: 2.11.0
+          version: 2.11.1
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -1108,9 +1108,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.11.0
+      - uses: Future-Element/pinset@v2.11.1
         with:
-          version: 2.11.0
+          version: 2.11.1
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -8,7 +8,7 @@ Configure `pinset.executablePath` when `pinset` is not available on the extensio
 
 ## Install
 
-Download `pinset-vscode-1.0.0.vsix` from the Pinset 2.11.0 GitHub Release, then run:
+Download `pinset-vscode-1.0.0.vsix` from the Pinset 2.11.1 GitHub Release, then run:
 
 ```sh
 code --install-extension pinset-vscode-1.0.0.vsix

--- a/examples/devcontainer/.devcontainer/Dockerfile
+++ b/examples/devcontainer/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
-ARG PINSET_VERSION=2.11.0
+ARG PINSET_VERSION=2.11.1
 
 RUN set -eux; \
     architecture="$(dpkg --print-architecture)"; \

--- a/examples/devcontainer/.devcontainer/devcontainer.json
+++ b/examples/devcontainer/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-        "PINSET_VERSION": "2.11.0"
+        "PINSET_VERSION": "2.11.1"
     }
   },
   "postCreateCommand": "pinset install --locked",

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string] $Version = '2.11.0',
+    [string] $Version = '2.11.1',
     [string] $InstallDir = (Join-Path $env:LOCALAPPDATA 'Pinset\bin')
 )
 

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="2.11.0"
+DEFAULT_VERSION="2.11.1"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -22,7 +22,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 2.11.0.
+  --version VERSION       Install an exact release, for example 2.11.1.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pinset-website",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "private": true,
   "packageManager": "pnpm@10.15.0",
   "scripts": {


### PR DESCRIPTION
A schema 4 validation guard accidentally applied the schema 1/2 equality rule to historical schema 3 locks. A valid state such as `bun = "latest"` resolving to `1.3.14` was rejected before `pinset migrate --global` could upgrade it.

This restores the schema 3 selector contract for every built-in runtime Provider, keeps schema 1/2 and artifact validation strict, and releases the fix as 2.11.1. Migration regression coverage includes all nine built-in runtimes, every pre-1.0 Linux ARM64 refresh Provider, the reported global command, and a copied real multi-Provider global state.

Validation:
- Docker Rust 1.97: fmt, Clippy with `-D warnings`, and all workspace tests with all features
- `scripts/tests/integrations_test.py`
- copied real schema 3 global state migrated atomically to schema 4 while preserving all selectors and exact versions