### PR TITLE
Pinset 2.12.2: remove GitHub API from self update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2.12.2 - 2026-09-11
+
+- Remove GitHub REST API usage from self-update version discovery. Stable checks resolve GitHub's public `releases/latest` redirect, while prerelease checks read the repository's Atom release feed; exact-version updates continue to download release assets directly.
+
 ## 2.12.1 - 2026-09-09
 
 - Prefer native artifacts from each runtime project's official release archive. Python now installs supported python.org full ZIPs, component MSI bundles, and historical monolithic MSIs directly, falling back to a compatible distribution only when the official archive has no native artifact for the current target.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2740,7 +2740,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinset-cli"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
  "atomic-write-file",
  "clap",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-core"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
  "atomic-write-file",
  "base64",
@@ -2797,7 +2797,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-env"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
  "age",
  "atomic-write-file",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "pinset-shim"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
  "pinset-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.97"
-version = "2.12.1"
+version = "2.12.2"
 authors = ["Future Element"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ export PATH="$HOME/.local/bin:$PATH"
 Install an exact version or choose another directory:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.12.1
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.12.2
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -114,7 +114,7 @@ Remove-Item .\install.ps1
 Install an exact version:
 
 ```powershell
-.\install.ps1 -Version 2.12.1
+.\install.ps1 -Version 2.12.2
 ```
 
 Windows and WSL are separate environments and require separate installations. The installer registers Pinset and every built-in command route, but it does not pre-download language runtimes.
@@ -319,9 +319,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.12.1
+      - uses: Future-Element/pinset@v2.12.2
         with:
-          version: 2.12.1
+          version: 2.12.2
           install: "true"
           cache: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
@@ -359,7 +359,7 @@ pinset self update
 pinset migrate --global
 ```
 
-`self update` checks `PINSET_HOME/state/global.lock` before downloading and safely migrates known pre-1.0 records for Node.js, pnpm, Bun, Go, Python, Java, Rust, and .NET SDK at their existing exact versions. Flutter's target matrix is unchanged. Unknown or corrupted lock shapes are rejected instead of guessed.
+`self outdated` and `self update` discover published versions through GitHub's public Release redirect or Atom feed without calling the rate-limited GitHub REST API. `self update` checks `PINSET_HOME/state/global.lock` before downloading and safely migrates known pre-1.0 records for Node.js, pnpm, Bun, Go, Python, Java, Rust, and .NET SDK at their existing exact versions. Flutter's target matrix is unchanged. Unknown or corrupted lock shapes are rejected instead of guessed.
 
 `doctor --deep` and installation receipt checks validate layout, critical entries, and statistics. They do not claim cryptographic verification of every installed file.
 
@@ -515,7 +515,7 @@ Pinset verifies the signed Registry, exact release asset URLs, upstream SHA-256 
 
 ### VS Code integration
 
-The [Pinset VS Code extension](editors/vscode/README.md) is released as `pinset-vscode-1.0.0.vsix` with Pinset 2.12.1. It reads the versioned `pinset editor context --json` protocol and provides per-folder status, diagnostics, environment selection, declared tasks, and cancellable task terminals in single-root and multi-root workspaces:
+The [Pinset VS Code extension](editors/vscode/README.md) is released as `pinset-vscode-1.0.0.vsix` with Pinset 2.12.2. It reads the versioned `pinset editor context --json` protocol and provides per-folder status, diagnostics, environment selection, declared tasks, and cancellable task terminals in single-root and multi-root workspaces:
 
 ```sh
 code --install-extension pinset-vscode-1.0.0.vsix

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,7 +99,7 @@ export PATH="$HOME/.local/bin:$PATH"
 安装指定版本或目录：
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.12.1
+curl -fsSL https://raw.githubusercontent.com/Future-Element/pinset/main/install.sh | sh -s -- --version 2.12.2
 PINSET_INSTALL_DIR=/opt/pinset/bin sh install.sh
 ```
 
@@ -114,7 +114,7 @@ Remove-Item .\install.ps1
 指定版本：
 
 ```powershell
-.\install.ps1 -Version 2.12.1
+.\install.ps1 -Version 2.12.2
 ```
 
 Windows 与 WSL 是两个独立环境，需要分别安装。安装器只安装 Pinset 和所有内置命令路由，不会预先下载语言运行时。
@@ -319,9 +319,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.12.1
+      - uses: Future-Element/pinset@v2.12.2
         with:
-          version: 2.12.1
+          version: 2.12.2
           install: "true"
           cache: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
@@ -359,7 +359,7 @@ pinset self update
 pinset migrate --global
 ```
 
-`self update` 会在下载前检查 `PINSET_HOME/state/global.lock`，并按原精确版本安全迁移 Node.js、pnpm、Bun、Go、Python、Java、Rust 与 .NET SDK 的已知 pre-1.0 记录。Flutter 的目标矩阵未变化。未知或损坏的锁结构会被拒绝，不会猜测迁移。
+`self outdated` 和 `self update` 通过 GitHub 公共 Release 重定向或 Atom 订阅发现已发布版本，不会调用有频率限制的 GitHub REST API。`self update` 会在下载前检查 `PINSET_HOME/state/global.lock`，并按原精确版本安全迁移 Node.js、pnpm、Bun、Go、Python、Java、Rust 与 .NET SDK 的已知 pre-1.0 记录。Flutter 的目标矩阵未变化。未知或损坏的锁结构会被拒绝，不会猜测迁移。
 
 `doctor --deep` 和安装收据验证的是安装布局、关键入口和统计信息，不宣称对每个已安装文件进行密码学验证。
 
@@ -515,7 +515,7 @@ Pinset 在路由命令前验证 Registry 签名、精确 Release 制品 URL、�
 
 ### VS Code 集成
 
-[Pinset VS Code 扩展](editors/vscode/README.md)随 Pinset 2.12.1 提供 `pinset-vscode-1.0.0.vsix`。扩展读取版本化的 `pinset editor context --json` 协议，在单根和多根工作区中按文件夹显示状态、诊断与环境选择，并提供已声明任务和可取消的任务终端：
+[Pinset VS Code 扩展](editors/vscode/README.md)随 Pinset 2.12.2 提供 `pinset-vscode-1.0.0.vsix`。扩展读取版本化的 `pinset editor context --json` 协议，在单根和多根工作区中按文件夹显示状态、诊断与环境选择，并提供已声明任务和可取消的任务终端：
 
 ```sh
 code --install-extension pinset-vscode-1.0.0.vsix

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   version:
     description: Exact Pinset release version without the leading v.
     required: false
-    default: 2.12.1
+    default: 2.12.2
   install:
     description: Run pinset install --locked after Pinset is available.
     required: false

--- a/crates/pinset/src/self_update.rs
+++ b/crates/pinset/src/self_update.rs
@@ -6,20 +6,18 @@ use std::{
     time::Duration,
 };
 
-use reqwest::blocking::Client;
+use reqwest::{Url, blocking::Client};
 use semver::Version;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
-const API: &str = "https://api.github.com/repos/Future-Element/pinset";
+const LATEST_RELEASE: &str = "https://github.com/Future-Element/pinset/releases/latest";
+const RELEASE_FEED: &str = "https://github.com/Future-Element/pinset/releases.atom";
+const RELEASE_TAG_PATH: &str = "/Future-Element/pinset/releases/tag/";
+const RELEASE_TAG_URL: &str = "https://github.com/Future-Element/pinset/releases/tag/";
 const RELEASES: &str = "https://github.com/Future-Element/pinset/releases/download";
 const MAX_ASSET_BYTES: u64 = 128 * 1024 * 1024;
-
-#[derive(Debug, Deserialize)]
-struct Release {
-    tag_name: String,
-    draft: bool,
-}
+const MAX_RELEASE_FEED_BYTES: u64 = 1024 * 1024;
 
 #[derive(Debug, Deserialize)]
 struct SelfUpdateResult {
@@ -31,9 +29,8 @@ struct SelfUpdateResult {
 
 pub(crate) fn outdated(prerelease: bool, json: bool) -> Result<(), Box<dyn std::error::Error>> {
     report_previous_result()?;
-    let latest = latest_release(prerelease)?;
+    let available = latest_release(prerelease)?;
     let current = Version::parse(pinset_core::pinset_version())?;
-    let available = parse_tag(&latest.tag_name)?;
     let is_outdated = available > current;
     if json {
         println!(
@@ -65,7 +62,7 @@ where
     let current = Version::parse(pinset_core::pinset_version())?;
     let version = match requested {
         Some(value) => Version::parse(value.trim_start_matches('v'))?,
-        None => parse_tag(&latest_release(false)?.tag_name)?,
+        None => latest_release(false)?,
     };
     if version < current {
         return Err(format!("refusing to downgrade Pinset from {current} to {version}").into());
@@ -92,26 +89,48 @@ where
     )
 }
 
-fn latest_release(prerelease: bool) -> Result<Release, Box<dyn std::error::Error>> {
+fn latest_release(prerelease: bool) -> Result<Version, Box<dyn std::error::Error>> {
     let client = client()?;
     if !prerelease {
-        let response = client
-            .get(format!("{API}/releases/latest"))
-            .send()?
-            .error_for_status()?
-            .text()?;
-        return Ok(serde_json::from_str(&response)?);
+        return latest_stable_release(&client, LATEST_RELEASE);
     }
-    let response = client
-        .get(format!("{API}/releases?per_page=20"))
-        .send()?
-        .error_for_status()?
-        .text()?;
-    let releases: Vec<Release> = serde_json::from_str(&response)?;
-    releases
-        .into_iter()
-        .find(|release| !release.draft)
-        .ok_or_else(|| "no published Pinset release was found".into())
+    let feed = download(&client, RELEASE_FEED, MAX_RELEASE_FEED_BYTES)?;
+    latest_release_from_feed(std::str::from_utf8(&feed)?)
+}
+
+fn latest_stable_release(
+    client: &Client,
+    url: &str,
+) -> Result<Version, Box<dyn std::error::Error>> {
+    let response = client.head(url).send()?.error_for_status()?;
+    release_version_from_url(response.url())
+}
+
+fn release_version_from_url(url: &Url) -> Result<Version, Box<dyn std::error::Error>> {
+    if url.scheme() != "https" || url.host_str() != Some("github.com") {
+        return Err("latest Pinset release redirected outside github.com".into());
+    }
+    let tag = url
+        .path()
+        .strip_prefix(RELEASE_TAG_PATH)
+        .filter(|tag| !tag.is_empty() && !tag.contains('/'))
+        .ok_or("latest Pinset release did not redirect to a release tag")?;
+    Ok(parse_tag(tag)?)
+}
+
+fn latest_release_from_feed(feed: &str) -> Result<Version, Box<dyn std::error::Error>> {
+    feed.match_indices(RELEASE_TAG_URL)
+        .filter_map(|(start, _)| {
+            let tag = feed[start + RELEASE_TAG_URL.len()..]
+                .split('"')
+                .next()
+                .unwrap_or_default();
+            (!tag.is_empty() && !tag.contains(['/', '&', '<', '>']))
+                .then(|| parse_tag(tag).ok())
+                .flatten()
+        })
+        .max()
+        .ok_or_else(|| "no published Pinset release was found in the GitHub release feed".into())
 }
 
 fn client() -> Result<Client, reqwest::Error> {
@@ -480,5 +499,46 @@ mod tests {
         assert!(parse_tag("v2.2.0-rc.10").unwrap() < parse_tag("v2.2.0").unwrap());
         assert!(Version::parse("1.9.0").unwrap() < Version::parse("2.0.0-rc.1").unwrap());
         assert_eq!(parse_tag("v2.0.0-rc.1").unwrap().to_string(), "2.0.0-rc.1");
+    }
+
+    #[test]
+    fn stable_release_version_comes_from_the_github_redirect_url() {
+        assert_eq!(
+            release_version_from_url(
+                &Url::parse("https://github.com/Future-Element/pinset/releases/tag/v2.12.2")
+                    .unwrap()
+            )
+            .unwrap(),
+            Version::parse("2.12.2").unwrap()
+        );
+        assert!(
+            release_version_from_url(
+                &Url::parse("https://example.com/Future-Element/pinset/releases/tag/v2.12.2")
+                    .unwrap()
+            )
+            .is_err()
+        );
+        assert!(
+            release_version_from_url(
+                &Url::parse("https://github.com/other/pinset/releases/tag/v2.12.2").unwrap()
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn prerelease_channel_uses_the_highest_release_feed_version() {
+        let feed = r#"
+            <feed>
+              <entry><link rel="alternate" href="https://github.com/Future-Element/pinset/releases/tag/not-semver"/></entry>
+              <entry><link rel="alternate" href="https://github.com/Future-Element/pinset/releases/tag/v2.12.2"/></entry>
+              <entry><link rel="alternate" href="https://github.com/Future-Element/pinset/releases/tag/v2.13.0-rc.2"/></entry>
+            </feed>
+        "#;
+        assert_eq!(
+            latest_release_from_feed(feed).unwrap(),
+            Version::parse("2.13.0-rc.2").unwrap()
+        );
+        assert!(latest_release_from_feed("<feed></feed>").is_err());
     }
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1111,9 +1111,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.12.1
+      - uses: Future-Element/pinset@v2.12.2
         with:
-          version: 2.12.1
+          version: 2.12.2
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js
@@ -1125,7 +1125,7 @@ The Action input is not a secret and does not persist the identity. Pinset remov
 
 `pinset paths [tool] [--json]` reports the CLI, adjacent shim, Pinset home, shim directory, installation root, and an optional tool's installed versions. `pinset list [tool] --long` adds receipt schema, installation root, file count, total size, critical entries, and integrity status. `pinset doctor --deep` rescans these statistics; it does not claim per-file cryptographic verification. `pinset install <tool@exact-version> --repair` repairs only an installation whose ownership receipt matches the requested tool, version, platform, and target directory. `pinset shim install --all` registers every built-in Provider command without downloading a runtime.
 
-`pinset self outdated [--channel stable|prerelease] [--json]` performs an explicit check against the fixed official repository. Before downloading an update, `pinset self update [--version <version>]` checks the global `global.lock` and automatically migrates safely recognized pre-1.0 Provider records at their existing exact versions. Compatibility migration covers the old Linux ARM64 target gaps in Node.js, pnpm, Bun, Go, Python, Java, Rust, and .NET SDK, and upgrades the historical Node.js HTTPS-checksum record to the current OpenPGP-authenticated record. Flutter's target matrix did not change. It then verifies platform, semantic version, archive structure, and `SHA256SUMS`, validates the new CLI, and replaces the CLI and shim as a pair with backup and rollback. If automatic migration cannot be completed, repair it explicitly with `pinset migrate --global`. Ordinary commands and `doctor` never check for updates in the background.
+`pinset self outdated [--channel stable|prerelease] [--json]` performs an explicit check against the fixed official repository. Stable discovery follows GitHub's public `releases/latest` redirect, prerelease discovery reads the repository's Atom release feed, and neither path calls the rate-limited GitHub REST API. Before downloading an update, `pinset self update [--version <version>]` checks the global `global.lock` and automatically migrates safely recognized pre-1.0 Provider records at their existing exact versions. Compatibility migration covers the old Linux ARM64 target gaps in Node.js, pnpm, Bun, Go, Python, Java, Rust, and .NET SDK, and upgrades the historical Node.js HTTPS-checksum record to the current OpenPGP-authenticated record. Flutter's target matrix did not change. It then verifies platform, semantic version, archive structure, and `SHA256SUMS`, validates the new CLI, and replaces the CLI and shim as a pair with backup and rollback. If automatic migration cannot be completed, repair it explicitly with `pinset migrate --global`. Ordinary commands and `doctor` never check for updates in the background.
 
 Self updates use a cross-process lock and a 60-second HTTP timeout. Windows replacement remains asynchronous because a running executable cannot replace itself; the helper records success or rollback under `PINSET_HOME/state`, and the next `self outdated` or `self update` reports that result. Windows `.cmd`/`.bat` runtime fallbacks reject arguments containing `cmd.exe` metacharacters rather than risk shell reinterpretation; managed `.exe` runtimes are unaffected.
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -1111,9 +1111,9 @@ jobs:
       PINSET_ENV_PROFILE: ci
     steps:
       - uses: actions/checkout@v4
-      - uses: Future-Element/pinset@v2.12.1
+      - uses: Future-Element/pinset@v2.12.2
         with:
-          version: 2.12.1
+          version: 2.12.2
           install: "true"
           trust-project-id: "4c5652e4-0000-4000-8000-000000000000"
       - run: pinset exec -- node app.js
@@ -1125,7 +1125,7 @@ Action 输入不是秘密，也不保存 identity。Pinset 会在子进程启动
 
 `pinset paths [tool] [--json]` 会报告 CLI、相邻 shim、Pinset home、shim 目录、安装根，以及可选工具的已安装版本。`pinset list [tool] --long` 增加收据 schema、安装根、文件数量、总大小、关键入口与完整性状态。`pinset doctor --deep` 会重新扫描这些统计，但不宣称逐文件密码学验证。`pinset install <tool@精确版本> --repair` 只修复所有权收据与工具、版本、平台和目标目录全部匹配的安装。`pinset shim install --all` 注册所有内置 Provider 命令，但不下载运行时。
 
-`pinset self outdated [--channel stable|prerelease] [--json]` 只在用户明确执行时检查固定官方仓库。下载更新前，`pinset self update [--version <版本>]` 会检查全局 `global.lock`，并按原精确版本自动迁移可安全识别的 pre-1.0 Provider 记录。兼容迁移覆盖 Node.js、pnpm、Bun、Go、Python、Java、Rust 与 .NET SDK 旧锁中缺少 Linux ARM64 目标的问题，并把 Node.js 历史 HTTPS checksum 记录升级为当前的 OpenPGP 认证记录；Flutter 的目标矩阵没有变化。随后命令会验证平台、语义版本、归档结构与 `SHA256SUMS`，校验新 CLI 后成对替换 CLI/shim，并支持备份与回滚。若自动迁移无法完成，可显式运行 `pinset migrate --global` 修复。普通命令和 `doctor` 不会后台检查更新。
+`pinset self outdated [--channel stable|prerelease] [--json]` 只在用户明确执行时检查固定官方仓库。稳定版发现跟随 GitHub 公共 `releases/latest` 重定向，预发布版发现读取仓库的 Atom Release 订阅，两条路径都不会调用有频率限制的 GitHub REST API。下载更新前，`pinset self update [--version <版本>]` 会检查全局 `global.lock`，并按原精确版本自动迁移可安全识别的 pre-1.0 Provider 记录。兼容迁移覆盖 Node.js、pnpm、Bun、Go、Python、Java、Rust 与 .NET SDK 旧锁中缺少 Linux ARM64 目标的问题，并把 Node.js 历史 HTTPS checksum 记录升级为当前的 OpenPGP 认证记录；Flutter 的目标矩阵没有变化。随后命令会验证平台、语义版本、归档结构与 `SHA256SUMS`，校验新 CLI 后成对替换 CLI/shim，并支持备份与回滚。若自动迁移无法完成，可显式运行 `pinset migrate --global` 修复。普通命令和 `doctor` 不会后台检查更新。
 
 自更新使用跨进程锁和 60 秒 HTTP 超时。Windows 中运行中的可执行文件不能替换自身，因此替换仍由异步辅助进程完成；辅助进程会把成功或回滚结果写入 `PINSET_HOME/state`，下一次执行 `self outdated` 或 `self update` 时会报告。Windows `.cmd`/`.bat` 运行时回退会拒绝包含 `cmd.exe` 元字符的参数，避免被 shell 二次解释；受管 `.exe` 运行时不受影响。
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -8,7 +8,7 @@ Configure `pinset.executablePath` when `pinset` is not available on the extensio
 
 ## Install
 
-Download `pinset-vscode-1.0.0.vsix` from the Pinset 2.12.1 GitHub Release, then run:
+Download `pinset-vscode-1.0.0.vsix` from the Pinset 2.12.2 GitHub Release, then run:
 
 ```sh
 code --install-extension pinset-vscode-1.0.0.vsix

--- a/examples/devcontainer/.devcontainer/Dockerfile
+++ b/examples/devcontainer/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
-ARG PINSET_VERSION=2.12.1
+ARG PINSET_VERSION=2.12.2
 
 RUN set -eux; \
     architecture="$(dpkg --print-architecture)"; \

--- a/examples/devcontainer/.devcontainer/devcontainer.json
+++ b/examples/devcontainer/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-        "PINSET_VERSION": "2.12.1"
+        "PINSET_VERSION": "2.12.2"
     }
   },
   "postCreateCommand": "pinset install --locked",

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string] $Version = '2.12.1',
+    [string] $Version = '2.12.2',
     [string] $InstallDir = (Join-Path $env:LOCALAPPDATA 'Pinset\bin')
 )
 

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 REPOSITORY="Future-Element/pinset"
-DEFAULT_VERSION="2.12.1"
+DEFAULT_VERSION="2.12.2"
 VERSION="${PINSET_VERSION:-$DEFAULT_VERSION}"
 INSTALL_DIR="${PINSET_INSTALL_DIR:-}"
 TEMP_ROOT=""
@@ -22,7 +22,7 @@ Usage:
   install.sh [--version VERSION] [--install-dir DIRECTORY]
 
 Options:
-  --version VERSION       Install an exact release, for example 2.12.1.
+  --version VERSION       Install an exact release, for example 2.12.2.
                           Default: the recommended release embedded in this script.
   --install-dir DIRECTORY Install binaries here. Default: $HOME/.local/bin.
   -h, --help              Show this help.

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pinset-website",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "private": true,
   "packageManager": "pnpm@10.15.0",
   "scripts": {


### PR DESCRIPTION
## Summary
- discover stable releases through the public GitHub Release redirect
- discover prereleases through the repository Atom feed and select the highest SemVer
- remove GitHub REST API usage from self-update paths
- prepare the unified 2.12.2 release metadata and documentation

## Validation
- cargo test --workspace --all-features
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo fmt --all -- --check
- website pnpm typecheck
- git diff --check

Post-release local installation and self-update verification are intentionally left to the maintainer.